### PR TITLE
Allow { and } to be escaped in string literals

### DIFF
--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -565,6 +565,12 @@ yylex_ReadQuotedString()
 			case '"':
 				ch = '"';
 				break;
+			case '{':
+				ch = '{';
+				break;
+			case '}':
+				ch = '}';
+				break;
 			default:
 				maxLength = MAXSTRLEN - index;
 				length = CopyMacroArg(&yylval.tzString[index], maxLength, ch);
@@ -697,6 +703,12 @@ yylex_MACROARGS()
 				break;
 			case '\\':
 				ch = '\\';
+				break;
+			case '{':
+				ch = '{';
+				break;
+			case '}':
+				ch = '}';
 				break;
 			default:
 				maxLength = MAXSTRLEN - index;


### PR DESCRIPTION
As stated in the documentation but that was not actually implemented.