### PR TITLE
Remove duplicate documentation of -E

### DIFF
--- a/src/asm/rgbasm.1
+++ b/src/asm/rgbasm.1
@@ -54,8 +54,6 @@ When padding an image, pad with this value.
 The default is 0x00.
 .It Fl v
 Be verbose.
-.It Fl E
-Export all relocable symbols by default.
 .El
 .Sh EXAMPLES
 Assembling a basic source file is simple:


### PR DESCRIPTION
Remove Sanqui’s documentation of the `-E` argument to `rgbasm`, in favour of bentley’s better-worded one.