### PR TITLE
Prohibit sections from having the same name

### DIFF
--- a/include/link/assign.h
+++ b/include/link/assign.h
@@ -35,6 +35,9 @@ extern void CreateSymbolTable(void);
 extern SLONG MaxBankUsed;
 extern SLONG MaxAvail[MAXBANKS];
 
+int
+IsSectionNameInUse(const char *name);
+
 void
 SetLinkerscriptName(char *tzLinkerscriptFile);
 

--- a/src/link/assign.c
+++ b/src/link/assign.c
@@ -217,6 +217,23 @@ FindLargestSection(enum eSectionType type, bool bankFixed)
 }
 
 int
+IsSectionNameInUse(const char *name)
+{
+	struct sSection *pSection;
+
+	pSection = pSections;
+	while (pSection) {
+		if (strcmp(pSection->pzName, name) == 0)
+			return 1;
+
+		pSection = pSection->pNext;
+	}
+
+	return 0;
+}
+
+
+int
 IsSectionSameTypeBankAndFloating(const char *name, enum eSectionType type, int bank)
 {
 	struct sSection *pSection;

--- a/src/link/object.c
+++ b/src/link/object.c
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include "extern/err.h"
+#include "link/assign.h"
 #include "link/mylink.h"
 #include "link/main.h"
 
@@ -288,13 +289,18 @@ obj_ReadRGBSection(FILE * f, enum ObjectFileContents contents)
 {
 	struct sSection *pSection;
 
-	pSection = AllocSection();
+	char * pzName;
 
 	if (contents & CONTAINS_SECTION_NAME) {
-		readasciiz(&pSection->pzName, f);
+		readasciiz(&pzName, f);
+		if (IsSectionNameInUse(pzName))
+			errx(1, "Section name \"%s\" is already in use.", pzName);
 	} else {
-		pSection->pzName = "";
+		pzName = "";
 	}
+
+	pSection = AllocSection();
+	pSection->pzName = pzName;
 
 	pSection->nByteSize = readlong(f);
 	pSection->Type = (enum eSectionType) fgetc(f);


### PR DESCRIPTION
To make the behaviour of the linkerscript consistent, every section read
from an object file must have an unique name. This is needed as the
linkerscript uses the name of sections to place them and it expects
every section to have a different name.

This doesn't break compatibility with the old behaviour that allowed to
continue sections if they had the same name, bank number and starting
address. That's still allowed because `rgbasm` outputs a single section
if this functionality is used, it is transparent to `rgblink`.

Fixes: https://github.com/rednex/rgbds/issues/142