### PR TITLE
Declare some opcodes obsolete

### DIFF
--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1279,7 +1279,11 @@ z80_jp			:	T_Z80_JP const_16bit
 				|	T_Z80_JP ccode comma const_16bit
 					{ out_AbsByte(0xC2|($2<<3)); out_RelWord(&$4); }
 				|	T_Z80_JP T_MODE_HL_IND
-					{ out_AbsByte(0xE9); }
+					{
+						out_AbsByte(0xE9);
+						if( nPass==1 )
+							printf("warning:'JP [HL]' is obsolete, use 'JP HL' instead.\n");
+					}
 				|	T_Z80_JP T_MODE_HL
 					{ out_AbsByte(0xE9); }
 ;
@@ -1293,7 +1297,11 @@ z80_jr			:	T_Z80_JR const_PCrel
 z80_ldi			:	T_Z80_LDI T_MODE_HL_IND comma T_MODE_A
 					{ out_AbsByte(0x02|(2<<4)); }
 				|	T_Z80_LDI T_MODE_A comma T_MODE_HL
-					{ out_AbsByte(0x0A|(2<<4)); }
+					{
+						out_AbsByte(0x0A|(2<<4));
+						if( nPass==1 )
+							printf("warning:'LDI A,HL' is obsolete, use 'LDI A,[HL]' or 'LD A,[HL+] instead.\n");
+					}
 				|	T_Z80_LDI T_MODE_A comma T_MODE_HL_IND
 					{ out_AbsByte(0x0A|(2<<4)); }
 ;
@@ -1301,7 +1309,11 @@ z80_ldi			:	T_Z80_LDI T_MODE_HL_IND comma T_MODE_A
 z80_ldd			:	T_Z80_LDD T_MODE_HL_IND comma T_MODE_A
 					{ out_AbsByte(0x02|(3<<4)); }
 				|	T_Z80_LDD T_MODE_A comma T_MODE_HL
-					{ out_AbsByte(0x0A|(3<<4)); }
+					{
+						out_AbsByte(0x0A|(3<<4));
+						if( nPass==1 )
+							printf("warning:'LDD A,HL' is obsolete, use 'LDD A,[HL]' or 'LD A,[HL-] instead.\n");
+					}
 				|	T_Z80_LDD T_MODE_A comma T_MODE_HL_IND
 					{ out_AbsByte(0x0A|(3<<4)); }
 ;


### PR DESCRIPTION
It's still working, it just outputs a warning.

This mnemonic is confusing as it may be thought that the CPU reads the
value pointed by `hl` and jumps to it.