### PR TITLE
 My Attempt to make the linker accept the new SRAM bank limit used by assembler

### DIFF
--- a/include/link/assign.h
+++ b/include/link/assign.h
@@ -11,7 +11,10 @@ enum eBankDefine {
 	BANK_HRAM = 522,
 	BANK_SRAM = 523
 };
-#define MAXBANKS	527
+#define AVAILABLE_SRAM_BANKS 511
+
+#define MAXBANKS	527 + AVAILABLE_SRAM_BANKS + 1
+
 
 extern SLONG area_Avail(SLONG bank);
 extern void AssignSections(void);

--- a/src/link/assign.c
+++ b/src/link/assign.c
@@ -421,7 +421,7 @@ AssignSections(void)
 			BankFree[i]->nOrg = 0xC000;
 			BankFree[i]->nSize = 0x1000;
 			MaxAvail[i] = 0x1000;
-		} else if (i >= BANK_SRAM && i <= BANK_SRAM + 3) {
+		} else if (i >= BANK_SRAM && i <= BANK_SRAM + AVAILABLE_SRAM_BANKS) {
 			/* Swappable SRAM bank */
 			BankFree[i]->nOrg = 0xA000;
 			BankFree[i]->nSize = 0x2000;
@@ -509,7 +509,7 @@ AssignSections(void)
 						 */
 
 						if (pSection->nBank >= 0
-						    && pSection->nBank <= 3) {
+						    && pSection->nBank <= AVAILABLE_SRAM_BANKS) {
 							pSection->nBank +=
 							    BANK_SRAM;
 							if (area_AllocAbs
@@ -519,14 +519,14 @@ AssignSections(void)
 							    pSection->nByteSize)
 							    != pSection->nOrg) {
 								errx(1,
-"Unable to load fixed SRAM section at $%lX in bank $%02lX", pSection->nOrg, pSection->nBank);
+"Unable to load fixed SRAM section at $%lX in bank $%02lX. Possible error: your start address is <$A000.", pSection->nOrg, pSection->nBank);
 							}
 							DOMAXVBANK(pSection->
 							    nBank);
 							pSection->oAssigned = 1;
 						} else {
 							errx(1,
-"Unable to load fixed SRAM section at $%lX in bank $%02lX", pSection->nOrg, pSection->nBank);
+"Unable to load fixed SRAM section at $%lX in bank $%02lX, because the bank number was out of range.", pSection->nOrg, pSection->nBank);
 						}
 					}
 				}
@@ -730,16 +730,16 @@ AssignSections(void)
 		    && pSection->nOrg == -1 && pSection->nBank != -1) {
 			pSection->nBank += BANK_SRAM;
 			/* User wants to have a say... and he's pissed */
-			if (pSection->nBank >= BANK_SRAM && pSection->nBank <= BANK_SRAM + 3) {
+			if (pSection->nBank >= BANK_SRAM && pSection->nBank <= BANK_SRAM + AVAILABLE_SRAM_BANKS) {
 				if ((pSection->nOrg =
 					area_Alloc(&BankFree[pSection->nBank],
 					    pSection->nByteSize)) == -1) {
-					errx(1, "Unable to load fixed SRAM section into bank $%02lX", pSection->nBank);
+					errx(1, "Unable to load fixed SRAM section with size §%02lX into bank $%02lX, because area_Alloc was -1.", pSection->nByteSize, pSection->nBank);
 				}
 				pSection->oAssigned = 1;
 				DOMAXSBANK(pSection->nBank);
 			} else {
-				errx(1, "Unable to load fixed VRAM section into bank $%02lX", pSection->nBank);
+				errx(1, "Unable to load fixed SRAM section into bank $%02lX, because the specified bank number is out of bounds.", pSection->nBank);
 			}
 		} else if (pSection->oAssigned == 0
 		    && pSection->Type == SECT_VRAM


### PR DESCRIPTION
I changed the available SRAM bank number to match the one used by the assembler. This was done by introducing a new constant called AVAILABLE_SRAM_BANKS with the value 511, which is now being used in the range checks.

Also, the MAXBANKS constant has been increased, to be the old 527 + AVAILABLE_SRAM_BANKS + 1, to acommodate the new ability to have 512 ram banks.
Adjusted Error messages of the sram sections to be a bit more helpful. (Check if correct)
