### PR TITLE
Fix issues in rgbasm raised by the tests

### DIFF
--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -142,8 +142,9 @@ void	copyrept( void )
 {
 	SLONG	level=1, len, instring=0;
 	char	*src=pCurrentBuffer->pBuffer;
+	char	*bufferEnd = pCurrentBuffer->pBufferStart + pCurrentBuffer->nBufferSize;
 
-	while( *src && level )
+	while( src < bufferEnd && level )
 	{
 		if( instring==0 )
 		{
@@ -217,8 +218,9 @@ void	copymacro( void )
 {
 	SLONG	level=1, len, instring=0;
 	char	*src=pCurrentBuffer->pBuffer;
+	char	*bufferEnd = pCurrentBuffer->pBufferStart + pCurrentBuffer->nBufferSize;
 
-	while( *src && level )
+	while( src < bufferEnd && level )
 	{
 		if( instring==0 )
 		{

--- a/src/asm/rpn.c
+++ b/src/asm/rpn.c
@@ -316,6 +316,9 @@ rpn_DIV(struct Expression * expr, struct Expression * src1,
     struct Expression * src2)
 {
 	joinexpr();
+	if (src2->nVal == 0) {
+		fatalerror("division by zero");
+	}
 	expr->nVal = (expr->nVal / src2->nVal);
 	pushbyte(expr, RPN_DIV);
 }
@@ -325,6 +328,9 @@ rpn_MOD(struct Expression * expr, struct Expression * src1,
     struct Expression * src2)
 {
 	joinexpr();
+	if (src2->nVal == 0) {
+		fatalerror("division by zero");
+	}
 	expr->nVal = (expr->nVal % src2->nVal);
 	pushbyte(expr, RPN_MOD);
 }


### PR DESCRIPTION
Addresses two issues in the assembler that were previously highlighted by the tests:

- The crashes due to divisions by zero in instructions (as in #49) have been resolved. Instead, rgbasm will print a more helpful error message. The corresponding `divzero-instr.asm` test now passes.
- The segmentation faults and memory allocation failures created when using null bytes in `REPT` and `MACRO` blocks (as in #50) have been resolved.
    - Note, however, that the `null-in-macro.asm` test won't complete with no output; the lack of an `ENDR` seems to cause additional problems, leading to a syntax error (but no crash).