### PR TITLE
Fix implicit declaration of yyparse()

### DIFF
--- a/src/link/lexer.l
+++ b/src/link/lexer.l
@@ -28,6 +28,8 @@
 
 #include "parser.h"
 
+extern int yyparse();
+
 /* File include stack. */
 
 #define	MAX_INCLUDE_DEPTH 8


### PR DESCRIPTION
This was causing compilation errors (on at least both macOS and Ubuntu), as `yyparse()` hadn’t been defined in `lexer.l`.

As of 7097b9885e4ff0c36878d5928c9554c673e82305, this error prevented rgbds from being built (hence this PR):
```
src/link/lexer.l:107:3: error: implicit declaration of function 'yyparse' is
      invalid in C99 [-Werror,-Wimplicit-function-declaration]
                yyparse();
                ^
```

(Travis CI is continuing to sound like a good idea 😉)