### PR TITLE
Improve section size checks and buffer handling

### DIFF
--- a/include/asm/localasm.h
+++ b/include/asm/localasm.h
@@ -80,8 +80,6 @@
 
  */
 
-#define MAXSECTIONSIZE	0x4000
-
 #define	NAME_DB			"db"
 #define	NAME_DW			"dw"
 #define	NAME_RB			"rb"

--- a/src/link/object.c
+++ b/src/link/object.c
@@ -169,6 +169,42 @@ obj_ReadRGBSection(FILE * f)
 		}
 	}
 
+	unsigned int maxsize = 0;
+
+	/* Verify that the section isn't too big */
+	switch (pSection->Type)
+	{
+		case SECT_ROM0:
+			maxsize = (options & OPT_TINY) ? 0x8000 : 0x4000;
+			break;
+		case SECT_ROMX:
+			maxsize = 0x4000;
+			break;
+		case SECT_VRAM:
+		case SECT_SRAM:
+			maxsize = 0x2000;
+			break;
+		case SECT_WRAM0:
+			maxsize = (options & OPT_CONTWRAM) ? 0x2000 : 0x1000;
+			break;
+		case SECT_WRAMX:
+			maxsize = 0x1000;
+			break;
+		case SECT_OAM:
+			maxsize = 0xA0;
+			break;
+		case SECT_HRAM:
+			maxsize = 0x7F;
+			break;
+		default:
+			errx(1, "Section \"%s\" has an invalid section type.", pzName);
+			break;
+	}
+	if (pSection->nByteSize > maxsize) {
+		errx(1, "Section \"%s\" is bigger than the max size for that type: 0x%X > 0x%X",
+			pzName, pSection->nByteSize, maxsize);
+	}
+
 	if ((pSection->Type == SECT_ROMX) || (pSection->Type == SECT_ROM0)) {
 		/*
 		 * These sectiontypes contain data...


### PR DESCRIPTION
This pull request makes rgbasm allocate buffers for ROM sections only (previously, it allocated memory for RAM sections as well, even though they were empty). Also, instead of allocating 0x4000 bytes and resizing the buffer if needed, the max possible size for that type of section is allocated now (0x4000 for ROMX, 0x8000 for ROM0).

In rgbasm, point out the line that caused an overflow in any type of section.

Add checks in rgblink to see if any section in an object file is bigger than the maximum size of the section type, as it depends on the flags passed to rgblink when executing it.

Fixes https://github.com/rednex/rgbds/issues/89