### PR TITLE
Don’t make FAIL cause fatal errors

### DIFF
--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -677,7 +677,7 @@ pushs : T_POP_PUSHS {
 	};
 
 fail : T_POP_FAIL string {
-		fatalerror("%s", $2);
+		yyerror("%s", $2);
 	};
 
 warn : T_POP_WARN string {


### PR DESCRIPTION
In accordance with making `WARN` emit warnings, `FAIL` now takes on `WARN`’s previous behaviour, which was to emit an error, but not stop assembling.