### PR TITLE
Output error message if diff of labels not defined

### DIFF
--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -71,5 +71,6 @@ ULONG sym_GetDefinedValue(char *s);
 ULONG sym_isDefined(char *tzName);
 void sym_Purge(char *tzName);
 ULONG sym_isConstDefined(char *tzName);
+int sym_IsRelocDiffDefined(char *tzSym1, char *tzSym2);
 
 #endif

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1040,9 +1040,14 @@ const			:	T_ID							{ $$ = sym_GetConstantValue($1); }
 				|	const T_OP_LOGICNE const 		{ $$ = $1 != $3; }
 				|	const T_OP_ADD const			{ $$ = $1 + $3; }
 				|	const T_OP_SUB const			{ $$ = $1 - $3; }
-				|	T_ID  T_OP_SUB T_ID				{ $$ = sym_GetDefinedValue($1) - sym_GetDefinedValue($3); }
+				|	T_ID  T_OP_SUB T_ID
+					{
+						if (sym_IsRelocDiffDefined($1, $3) == 0)
+							fatalerror("'%s - %s' not defined.", $1, $3);
+						$$ = sym_GetDefinedValue($1) - sym_GetDefinedValue($3);
+					}
 				|	const T_OP_XOR const			{ $$ = $1 ^ $3; }
-				|	const T_OP_OR const				{ $$ = $1 | $3; }
+				|	const T_OP_OR const			{ $$ = $1 | $3; }
 				|	const T_OP_AND const			{ $$ = $1 & $3; }
 				|	const T_OP_SHL const			{ $$ = $1 << $3; }
 				|	const T_OP_SHR const			{ $$ = $1 >> $3; }


### PR DESCRIPTION
When calculating the difference of addresses between two labels, for it
to be defined, either:

- Both of them must have their absolute address defined.
- They belong to the same section, so their relative addresses are
  compatible.

This patch adds a check to make sure that any other case is detected so
that the programmer can correct the code.

This applies to rgbasm. The difference of labels can be used, for
example, as argument of DS. The linker can't resize sections, which
means that the final value must be defined when creating the object
file.

This will prevent issues like https://github.com/rednex/rgbds/issues/149