### PR TITLE
Add a warning() function, similiar to other error handlers

### DIFF
--- a/include/asm/main.h
+++ b/include/asm/main.h
@@ -27,6 +27,7 @@ extern void opt_Parse(char *s);
 
 noreturn void fatalerror(const char *fmt, ...);
 void yyerror(const char *fmt, ...);
+void warning(const char *fmt, ...);
 
 #define	YY_FATAL_ERROR fatalerror
 

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1282,7 +1282,7 @@ z80_jp			:	T_Z80_JP const_16bit
 					{
 						out_AbsByte(0xE9);
 						if( nPass==1 )
-							printf("warning:'JP [HL]' is obsolete, use 'JP HL' instead.\n");
+							warning("'JP [HL]' is obsolete, use 'JP HL' instead.\n");
 					}
 				|	T_Z80_JP T_MODE_HL
 					{ out_AbsByte(0xE9); }
@@ -1300,7 +1300,7 @@ z80_ldi			:	T_Z80_LDI T_MODE_HL_IND comma T_MODE_A
 					{
 						out_AbsByte(0x0A|(2<<4));
 						if( nPass==1 )
-							printf("warning:'LDI A,HL' is obsolete, use 'LDI A,[HL]' or 'LD A,[HL+] instead.\n");
+							warning("'LDI A,HL' is obsolete, use 'LDI A,[HL]' or 'LD A,[HL+] instead.\n");
 					}
 				|	T_Z80_LDI T_MODE_A comma T_MODE_HL_IND
 					{ out_AbsByte(0x0A|(2<<4)); }
@@ -1312,7 +1312,7 @@ z80_ldd			:	T_Z80_LDD T_MODE_HL_IND comma T_MODE_A
 					{
 						out_AbsByte(0x0A|(3<<4));
 						if( nPass==1 )
-							printf("warning:'LDD A,HL' is obsolete, use 'LDD A,[HL]' or 'LD A,[HL-] instead.\n");
+							warning("'LDD A,HL' is obsolete, use 'LDD A,[HL]' or 'LD A,[HL-] instead.\n");
 					}
 				|	T_Z80_LDD T_MODE_A comma T_MODE_HL_IND
 					{ out_AbsByte(0x0A|(3<<4)); }

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -226,9 +226,9 @@ opt_ParseDefines()
 void
 verror(const char *fmt, va_list args)
 {
-	fprintf(stderr, "ERROR:\t");
+	fprintf(stderr, "ERROR: ");
 	fstk_Dump();
-	fprintf(stderr, " :\n\t");
+	fprintf(stderr, ":\n\t");
 	vfprintf(stderr, fmt, args);
 	fprintf(stderr, "\n");
 	nErrors += 1;
@@ -251,6 +251,21 @@ fatalerror(const char *fmt, ...)
 	verror(fmt, args);
 	va_end(args);
 	exit(5);
+}
+
+void
+warning(const char *fmt, ...)
+{
+	va_list args;
+	va_start(args, fmt);
+	
+	fprintf(stderr, "warning: ");
+	fstk_Dump();
+	fprintf(stderr, ":\n\t");
+	vfprintf(stderr, fmt, args);
+	fprintf(stderr, "\n");
+	
+	va_end(args);
 }
 
 static void 


### PR DESCRIPTION
This function produces a similar output to the other error handlers, including printing to stderr, and including a stack trace. However, ‘warning’ is displayed instead of ‘ERROR’, and the compilation does not fail.

This function is now used for the deprecation warnings, ensuring that these opcodes can be found and corrected.

Some very minor changes have also been made to the regular error handler, which I'm amenable to: the tab after "ERROR:" has been replaced with a space, since this produced an excessive gap when using "warning:"; and the space after the stack dump (before the colon) has been removed.