### PR TITLE
Add external projects to Travis CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,12 @@ language: c
 sudo: required
 install:
   - ./.travis-deps.sh
+  - make
+  - sudo make install
 os:
   - linux
 compiler:
   - clang
   - gcc
 script:
-  - make
-  - sudo make install
-after_success:
-  - pushd test/asm/ && ./test.sh && popd
-  - pushd test/link/ && ./test.sh && popd
+  - ./test/run-tests.sh

--- a/test/asm/bank-noexist.asm
+++ b/test/asm/bank-noexist.asm
@@ -1,2 +1,2 @@
 SECTION "sec", ROM0
-	db BANK(noexist) 
+	db BANK(noexist)

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Return failure as soon as a command fails to execute
+
+set -e
+
+cd test
+
+# Tests included with the repository
+
+pushd asm
+./test.sh
+popd
+
+pushd link
+./test.sh
+popd
+
+# Test some significant external projects that use RGBDS
+
+git clone https://github.com/pret/pokecrystal.git --depth=1
+pushd pokecrystal
+make -j
+make compare
+popd
+
+git clone --recursive https://github.com/pret/pokered.git --depth=1
+pushd pokered
+make -j
+make compare
+popd
+
+git clone https://github.com/AntonioND/ucity.git --depth=1
+pushd ucity
+make -j
+popd


### PR DESCRIPTION
Small tests like the ones included in this repository are good to test individual features, but it is also a good idea to test some real projects.

I've had to reorganize a bit how the Travis config works: https://docs.travis-ci.com/user/customizing-the-build/

Fixes https://github.com/rednex/rgbds/issues/197