### PR TITLE
Fix and document `DL` and add warnings to empty elements in lists of constants

### DIFF
--- a/include/asm/localasm.h
+++ b/include/asm/localasm.h
@@ -82,6 +82,7 @@
 
 #define	NAME_DB			"db"
 #define	NAME_DW			"dw"
+#define	NAME_DL			"dl"
 #define	NAME_RB			"rb"
 #define	NAME_RW			"rw"
 

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -982,32 +982,49 @@ const_3bit		:	const
 					}
 ;
 
-constlist_8bit	:	constlist_8bit_entry
-				|	constlist_8bit_entry ',' constlist_8bit
+constlist_8bit : constlist_8bit_entry
+	| constlist_8bit_entry ',' constlist_8bit
 ;
 
-constlist_8bit_entry	:               { out_Skip( 1 ); }
-						|	const_8bit	{ out_RelByte( &$1 ); }
-			   			|	string		{ char *s; int length; s = $1; length = charmap_Convert(&s); out_AbsByteGroup(s, length); free(s); }
+constlist_8bit_entry : /* empty */ {
+		out_Skip( 1 );
+		if( nPass==1 )
+			warning("Empty entry in list of 8-bit elements (treated as 0).");
+	} | const_8bit {
+		out_RelByte( &$1 );
+	} | string {
+		char *s = $1;
+		int length = charmap_Convert(&s);
+		out_AbsByteGroup(s, length);
+		free(s);
+	}
 ;
 
-constlist_16bit	:	constlist_16bit_entry
-				|	constlist_16bit_entry ',' constlist_16bit
+constlist_16bit : constlist_16bit_entry
+	| constlist_16bit_entry ',' constlist_16bit
 ;
 
-constlist_16bit_entry	:  				{ out_Skip( 2 ); }
-						|	const_16bit	{ out_RelWord( &$1 ); }
+constlist_16bit_entry : /* empty */ {
+		out_Skip( 2 );
+		if( nPass==1 )
+			warning("Empty entry in list of 16-bit elements (treated as 0).");
+	} | const_16bit {
+		out_RelWord( &$1 );
+	}
 ;
 
-
-constlist_32bit	:	constlist_32bit_entry
-				|	constlist_32bit_entry ',' constlist_32bit
+constlist_32bit : constlist_32bit_entry
+	| constlist_32bit_entry ',' constlist_32bit
 ;
 
-constlist_32bit_entry	:				{ out_Skip( 4 ); }
-						|	relocconst	{ out_RelLong( &$1 ); }
+constlist_32bit_entry : /* empty */ {
+		out_Skip( 4 );
+		if( nPass==1 )
+			warning("Empty entry in list of 32-bit elements (treated as 0).");
+	} | relocconst {
+		out_RelLong( &$1 );
+	}
 ;
-
 
 const_PCrel		:	relocconst
 					{

--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -305,6 +305,7 @@ struct sLexInitString staticstrings[] = {
 	{"ds", T_POP_DS},
 	{NAME_DB, T_POP_DB},
 	{NAME_DW, T_POP_DW},
+	{NAME_DL, T_POP_DL},
 	{"section", T_POP_SECTION},
 	{"purge", T_POP_PURGE},
 

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -558,30 +558,37 @@ The following symbols are defined by the assembler:
 .Ss Defining constant data
 .Ic DB
 defines a list of bytes that will be stored in the final image.
-Ideal for tables and text.
+Ideal for tables and text (which is not zero-terminated).
 .Pp
 .Dl DB 1,2,3,4,\[dq]This is a string\[dq]
 .Pp
 Alternatively, you can use
 .Ic DW
-to store a list of words.
+to store a list of words (16-bits) or
+.Ic DL
+to store a list of doublewords/longs (32-bits).
 Strings are not allowed as arguments to
-.Ic DW .
+.Ic DW
+and
+.Ic DL .
 .Pp
 You can also use
-.Ic DB
-and
+.Ic DB ,
 .Ic DW
-without arguments.
-This works exactly like
-.Sy DS 1
 and
+.Ic DL
+without arguments, or leaving empty elements at any point in the list.
+This works exactly like
+.Sy DS 1 ,
 .Sy DS 2
+and
+.Sy DS 4
 respectively.
 Consequently,
-.Ic DB
-and
+.Ic DB ,
 .Ic DW
+and
+.Ic DL
 can be used in a
 .Sy WRAM0 No / Sy WRAMX No / Sy HRAM No / Sy VRAM No / Sy SRAM
 section.
@@ -591,9 +598,10 @@ allocates a number of bytes.
 The content is undefined.
 This is the preferred method of allocationg space in a RAM section.
 You can, however, use
-.Ic DB
-and
+.Ic DB , 
 .Ic DW
+and
+.Ic DL
 without any arguments instead.
 .Pp
 .Dl DS str_SIZEOF ;allocate str_SIZEOF bytes
@@ -1036,6 +1044,7 @@ machine.
 .It Sx DB
 .It Sx DEF
 .It Sx DIV
+.It Sx DL
 .It Sx DS
 .It Sx DW
 .It Sx ELIF


### PR DESCRIPTION
`DL` acts like `DB` or `DW` but for 32-bit values.

Even though this behaviour is documented (empty elements are treated as 0), it can be misleading. By having a warning, compatibility is maintained and potential problems in the code can be detected.

Fixes https://github.com/rednex/rgbds/issues/208