### PR TITLE
Print more useful error messages when redefining symbols

### DIFF
--- a/include/asm/fstack.h
+++ b/include/asm/fstack.h
@@ -41,6 +41,8 @@ extern void fstk_RunRept(ULONG count);
 FILE *
 fstk_FindFile(char *);
 
+int fstk_GetLine(void);
+
 extern int yywrap(void);
 
 #endif

--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -15,7 +15,9 @@ struct sSymbol {
 	struct Section *pSection;
 	ULONG ulMacroSize;
 	char *pMacro;
-	     SLONG(*Callback) (struct sSymbol *);
+	SLONG(*Callback) (struct sSymbol *);
+	char tzFileName[_MAX_PATH + 1]; /* File where the symbol was defined. */
+	ULONG nFileLine; /* Line where the symbol was defined. */
 };
 #define SYMF_RELOC		0x001	/* symbol will be reloc'ed during
 					 * linking, it's absolute value is

--- a/include/link/mylink.h
+++ b/include/link/mylink.h
@@ -89,6 +89,8 @@ struct sSymbol {
 	SLONG nSectionID;	/* internal to object.c */
 	struct sSection *pSection;
 	SLONG nOffset;
+	char *pzFileName; /* File where the symbol was defined. */
+	ULONG nFileLine; /* Line where the symbol was defined. */
 };
 
 enum ePatchType {

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -502,7 +502,7 @@ out_WriteObject(void)
 		struct PatchSymbol *pSym;
 		struct Section *pSect;
 
-		fwrite("RGB4", 1, 4, f);
+		fwrite("RGB5", 1, 4, f);
 		fputlong(countsymbols(), f);
 		fputlong(countsections(), f);
 

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -281,6 +281,9 @@ writesymbol(struct sSymbol * pSym, FILE * f)
 	fputstring(symname, f);
 	fputc(type, f);
 
+	fputstring(pSym->tzFileName, f);
+	fputlong(pSym->nFileLine, f);
+
 	if (type != SYM_IMPORT) {
 		fputlong(sectid, f);
 		fputlong(offset, f);

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -8,6 +8,7 @@
 #include <time.h>
 
 #include "asm/asm.h"
+#include "asm/fstack.h"
 #include "asm/symbol.h"
 #include "asm/main.h"
 #include "asm/mymath.h"
@@ -108,6 +109,8 @@ createsymbol(char *s)
 		(*ppsym)->pMacro = NULL;
 		(*ppsym)->pSection = NULL;
 		(*ppsym)->Callback = NULL;
+		strcpy((*ppsym)->tzFileName, tzCurrentFileName);
+		(*ppsym)->nFileLine = fstk_GetLine();
 		return (*ppsym);
 	} else {
 		fatalerror("No memory for symbol");

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -520,7 +520,8 @@ sym_AddEqu(char *tzSym, SLONG value)
 
 		if ((nsym = findsymbol(tzSym, NULL)) != NULL) {
 			if (nsym->nType & SYMF_DEFINED) {
-				yyerror("'%s' already defined", tzSym);
+				yyerror("'%s' already defined in %s(%d)",
+					tzSym, nsym->tzFileName, nsym->nFileLine);
 			}
 		} else
 			nsym = createsymbol(tzSym);
@@ -552,7 +553,8 @@ sym_AddString(char *tzSym, char *tzValue)
 
 	if ((nsym = findsymbol(tzSym, NULL)) != NULL) {
 		if (nsym->nType & SYMF_DEFINED) {
-			yyerror("'%s' already defined", tzSym);
+			yyerror("'%s' already defined in %s(%d)",
+				tzSym, nsym->tzFileName, nsym->nFileLine);
 		}
 	} else
 		nsym = createsymbol(tzSym);
@@ -655,7 +657,8 @@ sym_AddReloc(char *tzSym)
 
 		if ((nsym = findsymbol(tzSym, scope)) != NULL) {
 			if (nsym->nType & SYMF_DEFINED) {
-				yyerror("'%s' already defined", tzSym);
+				yyerror("'%s' already defined in %s(%d)",
+					tzSym, nsym->tzFileName, nsym->nFileLine);
 			}
 		} else
 			nsym = createsymbol(tzSym);
@@ -784,7 +787,8 @@ sym_AddMacro(char *tzSym)
 
 		if ((nsym = findsymbol(tzSym, NULL)) != NULL) {
 			if (nsym->nType & SYMF_DEFINED) {
-				yyerror("'%s' already defined", tzSym);
+				yyerror("'%s' already defined in %s(%d)",
+					tzSym, nsym->tzFileName, nsym->nFileLine);
 			}
 		} else
 			nsym = createsymbol(tzSym);

--- a/src/link/object.c
+++ b/src/link/object.c
@@ -336,8 +336,7 @@ obj_ReadOpenFile(FILE * pObjfile, char *tzObjectfile)
 	tzHeader[4] = 0;
 	if (strncmp(tzHeader, "RGB", 3) == 0) {
 		switch (tzHeader[3]) {
-		case '3':
-		case '4': // V4 supports OAM sections, but is otherwise identical
+		case '5':
 			obj_ReadRGB(pObjfile);
 			break;
 		default:

--- a/src/link/object.c
+++ b/src/link/object.c
@@ -126,7 +126,12 @@ obj_ReadSymbol(FILE * f)
 	}
 
 	readasciiz(&pSym->pzName, f);
-	if ((pSym->Type = (enum eSymbolType) fgetc(f)) != SYM_IMPORT) {
+	pSym->Type = (enum eSymbolType)fgetc(f);
+
+	readasciiz(&pSym->pzFileName, f);
+	pSym->nFileLine = readlong(f);
+
+	if (pSym->Type != SYM_IMPORT) {
 		pSym->nSectionID = readlong(f);
 		pSym->nOffset = readlong(f);
 	}

--- a/src/rgbds.5
+++ b/src/rgbds.5
@@ -57,6 +57,10 @@ REPT    NumberOfSymbols   ; Number of symbols defined in this object file.
                           ; 1 = IMPORT this symbol from elsewhere (unused).
                           ; 2 = EXPORT this symbol to other objects.
 
+    STRING  FileName      ; File where the symbol is defined.
+
+    LONG    FileLineNum   ; Line number in the file where the symbol is defined.
+
     IF      Type != 1     ; If symbol is defined in this object file.
 
         LONG    SectionID ; The section number (of this object file) in which


### PR DESCRIPTION
This pull request improves the error messages that are shown when a symbol is redefined by telling the file and line where it was defined in the first place: ```'label' already defined in file.asm(42)```

Version number of object files increased because there is a compatibility break: New object files contain the name of the file and the line of code of the definition of each symbol.

Fixes #75