### PR TITLE
Add support for unions

### DIFF
--- a/include/asm/asm.h
+++ b/include/asm/asm.h
@@ -18,19 +18,23 @@
 
 #include "asm/localasm.h"
 
+#define MAXUNIONS		128
+#define MAXMACROARGS	256
+#define MAXINCPATHS		128
+
 extern SLONG nLineNo;
 extern ULONG nTotalLines;
 extern ULONG nPC;
 extern ULONG nPass;
 extern ULONG nIFDepth;
 extern bool skipElif;
+extern ULONG nUnionDepth;
+extern ULONG unionStart[MAXUNIONS];
+extern ULONG unionSize[MAXUNIONS];
 extern char tzCurrentFileName[_MAX_PATH + 1];
 extern struct Section *pCurrentSection;
 extern struct sSymbol *tHashedSymbols[HASHSIZE];
 extern struct sSymbol *pPCSymbol;
 extern bool oDontExpandStrings;
-
-#define MAXMACROARGS	256
-#define MAXINCPATHS		128
 
 #endif	/* //       ASM_H */

--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -331,6 +331,10 @@ struct sLexInitString staticstrings[] = {
 	{"else", T_POP_ELSE},
 	{"elif", T_POP_ELIF},
 	{"endc", T_POP_ENDC},
+	
+	{"union", T_POP_UNION},
+	{"nextu", T_POP_NEXTU},
+	{"endu", T_POP_ENDU},
 
 	{"wram0", T_SECT_WRAM0},
 	{"vram", T_SECT_VRAM},

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -22,8 +22,9 @@ char **cldefines;
 
 clock_t nStartClock, nEndClock;
 SLONG nLineNo;
-ULONG nTotalLines, nPass, nPC, nIFDepth, nErrors;
+ULONG nTotalLines, nPass, nPC, nIFDepth, nUnionDepth, nErrors;
 bool skipElif;
+ULONG unionStart[128], unionSize[128];
 
 extern int yydebug;
 
@@ -416,6 +417,7 @@ main(int argc, char *argv[])
 	nTotalLines = 0;
 	nIFDepth = 0;
 	skipElif = true;
+	nUnionDepth = 0;
 	nPC = 0;
 	nPass = 1;
 	nErrors = 0;
@@ -438,11 +440,16 @@ main(int argc, char *argv[])
 	if (nIFDepth != 0) {
 		errx(1, "Unterminated IF construct (%ld levels)!", nIFDepth);
 	}
+	
+	if (nUnionDepth != 0) {
+		errx(1, "Unterminated UNION construct (%ld levels)!", nUnionDepth);
+	}
 
 	nTotalLines = 0;
 	nLineNo = 1;
 	nIFDepth = 0;
 	skipElif = true;
+	nUnionDepth = 0;
 	nPC = 0;
 	nPass = 2;
 	nErrors = 0;

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -612,6 +612,41 @@ You can also include only part of a file with
 The example below includes 256 bytes from data.bin starting from byte 78.
 .Pp
 .Dl INCBIN \[dq]data.bin\[dq],78,256
+.Ss Unions
+Unions allow multiple memory allocations to share the same space in memory,
+like unions in C.
+This allows you to easily reuse memory for different purposes, depending on
+the game's state.
+.Pp
+You create unions using the
+.Ic UNION ,
+.Ic NEXTU
+and
+.Ic ENDU
+keywords.
+.Ic NEXTU
+lets you create a new block of allocations, and you may use it as many times
+within a union as necessary.
+.Pp
+.Bd -literal -offset indent
+UNION
+Name: ds 8
+Nickname: ds 8
+NEXTU
+Health: dw
+Something: ds 3
+Lives: db
+NEXTU
+Temporary: ds 19
+ENDU
+.Ed
+.Pp
+This union will use up 19 bytes, as this is the size of the largest block
+(the last one, containing 'Temporary').
+Of course, as 'Name', 'Health', and 'Temporary' all point to the same memory
+locations, writes to any one of these will affect values read from the others.
+.Pp
+Unions may be used in any section, but code and data may not be included.
 .Sh THE MACRO LANGUAGE
 .Pp
 .Ss Printing things during assembly


### PR DESCRIPTION
Unions allow multiple memory allocations (using `ds`, etc.) to share the same space in memory, similar to unions in C. This allows games to use the same memory for different purposes, depending on their state.

At present, the syntax looks like this:
```
UNION
Name: ds 8
Nickname: ds 8
NEXTU
Health: dw
Something: ds 3
Lives: db
NEXTU
Temporary: ds 19
ENDU
```

`UNION` begins a union, `NEXTU` begins a new block of allocations (so allocations begin from the original memory address), and `ENDU` finishes the union. You can include as many or as few of these blocks as you like.

Unions may be used in any section, but code and data may not be included.

*Aside: I've been unsure what to name `NEXTU`, so if anyone has any better ideas, do let me know.*

I've also added documentation on how to use the new `UNION`, `NEXTU`, and `ENDU` keywords. Feel free to fix the formatting in it, if necessary.

Fixes #190.