### PR TITLE
Remove warning on DB/DW/DL emtpy lists

### DIFF
--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -806,13 +806,16 @@ ds				:	T_POP_DS uconst
 					{ out_Skip( $2 ); }
 ;
 
-db				:	T_POP_DB constlist_8bit
+db			:		T_POP_DB constlist_8bit_entry ',' constlist_8bit
+				|	T_POP_DB constlist_8bit_entry_single
 ;
 
-dw				:	T_POP_DW constlist_16bit
+dw			:		T_POP_DW constlist_16bit_entry ',' constlist_16bit
+				|	T_POP_DW constlist_16bit_entry_single
 ;
 
-dl				:	T_POP_DL constlist_32bit
+dl			:		T_POP_DL constlist_32bit_entry ',' constlist_32bit
+				|	T_POP_DL constlist_32bit_entry_single
 ;
 
 purge			:	T_POP_PURGE
@@ -1000,6 +1003,18 @@ constlist_8bit_entry : /* empty */ {
 	}
 ;
 
+constlist_8bit_entry_single : /* empty */ {
+		out_Skip( 1 );
+	} | const_8bit {
+		out_RelByte( &$1 );
+	} | string {
+		char *s = $1;
+		int length = charmap_Convert(&s);
+		out_AbsByteGroup(s, length);
+		free(s);
+	}
+;
+
 constlist_16bit : constlist_16bit_entry
 	| constlist_16bit_entry ',' constlist_16bit
 ;
@@ -1013,6 +1028,13 @@ constlist_16bit_entry : /* empty */ {
 	}
 ;
 
+constlist_16bit_entry_single : /* empty */ {
+		out_Skip( 2 );
+	} | const_16bit {
+		out_RelWord( &$1 );
+	}
+;
+
 constlist_32bit : constlist_32bit_entry
 	| constlist_32bit_entry ',' constlist_32bit
 ;
@@ -1021,6 +1043,13 @@ constlist_32bit_entry : /* empty */ {
 		out_Skip( 4 );
 		if( nPass==1 )
 			warning("Empty entry in list of 32-bit elements (treated as 0).");
+	} | relocconst {
+		out_RelLong( &$1 );
+	}
+;
+
+constlist_32bit_entry_single : /* empty */ {
+		out_Skip( 4 );
 	} | relocconst {
 		out_RelLong( &$1 );
 	}

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -598,7 +598,7 @@ allocates a number of bytes.
 The content is undefined.
 This is the preferred method of allocationg space in a RAM section.
 You can, however, use
-.Ic DB , 
+.Ic DB ,
 .Ic DW
 and
 .Ic DL


### PR DESCRIPTION
This warning was added in 781c90b940ba24e23eb6c92eea6549f7643746fa as a way of catching the following cases, which are most likely programmer mistakes:

    DB 1,, 2
    DB 1, 2,

However, the warning was also triggered in the following case:

    DB

It can be used as a replacement of:

    DS 1

In this case, it shouldn't output a warning.