### PR TITLE
Add shebang to test shell scripts

### DIFF
--- a/test/asm/test.sh
+++ b/test/asm/test.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 fname=$(mktemp)
 rc=0
 

--- a/test/asm/update-refs.sh
+++ b/test/asm/update-refs.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 fname=$(mktemp)
 
 for i in *.asm; do

--- a/test/link/test.sh
+++ b/test/link/test.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 otemp=$(mktemp)
 gbtemp=$(mktemp)
 gbtemp2=$(mktemp)

--- a/test/link/update-refs.sh
+++ b/test/link/update-refs.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 otemp=$(mktemp)
 gbtemp=$(mktemp)
 


### PR DESCRIPTION
This ensures that the test scripts are correctly run with the Bourne shell, regardless of the (potentially more exotic) shell that is used to invoke the script.

*(This is a really exciting change, I know…)*