### PR TITLE
Generate make-style dependency files

### DIFF
--- a/src/asm/fstack.c
+++ b/src/asm/fstack.c
@@ -36,6 +36,9 @@ ULONG nCurrentREPTBlockCount;
 
 ULONG ulMacroReturnValue;
 
+extern char *tzObjectname;
+extern FILE *dependfile;
+
 /*
  * defines for nCurrentStatus
  */
@@ -198,6 +201,9 @@ fstk_FindFile(char *fname)
 	FILE *f;
 
 	if ((f = fopen(fname, "rb")) != NULL || errno != ENOENT) {
+		if (dependfile) {
+			fprintf(dependfile, "%s: %s\n", tzObjectname, fname);
+		}
 		return f;
 	}
 

--- a/src/asm/fstack.c
+++ b/src/asm/fstack.c
@@ -217,6 +217,9 @@ fstk_FindFile(char *fname)
 		}
 
 		if ((f = fopen(path, "rb")) != NULL || errno != ENOENT) {
+			if (dependfile) {
+				fprintf(dependfile, "%s: %s\n", tzObjectname, path);
+			}
 			return f;
 		}
 	}

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -403,6 +403,9 @@ main(int argc, char *argv[])
 	}
 
 	if (dependfile) {
+		if (!tzObjectname)
+			errx(1, "Dependency files can only be created if an output object file is specified.\n");
+
 		fprintf(dependfile, "%s: %s\n", tzObjectname, tzMainfile);
 	}
 

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -26,6 +26,9 @@ ULONG nTotalLines, nPass, nPC, nIFDepth, nErrors;
 
 extern int yydebug;
 
+FILE *dependfile;
+extern char *tzObjectname;
+
 /*
  * Option stack
  */
@@ -274,7 +277,7 @@ usage(void)
 {
 	printf(
 "Usage: rgbasm [-hvE] [-b chars] [-Dname[=value]] [-g chars] [-i path]\n"
-"              [-o outfile] [-p pad_value] file.asm\n");
+"              [-M dependfile] [-o outfile] [-p pad_value] file.asm\n");
 	exit(1);
 }
 
@@ -287,6 +290,8 @@ main(int argc, char *argv[])
 	struct sOptions newopt;
 
 	char *tzMainfile;
+
+	dependfile = NULL;
 
 	cldefines_size = 32;
 	cldefines = reallocarray(cldefines, cldefines_size,
@@ -317,7 +322,7 @@ main(int argc, char *argv[])
 
 	newopt = CurrentOptions;
 
-	while ((ch = getopt(argc, argv, "b:D:g:hi:o:p:vEw")) != -1) {
+	while ((ch = getopt(argc, argv, "b:D:g:hi:M:o:p:vEw")) != -1) {
 		switch (ch) {
 		case 'b':
 			if (strlen(optarg) == 2) {
@@ -347,6 +352,11 @@ main(int argc, char *argv[])
 			break;
 		case 'i':
 			fstk_AddIncludePath(optarg);
+			break;
+		case 'M':
+			if ((dependfile = fopen(optarg, "w")) == NULL) {
+				err(1, "Could not open dependfile %s", optarg);
+			}
 			break;
 		case 'o':
 			out_SetFileName(optarg);
@@ -390,6 +400,10 @@ main(int argc, char *argv[])
 
 	if (CurrentOptions.verbose) {
 		printf("Assembling %s\n", tzMainfile);
+	}
+
+	if (dependfile) {
+		fprintf(dependfile, "%s: %s\n", tzObjectname, tzMainfile);
 	}
 
 	nStartClock = clock();

--- a/src/asm/rgbasm.1
+++ b/src/asm/rgbasm.1
@@ -61,6 +61,11 @@ The
 option disables this behavior.
 .It Fl i Ar path
 Add an include path.
+.It Fl M Ar dependfile
+Print
+.Xr make 1
+dependencies to
+.Ar dependfile .
 .It Fl o Ar outfile
 Write an object file to the given filename.
 .It Fl p Ar pad_value


### PR DESCRIPTION
Add option to `rgbasm` to generate a dependency. For example, for the following file named `code.asm`:
```
INCLUDE "header.inc"
```
If compiled with `rgbasm -Mcode.d -ocode.obj code.asm` the contents of `code.d` would be:
```
code.obj: code.asm
code.obj: header.inc
```
If the file is in one of the directories in the include path list passed to `rgbasm`, that path is added to the dependency file as expected.

This change is based on an old commit by @bentley.