### PR TITLE
Implement byte alignment for data

### DIFF
--- a/include/asm/output.h
+++ b/include/asm/output.h
@@ -10,6 +10,7 @@ struct Section {
 	ULONG nPC;
 	ULONG nOrg;
 	ULONG nBank;
+	ULONG nAlign;
 	struct Section *pNext;
 	struct Patch *pPatches;
 	struct Charmap *charmap;
@@ -20,6 +21,7 @@ void out_PrepPass2(void);
 void out_SetFileName(char *s);
 void out_NewSection(char *pzName, ULONG secttype);
 void out_NewAbsSection(char *pzName, ULONG secttype, SLONG org, SLONG bank);
+void out_NewAlignedSection(char *pzName, ULONG secttype, SLONG alignment, SLONG bank);
 void out_AbsByte(int b);
 void out_AbsByteGroup(char *s, int length);
 void out_RelByte(struct Expression * expr);

--- a/include/link/mylink.h
+++ b/include/link/mylink.h
@@ -63,8 +63,10 @@ enum eSectionType {
 struct sSection {
 	SLONG nBank;
 	SLONG nOrg;
+	SLONG nAlign;
 	BBOOL oAssigned;
 
+	char *pzName;
 	SLONG nByteSize;
 	enum eSectionType Type;
 	UBYTE *pData;

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -442,7 +442,7 @@ void	if_skip_to_endc( void )
 %left	T_OP_MUL T_OP_DIV T_OP_MOD
 %left	T_OP_NOT
 %left	T_OP_DEF
-%left	T_OP_BANK
+%left	T_OP_BANK T_OP_ALIGN
 %left	T_OP_SIN
 %left	T_OP_COS
 %left	T_OP_TAN
@@ -1095,6 +1095,10 @@ section:
 			else
 				yyerror("Address $%x not 16-bit", $6);
 		}
+	|	T_POP_SECTION string ',' sectiontype ',' T_OP_ALIGN '[' const ']'
+		{
+			out_NewAlignedSection($2, $4, $8, -1);
+		}
 	|	T_POP_SECTION string ',' sectiontype ',' T_OP_BANK '[' const ']'
 		{
 			bankrangecheck($2, $4, -1, $8);
@@ -1105,6 +1109,14 @@ section:
 				yyerror("Address $%x not 16-bit", $6);
 			}
 			bankrangecheck($2, $4, $6, $11);
+		}
+	|	T_POP_SECTION string ',' sectiontype ',' T_OP_ALIGN '[' const ']' ',' T_OP_BANK '[' const ']'
+		{
+			out_NewAlignedSection($2, $4, $8, $13);
+		}
+	|	T_POP_SECTION string ',' sectiontype ',' T_OP_BANK '[' const ']' ',' T_OP_ALIGN '[' const ']'
+		{
+			out_NewAlignedSection($2, $4, $13, $8);
 		}
 ;
 

--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -267,6 +267,7 @@ struct sLexInitString staticstrings[] = {
 	{"def", T_OP_DEF},
 
 	{"bank", T_OP_BANK},
+	{"align", T_OP_ALIGN},
 
 	{"round", T_OP_ROUND},
 	{"ceil", T_OP_CEIL},

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -631,7 +631,10 @@ out_NewAbsSection(char *pzName, ULONG secttype, SLONG org, SLONG bank)
 void 
 out_NewAlignedSection(char *pzName, ULONG secttype, SLONG alignment, SLONG bank)
 {
-	out_SetCurrentSection(out_FindSection(pzName, secttype, -1, bank, alignment));
+	if (alignment < 0) {
+		yyerror("Alignment must not be negative.");
+	}
+	out_SetCurrentSection(out_FindSection(pzName, secttype, -1, bank, 1 << alignment));
 }
 
 /*

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -631,8 +631,8 @@ out_NewAbsSection(char *pzName, ULONG secttype, SLONG org, SLONG bank)
 void 
 out_NewAlignedSection(char *pzName, ULONG secttype, SLONG alignment, SLONG bank)
 {
-	if (alignment < 0) {
-		yyerror("Alignment must not be negative.");
+	if (alignment < 1 || alignment > 16) {
+		yyerror("Alignment must be between 1-16 bits.");
 	}
 	out_SetCurrentSection(out_FindSection(pzName, secttype, -1, bank, 1 << alignment));
 }

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -631,8 +631,8 @@ out_NewAbsSection(char *pzName, ULONG secttype, SLONG org, SLONG bank)
 void 
 out_NewAlignedSection(char *pzName, ULONG secttype, SLONG alignment, SLONG bank)
 {
-	if (alignment < 1 || alignment > 16) {
-		yyerror("Alignment must be between 1-16 bits.");
+	if (alignment < 0 || alignment > 16) {
+		yyerror("Alignment must be between 0-16 bits.");
 	}
 	out_SetCurrentSection(out_FindSection(pzName, secttype, -1, bank, 1 << alignment));
 }


### PR DESCRIPTION
Amongst other things, this is really helpful for using the Game Boy's OAM and VRAM DMA.

Implement byte alignment using a new `ALIGN` keyword, which specifies the number of bits that should be set to zero in a section's starting memory address. It syntactically works in a similar fashion to `BANK`.

This information is stored in (v3) object files, and the linker will assign the least flexible sections first (i.e. those with the largest alignment value). In future, this may be improved by using dense packing (as suggested by #83).

In addition:
- The new object files also include the section names, for potential improvements to linker error messages.
- The `readasciiz()` function in [src/link/object.c](src/link/object.c) now uses malloc to create a buffer, resizing it if necessary. This reduces the risk of buffer overflows if a long string (< 255 chars) was encountered.

Feel free to improve any aspect of this, especially the changes to the parser! Fixes #124.