### PR TITLE
Relicense codebase under the MIT license

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,0 +1,39 @@
+Contributors to RGBDS
+=====================
+
+Original author
+---------------
+
+- Carsten Elton Sørensen <csoren@gmail.com>
+
+Main contributors
+-----------------
+
+- Justin Lloyd <jlloyd@imf.la>
+
+- Vegard Nossum <vegard.nossum@gmail.com>
+
+- Anthony J. Bentley <anthony@anjbe.name>
+
+- stag019 <stag019@gmail.com>
+
+- Antonio Niño Díaz <antonio_nd@outlook.com>
+
+Other contributors
+------------------
+
+- Ben10do
+
+- Björn Höhrmann <bjoern@hoehrmann.de>
+
+- Christophe Staïesse <chastai@skynet.be>
+
+- The Musl C library <http://www.musl-libc.org>
+
+- The OpenBSD Project <http://www.openbsd.org>
+
+- Sanqui <gsanky@gmail.com>
+
+- YamaArashi <shadow962@live.com>
+
+- yenatch <yenatch@gmail.com>

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,81 +1,31 @@
 LICENSE
 =======
 
-Original code
--------------
+Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
 
-Copyright (C) 1997 Carsten Sorensen <surfsmurf@matilde.demon.co.uk>
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The ASMotor package (xAsm, xLink, RGBFix, examples and documentation) is
-freeware and distributed as is. The author retains his copyright and right to
-modify the specifications and operation of the software without notice.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-In other words this means I encourage you to...
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
 
-- use it for whatever purpose even professional work without me charging you a
-  penny
-- copy it to another person (wholly or in part, though I'm sure he'd appreciate
-  the whole package) in whatever form you find suitable
-- mass-distribute the ASMotor package if it is complete (xAsm, xLink, RGBFix and
-  documentation).
-- contact me if you have any problems
-
-This also means you can't...
-
-- blame me for loss of profit, data, sleep, food or other nasty things through
-  the use or distribution of ASMotor. If you choose to use ASMotor you do so at
-  your own risk.
-- expect me to be able to help you should you have a problem related or not to
-  ASMotor.
-
-Otaku no Zoku's modifications
------------------------------
-
-Copyright (C) 1999 Justin Lloyd <jlloyd@imf.la> (?)
-
-::
-
-                         DO WHATEVER PUBLIC LICENSE*
-      TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
-
-     0. You can do whatever you want to with the work.
-     1. You cannot stop anybody from doing whatever they want to with the work.
-     2. You cannot revoke anybody elses DO WHATEVER PUBLIC LICENSE in the work.
-
-    This program is free software. It comes without any warranty, to
-    the extent permitted by applicable law. You can redistribute it
-    and/or modify it under the terms of the DO WHATEVER PUBLIC LICENSE
-
-    Software originally created by Justin Lloyd @ http://otakunozoku.com/
-
-rgbds-linux
------------
-
-Copyright (C) 2009 Vegard Nossum <vegard.nossum@gmail.com>
-
-Current
--------
-
-rgbasm and rgblink are derived from Justin Lloyd's RGBDS.
-
-rgbfix was rewritten from scratch by Anthony J. Bentley, and is released under
-the ISC license; see the source file for the text of the license.
-
-rgbgfx was written by stag019, and is released under the ISC license.
-
-Some files of rgblink were written by Antonio Niño Díaz, and they are relased
-under the ISC license. The affected files have the appropriate license in the
-header of the file.
-
-The UTF-8 decoder in src/asm/charmap.c was written by Björn Höhrmann and is
-released under the MIT license. The remainder of charmap.c was written by
-stag019, and is released under the ISC license.
-
-extern/err.c is derived from the Musl C library, http://www.musl-libc.org, and
-is released under the MIT license.
+Other
+-----
 
 extern/reallocarray.c is derived from the OpenBSD Project,
 http://www.openbsd.org, and is released under the ISC license.
 
-extern/strl.c is derived from the OpenBSD Project, http://www.openbsd.org, and
-is released under the BSD license.
+extern/strlcat.c and extern/strlcpy.c are derived from the OpenBSD Project,
+http://www.openbsd.org, and are released under the BSD license.

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ rgbasm_obj := \
 	src/extern/reallocarray.o \
 	src/extern/strlcpy.o \
 	src/extern/strlcat.o \
+	src/extern/utf8decoder.o \
 	src/extern/version.o
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+#
+# This file is part of RGBDS.
+#
+# Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+#
+# SPDX-License-Identifier: MIT
+#
+
 # User-defined variables
 
 Q		:= @

--- a/README.rst
+++ b/README.rst
@@ -170,3 +170,5 @@ This is the complete list of user-defined variables:
   implementation of rgbds.
 
 - 2017, Bentley's repository is moved to a neutral name.
+
+- 2018, codebase relicensed under the MIT license.

--- a/docs/gbz80.7.html
+++ b/docs/gbz80.7.html
@@ -1689,7 +1689,7 @@ Flags: See <a class="Sx" title="Sx" href="#XOR_A,r8">XOR A,r8</a>
   <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">April 17, 2017</td>
+    <td class="foot-date">January 26, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/docs/rgbasm.1.html
+++ b/docs/rgbasm.1.html
@@ -138,7 +138,7 @@ The resulting object file is not yet a usable ROM image &#x2014; it must first
   <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">April 17, 2017</td>
+    <td class="foot-date">January 26, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/docs/rgbasm.5.html
+++ b/docs/rgbasm.5.html
@@ -1451,7 +1451,7 @@ The options that OPT can modify are currently: <b class="Sy" title="Sy">b</b>,
   <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">January 7, 2018</td>
+    <td class="foot-date">January 26, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/docs/rgbds.5.html
+++ b/docs/rgbds.5.html
@@ -298,7 +298,7 @@ Expressions in the object file are stored as RPN. This is an expression of the
   <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">January 7, 2018</td>
+    <td class="foot-date">January 26, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/docs/rgbds.7.html
+++ b/docs/rgbds.7.html
@@ -52,12 +52,13 @@ To get a working ROM image from a single assembly source file:
   <dt class="It-ohang"></dt>
   <dd class="It-ohang">2017, Bentley's repository is moved to a neutral name. It
       is now maintained by a number of contributors at
-      <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</dd>
+      <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.
+      2018, codebase relicensed under the MIT license.</dd>
 </dl>
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">April 17, 2017</td>
+    <td class="foot-date">January 26, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/docs/rgbfix.1.html
+++ b/docs/rgbfix.1.html
@@ -179,7 +179,7 @@ The following will duplicate the header (sans global checksum) of the game
   <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">April 17, 2017</td>
+    <td class="foot-date">January 26, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/docs/rgbgfx.1.html
+++ b/docs/rgbgfx.1.html
@@ -145,7 +145,7 @@ The following will do nothing:
   <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">April 17, 2017</td>
+    <td class="foot-date">January 26, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/docs/rgblink.1.html
+++ b/docs/rgblink.1.html
@@ -153,7 +153,7 @@ The resulting bar.gb will not have correct checksums (unless you put them in the
   <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">April 17, 2017</td>
+    <td class="foot-date">January 26, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/docs/rgblink.5.html
+++ b/docs/rgblink.5.html
@@ -97,7 +97,7 @@ Note: The bank, alignment, address and type of sections can be specified both in
   <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">April 17, 2017</td>
+    <td class="foot-date">January 26, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/include/asm/asm.h
+++ b/include/asm/asm.h
@@ -1,9 +1,13 @@
 /*
- * asm.h
+ * This file is part of RGBDS.
  *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
  * Contains some assembler-wide defines and externs
- *
- * Copyright 1997 Carsten Sorensen
  */
 
 #ifndef RGBDS_ASM_ASM_H

--- a/include/asm/charmap.h
+++ b/include/asm/charmap.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_ASM_CHARMAP_H
 #define RGBDS_ASM_CHARMAP_H
 

--- a/include/asm/fstack.h
+++ b/include/asm/fstack.h
@@ -1,9 +1,13 @@
-/*  fstack.h
+/*
+ * This file is part of RGBDS.
  *
- *  Contains some assembler-wide defines and externs
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
  *
- *  Copyright 1997 Carsten Sorensen
- *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * Contains some assembler-wide defines and externs
  */
 
 #ifndef RGBDS_ASM_FSTACK_H

--- a/include/asm/lexer.h
+++ b/include/asm/lexer.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_ASM_LEXER_H
 #define RGBDS_ASM_LEXER_H
 

--- a/include/asm/localasm.h
+++ b/include/asm/localasm.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_ASM_LOCALASM_H
 #define RGBDS_ASM_LOCALASM_H
 

--- a/include/asm/main.h
+++ b/include/asm/main.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_MAIN_H
 #define RGBDS_MAIN_H
 

--- a/include/asm/mymath.h
+++ b/include/asm/mymath.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_ASM_MATH_H
 #define RGBDS_ASM_MATH_H
 

--- a/include/asm/output.h
+++ b/include/asm/output.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_ASM_OUTPUT_H
 #define RGBDS_ASM_OUTPUT_H
 

--- a/include/asm/rpn.h
+++ b/include/asm/rpn.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_ASM_RPN_H
 #define RGBDS_ASM_RPN_H
 

--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_SYMBOL_H
 #define RGBDS_SYMBOL_H
 

--- a/include/common.h
+++ b/include/common.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_COMMON_H
 #define RGBDS_COMMON_H
 

--- a/include/extern/err.h
+++ b/include/extern/err.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef EXTERN_ERR_H
 #define EXTERN_ERR_H
 

--- a/include/extern/reallocarray.h
+++ b/include/extern/reallocarray.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 2015-2018, RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef EXTERN_REALLOCARRAY_H
 #define EXTERN_REALLOCARRAY_H
 

--- a/include/extern/stdnoreturn.h
+++ b/include/extern/stdnoreturn.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 2014-2018, RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef EXTERN_STDNORETURN_H
 #define EXTERN_STDNORETURN_H
 

--- a/include/extern/strl.h
+++ b/include/extern/strl.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 2015-2018, RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef EXTERN_STRL_H
 #define EXTERN_STRL_H
 

--- a/include/extern/utf8decoder.h
+++ b/include/extern/utf8decoder.h
@@ -1,0 +1,6 @@
+#ifndef EXTERN_UTF8DECODER_H
+#define EXTERN_UTF8DECODER_H
+
+uint32_t decode(uint32_t *state, uint32_t *codep, uint32_t byte);
+
+#endif /* EXTERN_UTF8DECODER_H */

--- a/include/extern/utf8decoder.h
+++ b/include/extern/utf8decoder.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 2018, Antonio Nino Diaz and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef EXTERN_UTF8DECODER_H
 #define EXTERN_UTF8DECODER_H
 

--- a/include/extern/version.h
+++ b/include/extern/version.h
@@ -1,17 +1,9 @@
 /*
- * Copyright (C) 2017 Antonio Nino Diaz <antonio_nd@outlook.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 #ifndef EXTERN_VERSION_H

--- a/include/gfx/gb.h
+++ b/include/gfx/gb.h
@@ -1,17 +1,9 @@
 /*
- * Copyright © 2013 stag019 <stag019@gmail.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2013-2018, stag019 and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 #ifndef RGBDS_GFX_GB_H

--- a/include/gfx/main.h
+++ b/include/gfx/main.h
@@ -1,17 +1,9 @@
 /*
- * Copyright © 2013 stag019 <stag019@gmail.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2013-2018, stag019 and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 #ifndef RGBDS_GFX_MAIN_H

--- a/include/gfx/makepng.h
+++ b/include/gfx/makepng.h
@@ -1,17 +1,9 @@
 /*
- * Copyright © 2013 stag019 <stag019@gmail.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2013-2018, stag019 and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 #ifndef RGBDS_GFX_PNG_H

--- a/include/link/assign.h
+++ b/include/link/assign.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_LINK_ASSIGN_H
 #define RGBDS_LINK_ASSIGN_H
 

--- a/include/link/library.h
+++ b/include/link/library.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_LINK_LIBRARY_H
 #define RGBDS_LINK_LIBRARY_H
 

--- a/include/link/main.h
+++ b/include/link/main.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_LINK_MAIN_H
 #define RGBDS_LINK_MAIN_H
 

--- a/include/link/mapfile.h
+++ b/include/link/mapfile.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_LINK_MAPFILE_H
 #define RGBDS_LINK_MAPFILE_H
 

--- a/include/link/mylink.h
+++ b/include/link/mylink.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_LINK_LINK_H
 #define RGBDS_LINK_LINK_H
 

--- a/include/link/object.h
+++ b/include/link/object.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_LINK_OBJECT_H
 #define RGBDS_LINK_OBJECT_H
 

--- a/include/link/output.h
+++ b/include/link/output.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_LINK_OUTPUT_H
 #define RGBDS_LINK_OUTPUT_H
 

--- a/include/link/patch.h
+++ b/include/link/patch.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_LINK_PATCH_H
 #define RGBDS_LINK_PATCH_H
 

--- a/include/link/script.h
+++ b/include/link/script.h
@@ -1,17 +1,9 @@
 /*
- * Copyright (C) 2017 Antonio Nino Diaz <antonio_nd@outlook.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 #ifndef RGBDS_LINK_SCRIPT_H

--- a/include/link/symbol.h
+++ b/include/link/symbol.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_LINK_SYMBOL_H
 #define RGBDS_LINK_SYMBOL_H
 

--- a/include/linkdefs.h
+++ b/include/linkdefs.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_LINKDEFS_H
 #define RGBDS_LINKDEFS_H
 

--- a/include/types.h
+++ b/include/types.h
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef RGBDS_TYPES_H
 #define RGBDS_TYPES_H
 

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 %{
 #include <ctype.h>
 #include <errno.h>

--- a/src/asm/charmap.c
+++ b/src/asm/charmap.c
@@ -1,72 +1,4 @@
 /*
- * UTF-8 decoder copyright © 2008–2009 Björn Höhrmann <bjoern@hoehrmann.de>
- * http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to
- * deal in the Software without restriction, including without limitation the
- * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
- * sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
- */
-
-#include <stdint.h>
-
-static const uint8_t utf8d[] = {
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 00..0f */
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 10..1f */
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 20..2f */
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 30..3f */
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 40..4f */
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 50..5f */
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 60..6f */
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 70..7f */
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 80..8f */
-	9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, /* 90..9f */
-	7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, /* a0..af */
-	7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, /* b0..bf */
-	8, 8, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* c0..cf */
-	2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* d0..df */
-	0xa, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, /* e0..e7 */
-	0x3, 0x3, 0x3, 0x3, 0x3, 0x4, 0x3, 0x3, /* e8..ef */
-	0xb, 0x6, 0x6, 0x6, 0x5, 0x8, 0x8, 0x8, /* f0..f7 */
-	0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, /* f8..ff */
-	0x0, 0x1, 0x2, 0x3, 0x5, 0x8, 0x7, 0x1, /* s0..   */
-	0x1, 0x1, 0x4, 0x6, 0x1, 0x1, 0x1, 0x1, /*   ..s0 */
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* s1 */
-	1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, /* s1 */
-	1, 2, 1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 1, 1, 1, 1, /* s3 */
-	1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, /* s4 */
-	1, 2, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, /* s5 */
-	1, 1, 1, 1, 1, 1, 1, 3, 1, 3, 1, 1, 1, 1, 1, 1, /* s6 */
-	1, 3, 1, 1, 1, 1, 1, 3, 1, 3, 1, 1, 1, 1, 1, 1, /* s7 */
-	1, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* s8 */
-};
-
-uint32_t decode(uint32_t *state, uint32_t *codep, uint32_t byte)
-{
-	uint32_t type = utf8d[byte];
-
-	*codep = (*state != 0) ?
-			(byte & 0x3fu) | (*codep << 6) :
-			(0xff >> type) & (byte);
-
-	*state = utf8d[256 + *state * 16 + type];
-	return *state;
-}
-
-/*
  * Copyright © 2013 stag019 <stag019@gmail.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -82,6 +14,7 @@ uint32_t decode(uint32_t *state, uint32_t *codep, uint32_t byte)
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -90,6 +23,8 @@ uint32_t decode(uint32_t *state, uint32_t *codep, uint32_t byte)
 #include "asm/charmap.h"
 #include "asm/main.h"
 #include "asm/output.h"
+
+#include "extern/utf8decoder.h"
 
 struct Charmap globalCharmap = {0};
 

--- a/src/asm/charmap.c
+++ b/src/asm/charmap.c
@@ -1,17 +1,9 @@
 /*
- * Copyright © 2013 stag019 <stag019@gmail.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2013-2018, stag019 and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 #include <stdint.h>

--- a/src/asm/fstack.c
+++ b/src/asm/fstack.c
@@ -1,4 +1,12 @@
 /*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
  * FileStack routines
  */
 

--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <math.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <math.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/src/asm/math.c
+++ b/src/asm/math.c
@@ -1,4 +1,12 @@
 /*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
  * Fixedpoint math routines
  */
 

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -1,4 +1,12 @@
 /*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
  * Outputs an objectfile
  */
 

--- a/src/asm/rgbasm.1
+++ b/src/asm/rgbasm.1
@@ -1,18 +1,11 @@
-.\" Copyright © 2010 Anthony J. Bentley <anthony@anjbe.name>
 .\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
+.\" This file is part of RGBDS.
 .\"
-.\" THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+.\" Copyright (c) 2010-2018, Anthony J. Bentley and RGBDS contributors.
 .\"
-.Dd April 17, 2017
+.\" SPDX-License-Identifier: MIT
+.\"
+.Dd January 26, 2018
 .Dt RGBASM 1
 .Os RGBDS Manual
 .Sh NAME

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -1,18 +1,11 @@
-.\" Copyright (c) 2017-2018 Antonio Nino Diaz <antonio_nd@outlook.com>
 .\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
+.\" This file is part of RGBDS.
 .\"
-.\" THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+.\" Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
 .\"
-.Dd January 7, 2018
+.\" SPDX-License-Identifier: MIT
+.\"
+.Dd January 26, 2018
 .Dt RGBASM 5
 .Os RGBDS Manual
 .Sh NAME

--- a/src/asm/rpn.c
+++ b/src/asm/rpn.c
@@ -1,4 +1,12 @@
 /*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
  * Controls RPN expressions for objectfiles
  */
 

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -1,4 +1,12 @@
 /*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
  * Symboltable and macroargs stuff
  */
 

--- a/src/extern/err.c
+++ b/src/extern/err.c
@@ -1,24 +1,9 @@
 /*
- * Copyright © 2005-2013 Rich Felker, et al.
+ * This file is part of RGBDS.
  *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to
- * the following conditions:
+ * Copyright (c) 2005-2018, Rich Felker and RGBDS contributors.
  *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
- * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
- * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 #include <stdarg.h>

--- a/src/extern/utf8decoder.c
+++ b/src/extern/utf8decoder.c
@@ -1,24 +1,11 @@
 /*
- * UTF-8 decoder copyright © 2008–2009 Björn Höhrmann <bjoern@hoehrmann.de>
- * http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+ * Copyright (c) 2008-2009, Björn Höhrmann <bjoern@hoehrmann.de>
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to
- * deal in the Software without restriction, including without limitation the
- * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
- * sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * UTF-8 decoder: http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
  */
 
 #include <stdint.h>

--- a/src/extern/utf8decoder.c
+++ b/src/extern/utf8decoder.c
@@ -1,0 +1,67 @@
+/*
+ * UTF-8 decoder copyright © 2008–2009 Björn Höhrmann <bjoern@hoehrmann.de>
+ * http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <stdint.h>
+
+static const uint8_t utf8d[] = {
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 00..0f */
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 10..1f */
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 20..2f */
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 30..3f */
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 40..4f */
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 50..5f */
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 60..6f */
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 70..7f */
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 80..8f */
+	9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, /* 90..9f */
+	7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, /* a0..af */
+	7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, /* b0..bf */
+	8, 8, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* c0..cf */
+	2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* d0..df */
+	0xa, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, /* e0..e7 */
+	0x3, 0x3, 0x3, 0x3, 0x3, 0x4, 0x3, 0x3, /* e8..ef */
+	0xb, 0x6, 0x6, 0x6, 0x5, 0x8, 0x8, 0x8, /* f0..f7 */
+	0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, /* f8..ff */
+	0x0, 0x1, 0x2, 0x3, 0x5, 0x8, 0x7, 0x1, /* s0..   */
+	0x1, 0x1, 0x4, 0x6, 0x1, 0x1, 0x1, 0x1, /*   ..s0 */
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* s1 */
+	1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, /* s1 */
+	1, 2, 1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 1, 1, 1, 1, /* s3 */
+	1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, /* s4 */
+	1, 2, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, /* s5 */
+	1, 1, 1, 1, 1, 1, 1, 3, 1, 3, 1, 1, 1, 1, 1, 1, /* s6 */
+	1, 3, 1, 1, 1, 1, 1, 3, 1, 3, 1, 1, 1, 1, 1, 1, /* s7 */
+	1, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* s8 */
+};
+
+uint32_t decode(uint32_t *state, uint32_t *codep, uint32_t byte)
+{
+	uint32_t type = utf8d[byte];
+
+	*codep = (*state != 0) ?
+			(byte & 0x3fu) | (*codep << 6) :
+			(0xff >> type) & (byte);
+
+	*state = utf8d[256 + *state * 16 + type];
+	return *state;
+}

--- a/src/extern/version.c
+++ b/src/extern/version.c
@@ -1,17 +1,9 @@
 /*
- * Copyright (C) 2017 Antonio Nino Diaz <antonio_nd@outlook.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 #include <stdio.h>

--- a/src/fix/main.c
+++ b/src/fix/main.c
@@ -1,17 +1,9 @@
 /*
- * Copyright © 2010 Anthony J. Bentley <anthonyjbentley@gmail.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2010-2018, Anthony J. Bentley and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 #include <stdbool.h>

--- a/src/fix/rgbfix.1
+++ b/src/fix/rgbfix.1
@@ -1,18 +1,11 @@
-.\" Copyright © 2010 Anthony J. Bentley <anthony@anjbe.name>
 .\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
+.\" This file is part of RGBDS.
 .\"
-.\" THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+.\" Copyright (c) 2010-2017, Anthony J. Bentley and RGBDS contributors.
 .\"
-.Dd April 17, 2017
+.\" SPDX-License-Identifier: MIT
+.\"
+.Dd January 26, 2018
 .Dt RGBFIX 1
 .Os RGBDS Manual
 .Sh NAME

--- a/src/gbz80.7
+++ b/src/gbz80.7
@@ -1,18 +1,11 @@
-.\" Copyright (c) 2017 Antonio Nino Diaz <antonio_nd@outlook.com>
 .\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
+.\" This file is part of RGBDS.
 .\"
-.\" THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+.\" Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
 .\"
-.Dd April 17, 2017
+.\" SPDX-License-Identifier: MIT
+.\"
+.Dd January 26, 2018
 .Dt GBZ80 7
 .Os RGBDS Manual
 .Sh NAME

--- a/src/gfx/gb.c
+++ b/src/gfx/gb.c
@@ -1,17 +1,9 @@
 /*
- * Copyright © 2013 stag019 <stag019@gmail.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2013-2018, stag019 and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 #include <stdio.h>

--- a/src/gfx/main.c
+++ b/src/gfx/main.c
@@ -1,17 +1,9 @@
 /*
- * Copyright © 2013 stag019 <stag019@gmail.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2013-2018, stag019 and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 #include <stdlib.h>

--- a/src/gfx/makepng.c
+++ b/src/gfx/makepng.c
@@ -1,17 +1,9 @@
 /*
- * Copyright © 2013 stag019 <stag019@gmail.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2013-2018, stag019 and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 #include <stdlib.h>

--- a/src/gfx/rgbgfx.1
+++ b/src/gfx/rgbgfx.1
@@ -1,18 +1,11 @@
-.\" Copyright © 2013 stag019 <stag019@gmail.com>
 .\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
+.\" This file is part of RGBDS.
 .\"
-.\" THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+.\" Copyright (c) 2013-2018, stag019 and RGBDS contributors.
 .\"
-.Dd April 17, 2017
+.\" SPDX-License-Identifier: MIT
+.\"
+.Dd January 26, 2018
 .Dt RGBGFX 1
 .Os RGBDS Manual
 .Sh NAME

--- a/src/link/assign.c
+++ b/src/link/assign.c
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/link/lexer.l
+++ b/src/link/lexer.l
@@ -1,17 +1,9 @@
 /*
- * Copyright (C) 2017 Antonio Nino Diaz <antonio_nd@outlook.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 %option noinput

--- a/src/link/library.c
+++ b/src/link/library.c
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/link/main.c
+++ b/src/link/main.c
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/link/mapfile.c
+++ b/src/link/mapfile.c
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/link/object.c
+++ b/src/link/object.c
@@ -1,4 +1,12 @@
 /*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
  * Here we have the routines that read an objectfile
  */
 

--- a/src/link/output.c
+++ b/src/link/output.c
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/link/parser.y
+++ b/src/link/parser.y
@@ -1,17 +1,9 @@
 /*
- * Copyright (C) 2017 Antonio Nino Diaz <antonio_nd@outlook.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 %{

--- a/src/link/patch.c
+++ b/src/link/patch.c
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/link/rgblink.1
+++ b/src/link/rgblink.1
@@ -1,18 +1,11 @@
-.\" Copyright © 2010 Anthony J. Bentley <anthony@anjbe.name>
 .\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
+.\" This file is part of RGBDS.
 .\"
-.\" THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+.\" Copyright (c) 2010-2018, Anthony J. Bentley and RGBDS contributors.
 .\"
-.Dd April 17, 2017
+.\" SPDX-License-Identifier: MIT
+.\"
+.Dd January 26, 2018
 .Dt RGBLINK 1
 .Os RGBDS Manual
 .Sh NAME

--- a/src/link/rgblink.5
+++ b/src/link/rgblink.5
@@ -1,18 +1,11 @@
-.\" Copyright (C) 2017 Antonio Nino Diaz <antonio_nd@outlook.com>
 .\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
+.\" This file is part of RGBDS.
 .\"
-.\" THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+.\" Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
 .\"
-.Dd April 17, 2017
+.\" SPDX-License-Identifier: MIT
+.\"
+.Dd January 26, 2018
 .Dt RGBLINK 5
 .Os RGBDS Manual
 .Sh NAME

--- a/src/link/script.c
+++ b/src/link/script.c
@@ -1,17 +1,9 @@
 /*
- * Copyright (C) 2017 Antonio Nino Diaz <antonio_nd@outlook.com>
+ * This file is part of RGBDS.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * SPDX-License-Identifier: MIT
  */
 
 #include <stdint.h>

--- a/src/link/symbol.c
+++ b/src/link/symbol.c
@@ -1,3 +1,11 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/rgbds.5
+++ b/src/rgbds.5
@@ -1,18 +1,11 @@
-.\" Copyright (c) 2017-2018 Antonio Nino Diaz <antonio_nd@outlook.com>
 .\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
+.\" This file is part of RGBDS.
 .\"
-.\" THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+.\" Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
 .\"
-.Dd January 7, 2018
+.\" SPDX-License-Identifier: MIT
+.\"
+.Dd January 26, 2018
 .Dt RGBDS 5
 .Os RGBDS Manual
 .Sh NAME

--- a/src/rgbds.7
+++ b/src/rgbds.7
@@ -1,18 +1,11 @@
-.\" Copyright © 2010 Anthony J. Bentley <anthony@anjbe.name>
 .\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
+.\" This file is part of RGBDS.
 .\"
-.\" THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+.\" Copyright (c) 2010-2018, Anthony J. Bentley and RGBDS contributors.
 .\"
-.Dd April 17, 2017
+.\" SPDX-License-Identifier: MIT
+.\"
+.Dd January 26, 2018
 .Dt RGBDS 7
 .Os RGBDS Manual
 .Sh NAME
@@ -48,4 +41,5 @@ implementation of rgbds.
 2017, Bentley's repository is moved to a neutral name.
 It is now maintained by a number of contributors at
 .Lk https://github.com/rednex/rgbds .
+2018, codebase relicensed under the MIT license.
 .El


### PR DESCRIPTION
The main contributors have agreed to relicense the code under the MIT license: https://github.com/rednex/rgbds/issues/128

Some other files are still licensed under the ISC and BSD licenses, but they are compatible with the MIT license.

For now, the fact that all the rest of the codebase is consistent is enough.

In order not to have too long headers, I've used SPDX identifiers: https://spdx.org and https://github.com/david-a-wheeler/spdx-tutorial/blob/master/README.md

I've also added a `CONTRIBUTORS.rst` file.

@csoren, @JustinLloyd, @vegard, @bentley, @stag019.