### PR TITLE
Deprecate IMPORT, EXPORT and GLOBAL keywords

### DIFF
--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -54,7 +54,6 @@ void sym_AddEqu(char *tzSym, SLONG value);
 void sym_AddSet(char *tzSym, SLONG value);
 void sym_Init(void);
 ULONG sym_GetConstantValue(char *s);
-void sym_Import(char *tzSym);
 ULONG sym_isConstant(char *s);
 struct sSymbol *sym_FindSymbol(char *tzName);
 void sym_Global(char *tzSym);

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -786,7 +786,14 @@ export_list		:	export_list_entry
 				|	export_list_entry ',' export_list
 ;
 
-export_list_entry	:	T_ID	{ sym_Export($1); }
+export_list_entry	:	T_ID	{
+						/* This is still useful if a
+						 * label is not defined as
+						 * global with two colons. */
+						if( nPass==1 )
+							warning("EXPORT is deprecated, use '%s::' instead.", $1);
+						sym_Export($1);
+					}
 ;
 
 global			:	T_POP_GLOBAL global_list
@@ -796,7 +803,17 @@ global_list		:	global_list_entry
 				|	global_list_entry ',' global_list
 ;
 
-global_list_entry	:	T_ID	{ sym_Global($1); }
+global_list_entry	:	T_ID	{
+						/* This is still useful if a
+						 * label is not defined as
+						 * global with two colons, but
+						 * it is useless for importing
+						 * them, the assembler does that
+						 * automatically.  */
+						if( nPass==1 )
+							warning("GLOBAL is deprecated, use '%s::' instead.", $1);
+						sym_Global($1);
+					}
 ;
 
 equ				:	T_LABEL T_POP_EQU const

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -770,7 +770,13 @@ import_list		:	import_list_entry
 				|	import_list_entry ',' import_list
 ;
 
-import_list_entry	:	T_ID	{ sym_Import($1); }
+import_list_entry	:	T_ID	{
+						/* This is done automatically if
+						 * the label isn't found in the
+						 * list of defined symbols. */
+						if( nPass==1 )
+							warning("IMPORT is a deprecated keyword with no effect: %s", $1);
+					}
 ;
 
 export			:	T_POP_EXPORT export_list

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -690,24 +690,6 @@ sym_Export(char *tzSym)
 }
 
 /*
- * Import a symbol
- */
-void
-sym_Import(char *tzSym)
-{
-	if (nPass == 1) {
-		/* only import symbols in pass 1 */
-		struct sSymbol *nsym;
-
-		if (findsymbol(tzSym, NULL)) {
-			yyerror("'%s' already defined", tzSym);
-		}
-		if ((nsym = createsymbol(tzSym)) != NULL)
-			nsym->nType |= SYMF_IMPORT;
-	}
-}
-
-/*
  * Globalize a symbol (export if defined, import if not)
  */
 void


### PR DESCRIPTION
Deprecated the following keywords:

- IMPORT is simply useless, any symbol that isn't found in the current
  file is automatically flagged as imported symbol.

- EXPORT could be useful if a label is defined as `label:` instead of
  `label::`, but the second version is preferred as it is less verbose.

- GLOBAL imports a symbol if it isn't found in the current file and
  exports it if it is found. Both comments above apply in this case.