### PR TITLE
Improve build process

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,0 @@
-# GNU Make 3.x doesn't support the "!=" shell syntax, so here's an alternative
-
-PKG_CONFIG = pkg-config
-PNGFLAGS = $(shell ${PKG_CONFIG} --cflags libpng)
-
-include Makefile

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
-PKG_CONFIG =	pkg-config
-WARNFLAGS =	-Wall -Werror=implicit
-PNGFLAGS !=	${PKG_CONFIG} --cflags libpng
-REALCFLAGS =	${CFLAGS} ${WARNFLAGS} ${PNGFLAGS} -Iinclude -g \
-		-std=c99 -D_POSIX_C_SOURCE=200809L
+CFLAGS  += -std=c99 -D_POSIX_C_SOURCE=200809L -Wall -Werror=implicit -D_POSIX_C_SOURCE=200809L -Iinclude -g
+YFLAGS  =
+LDFLAGS =
+LIBS    =
 
 # User-defined variables
-PREFIX =	/usr/local
-BINPREFIX =	${PREFIX}/bin
-MANPREFIX =	${PREFIX}/man
-Q =		@
+PREFIX    = /usr/local
+BINPREFIX = ${PREFIX}/bin
+MANPREFIX = ${PREFIX}/man
+Q         = @
 
 rgbasm_obj = \
 	src/asm/asmy.o \
@@ -71,23 +70,35 @@ install: all
 	$Qinstall -m 444 src/link/rgblink.1 ${MANPREFIX}/man1/rgblink.1
 	$Qinstall -m 444 src/gfx/rgbgfx.1 ${MANPREFIX}/man1/rgbgfx.1
 
+rgbasm: CFLAGS += ${ASM_CFLAGS}
+rgbasm: LDFLAGS += ${ASM_LDFLAGS}
+rgbasm: LIBS += ${ASM_LIBS}
 rgbasm: ${rgbasm_obj}
-	$Q${CC} ${REALCFLAGS} -o $@ ${rgbasm_obj} -lm
+	$Q${CC} ${CFLAGS} ${LDFLAGS} ${LIBS} -lm -o $@ ${rgbasm_obj}
 
+rgblink: CFLAGS += ${LINK_CFLAGS}
+rgblink: LDFLAGS += ${LINK_LDFLAGS}
+rgblink: LIBS += ${LINK_LIBS}
 rgblink: ${rgblink_obj}
-	$Q${CC} ${REALCFLAGS} -o $@ ${rgblink_obj}
+	$Q${CC} ${CFLAGS} ${LDFLAGS} ${LIBS} -o $@ ${rgblink_obj}
 
+rgbfix: CFLAGS += ${FIX_CFLAGS}
+rgbfix: LDFLAGS += ${FIX_LDFLAGS}
+rgbfix: LIBS += ${FIX_LIBS}
 rgbfix: ${rgbfix_obj}
-	$Q${CC} ${REALCFLAGS} -o $@ ${rgbfix_obj}
+	$Q${CC} ${CFLAGS} ${LDFLAGS} ${LIBS} -o $@ ${rgbfix_obj}
 
+rgbgfx: CFLAGS  += ${GFX_CFLAGS}
+rgbgfx: LDFLAGS += ${GFX_LDFLAGS}
+rgbgfx: LIBS    += ${GFX_LIBS}
 rgbgfx: ${rgbgfx_obj}
-	$Q${CC} ${REALCFLAGS} -o $@ ${rgbgfx_obj} `${PKG_CONFIG} --libs libpng`
+	$Q${CC} ${CFLAGS} ${LDFLAGS} ${LIBS} -o $@ ${rgbgfx_obj} 
 
 .y.c:
 	$Q${YACC} -d ${YFLAGS} -o $@ $<
 
 .c.o:
-	$Q${CC} ${REALCFLAGS} -c -o $@ $<
+	$Q${CC} ${CFLAGS} -c -o $@ $<
 
 src/asm/locallex.o src/asm/globlex.o src/asm/lexer.o: src/asm/asmy.h
 src/asm/asmy.h: src/asm/asmy.c
@@ -98,7 +109,7 @@ src/asm/asmy.h: src/asm/asmy.c
 # install instructions instead.
 mingw:
 	$Qenv PATH=/usr/local/mingw32/bin:/bin:/usr/bin:/usr/local/bin \
-		make WARNFLAGS= CC=gcc CFLAGS="-I/usr/local/mingw32/include \
+		make CC=gcc CFLAGS="-I/usr/local/mingw32/include \
 			${CFLAGS}"
 	$Qmv rgbasm rgbasm.exe
 	$Qmv rgblink rgblink.exe

--- a/README
+++ b/README
@@ -14,24 +14,69 @@ rgbds-linux is a fork of the original RGBDS which aims to make the programs
 more like other UNIX tools.
 
 
-  Installing RGBDS (UNIX)
+
+  Installing RGBDS
 =========================
 
-RGBDS requires libpng and pkg-config to be installed.
+-------------------------
+  macOS
+-------------------------
 
-On Mac OS X, install them with [Homebrew](http://brew.sh/). On other Unixes,
-use the built-in package manager.
+You can use Homebrew (http://brew.sh/):
 
-You can test if they're installed by running "pkg-config --cflags libpng":
-if the output is a path, then you're good, and if it outputs an error then
-you need to install them via a package manager.
+  brew install rgbds
 
-To build the programs on a UNIX or UNIX-like system, just run in your terminal:
+or
 
-  make
+  brew install rgbds --build-from-source
 
-Then to install the compiled programs and manual pages, run (with appropriate
-privileges):
+or
+
+  brew install rgbds --HEAD
+
+Additionally, UNIX-like compilation is available (see below)
+
+-------------------------
+  UNIX
+-------------------------
+
+Check Makefile for user-defined variables:
+
+PREFIX
+  Location where RGBDS will be installed.
+  Defaults to /usr/local.
+
+BINPREFIX
+  Location where the RGBDS programs will be installed.
+  Defaults to ${PREFIX}/bin.
+
+MANPREFIX
+  Location where the RGBDS man pages will be installed.
+  Defaults to ${PREFIX}/man.
+
+Q
+  Quiet. To make the build more verbose, clear this variable.
+  Defaults to @.
+
+Additionally, there are specific variables for dependency resolution.
+
+*_CFLAGS
+*_LDFLAGS
+*_LIBS
+  Where * is ASM, LINK, FIX or GFX e.g. ASM_CFLAGS
+
+Dependencies are refered to in further in this document.
+
+To build the programs on a UNIX or UNIX-like system, just run in your terminal
+
+  make [<FLAG>=<FVALUE>...]
+
+e.g. this is a common way of compiling RGBDS, resolving deps via pkg-config
+
+  make GFX_CFLAGS='`pkg-config libpng --cflags`' GFX_LIBS='`pkg-config libpng --libs`'
+
+To install the compiled programs and manual pages, run (with appropriate
+privileges)
 
   make install
 
@@ -39,30 +84,24 @@ After installation, you can read the manuals with the man(1) command. E.g.,
 
   man 1 rgbasm
 
-
-Note: the variables described below can affect installation behavior when given
-on the make command line. For example, to install rgbds in your home directory
-instead of systemwide, run the following:
-
-  mkdir -p $HOME/{bin,man/man1,man/man7}
-  make install PREFIX=$HOME
-
-
-PREFIX: Location where RGBDS will be installed. Defaults to /usr/local.
-
-BINPREFIX: Location where the RGBDS programs will be installed. Defaults
-to ${PREFIX}/bin.
-
-MANPREFIX: Location where the RGBDS man pages will be installed. Defaults
-to ${PREFIX}/man.
-
-Q: Whether to quiet the build or not. To make the build more verbose, clear
-this variable. Defaults to @.
-
-
-  Installing RGBDS (Windows)
-============================
+-------------------------
+  Windows
+-------------------------
 
 Windows builds are available here: https://github.com/bentley/rgbds/releases
 
 Copy the .exe files to C:\Windows\ or similar.
+
+
+  Dependencies
+=========================
+
+Here's the list of dependencies of each program
+
+rgbasm  | libm*, yacc
+rgblink |
+rgbfix  |
+rgbgfx  | libpng
+
+* libm (math lib) is automatically supplied to the linker
+


### PR DESCRIPTION
Quite some internal Makefile rework, but in the end this brings manual libpng searching via `PNG` (in case you want to avoid pkg-config), exposes some more variables on the Makefile and updates the README to reflect all those changes.

It explains build intructions with bigger detail, and warns about yacc as a requirement for rgbasm.