### PR TITLE
Fix conflict in yacc

### DIFF
--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1482,8 +1482,14 @@ z80_ld_a		:	T_Z80_LD reg_r comma T_MODE_C_IND
 					}
 ;
 
-z80_ld_ss		:	T_Z80_LD reg_ss comma const_16bit
-					{ out_AbsByte(0x01|($2<<4)); out_RelWord(&$4); }
+z80_ld_ss		:	T_Z80_LD T_MODE_BC comma const_16bit
+					{ out_AbsByte(0x01|(REG_BC<<4)); out_RelWord(&$4); }
+				|	T_Z80_LD T_MODE_DE comma const_16bit
+					{ out_AbsByte(0x01|(REG_DE<<4)); out_RelWord(&$4); }
+				/*
+				 * HL is taken care of in z80_ld_hl
+				 * SP is taken care of in z80_ld_sp
+				 */
 ;
 
 z80_nop			:	T_Z80_NOP


### PR DESCRIPTION
`LD HL,n16` and `LD SP,n16` are handled in a different rule as `LD r16,n16`, but they are also part of that rule.

This patch converts the `LD r16,n16` rule into two rules, one for doing `LD BC,n16` and other one for `LD DE,n16`.