### PR TITLE
PUSHS and POPS also affect the symbol scope

### DIFF
--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -80,4 +80,8 @@ void sym_Purge(char *tzName);
 uint32_t sym_isConstDefined(char *tzName);
 int32_t sym_IsRelocDiffDefined(char *tzSym1, char *tzSym2);
 
+/* Functions to save and restore the current symbol scope. */
+struct sSymbol *sym_GetCurrentSymbolScope(void);
+void sym_SetCurrentSymbolScope(struct sSymbol *pNewScope);
+
 #endif /* RGBDS_SYMBOL_H */

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -42,6 +42,7 @@ struct PatchSymbol {
 
 struct SectionStackEntry {
 	struct Section *pSection;
+	struct sSymbol *pScope; /* Section's symbol scope */
 	struct SectionStackEntry *pNext;
 };
 
@@ -64,6 +65,7 @@ void out_PushSection(void)
 		fatalerror("No memory for section stack");
 
 	pSect->pSection = pCurrentSection;
+	pSect->pScope = sym_GetCurrentSymbolScope();
 	pSect->pNext = pSectionStack;
 	pSectionStack = pSect;
 }
@@ -77,6 +79,7 @@ void out_PopSection(void)
 
 	pSect = pSectionStack;
 	out_SetCurrentSection(pSect->pSection);
+	sym_SetCurrentSymbolScope(pSect->pScope);
 	pSectionStack = pSect->pNext;
 	free(pSect);
 }

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -19,7 +19,7 @@
 #include "extern/version.h"
 
 struct sSymbol *tHashedSymbols[HASHSIZE];
-static struct sSymbol *pScope;
+static struct sSymbol *pScope; /* Current section symbol scope */
 struct sSymbol *pPCSymbol;
 static struct sSymbol *p_NARGSymbol;
 static struct sSymbol *p__LINE__Symbol;
@@ -404,6 +404,16 @@ uint32_t sym_GetDefinedValue(char *s)
 	yyerror("'%s' not defined", s);
 
 	return 0;
+}
+
+struct sSymbol *sym_GetCurrentSymbolScope(void)
+{
+	return pScope;
+}
+
+void sym_SetCurrentSymbolScope(struct sSymbol *pNewScope)
+{
+	pScope = pNewScope;
 }
 
 /*


### PR DESCRIPTION
Now, when POPS is executed, it restores the symbol scope of the corresponding PUSHS. That way, the local symbols previously available can be used again after the POPS.

This is useful in cases like this one:

```
    SECTION "Section 1", ROMX

BigFunction:

    ...

.loop:

    ...

    PUSHS

    SECTION "Section 2", ROMX

DataForBigFunction:
    DB 1, 2, 3, 4, 5

    POPS

    ld  a,BANK(DataForBigFunction)
    ld  hl,DataForBigFunction

    ...

    jr  .loop
```

Fixes https://github.com/rednex/rgbds/issues/205