### PR TITLE
rgbasm: Evaluate BANK() arguments to verify they exist.

### DIFF
--- a/src/asm/rpn.c
+++ b/src/asm/rpn.c
@@ -149,14 +149,11 @@ void
 rpn_Bank(struct Expression * expr, char *tzSym)
 {
 	if (!sym_isConstant(tzSym)) {
-		struct sSymbol *psym;
-
 		rpn_Reset(expr);
 
-		psym = sym_FindSymbol(tzSym);
-		if (nPass == 2 && psym == NULL) {
-			yyerror("'%s' not defined", tzSym);
-		}
+		/* Check that the symbol exists by evaluating and discarding the value. */
+		sym_GetValue(tzSym);
+
 		expr->isReloc = 1;
 		pushbyte(expr, RPN_BANK);
 		while (*tzSym)


### PR DESCRIPTION
Symbols are created when using a label in the wild, even if they aren't defined. Solely using a symbol as an argument to BANK() skips this, so the symbol is never created.

This evaluates the argument instead of trying to find a symbol. This way, symbols that don't exist are created when passed into BANK().
