### PR TITLE
Allow local labels to be referenced through their parent

### DIFF
--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -475,6 +475,7 @@ setuplex(void)
 	lex_FloatAddSecondRange(id, '\\', '\\');
 	lex_FloatAddSecondRange(id, '@', '@');
 	lex_FloatAddSecondRange(id, '#', '#');
+	lex_FloatAddRange(id, '.', '.');
 	lex_FloatAddRange(id, 'a', 'z');
 	lex_FloatAddRange(id, 'A', 'Z');
 	lex_FloatAddRange(id, '0', '9');

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -123,6 +123,7 @@ findsymbol(char *s, struct sSymbol * scope)
 	struct sSymbol **ppsym;
 	SLONG hash;
 	int local;
+	int local2; // for testing the presence of another .
 	int result;
 
 	// If referencing a local label from out of scope,
@@ -135,9 +136,19 @@ findsymbol(char *s, struct sSymbol * scope)
 		s[local] = '\0';
 		hash = calchash(s);
 		s[local] = '.';
+		
+		local2 = local + 1;
+		while (s[local2] != '\0' && s[local2] != '.') {
+			local2++;
+		}
+		if (s[local2] == '.') {
+			fatalerror("'%s' is a nonsensical reference to a nested local symbol", s);
+			return (NULL);
+		}
 	} else {
 		hash = calchash(s);
 	}
+	
 	ppsym = &(tHashedSymbols[hash]);
 
 	while ((*ppsym) != NULL) {

--- a/test/asm/remote-local-noexist.asm
+++ b/test/asm/remote-local-noexist.asm
@@ -1,0 +1,7 @@
+SECTION "sec", ROM0
+
+Parent:
+.child:
+	db 0
+NotParent:
+	dw Parent.child.fail

--- a/test/asm/remote-local-noexist.out
+++ b/test/asm/remote-local-noexist.out
@@ -1,0 +1,2 @@
+ERROR: remote-local-noexist.asm(7):
+	'Parent.child.fail' is a nonsensical reference to a nested local symbol

--- a/test/asm/remote-local.asm
+++ b/test/asm/remote-local.asm
@@ -1,0 +1,7 @@
+SECTION "sec", ROM0
+
+Parent:
+.child:
+	db 0
+NotParent:
+	dw Parent.child


### PR DESCRIPTION
This is an extremely useful feature that's been in use in the [Telefang disassembly](https://github.com/telefang/telefang).

Example:

```
Parent:
.child:
	db 0
NotParent:
	dw Parent.child
```