### PR TITLE
Allow to continue lines

### DIFF
--- a/docs/gbz80.7.html
+++ b/docs/gbz80.7.html
@@ -34,8 +34,12 @@ Note: All arithmetic/logic operations that use register
   is assumed it's register <b class="Sy" title="Sy">A</b>. The following two
   lines have the same effect:
 <div class="Pp"></div>
-<div class="D1"><code class="Li">OR A,B</code></div>
-<div class="D1"><code class="Li">OR B</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+OR A,B 
+OR B
+</pre>
+</div>
 <h1 class="Sh" title="Sh" id="LEGEND"><a class="selflink" href="#LEGEND">LEGEND</a></h1>
 List of abbreviations used in this document.
 <dl class="Bl-tag">
@@ -1689,7 +1693,7 @@ Flags: See <a class="Sx" title="Sx" href="#XOR_A,r8">XOR A,r8</a>
   <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">January 26, 2018</td>
+    <td class="foot-date">February 23, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/docs/rgbasm.1.html
+++ b/docs/rgbasm.1.html
@@ -27,7 +27,7 @@
 <table class="Nm">
   <tr>
     <td><b class="Nm" title="Nm">rgbasm</b></td>
-    <td>[<span class="Op"><b class="Fl" title="Fl">-EhVvw</b></span>]
+    <td>[<span class="Op"><b class="Fl" title="Fl">-EhLVvw</b></span>]
       [<span class="Op"><b class="Fl" title="Fl">-b</b>
       <var class="Ar" title="Ar">chars</var></span>]
       [<span class="Op"><b class="Fl" title="Fl">-D</b>
@@ -89,6 +89,13 @@ The <b class="Nm" title="Nm">rgbasm</b> program creates an object file from an
   <dd class="It-tag">Add an include path.</dd>
   <dt class="It-tag">&#x00A0;</dt>
   <dd class="It-tag">&#x00A0;</dd>
+  <dt class="It-tag"><a class="selflink" href="#L"><b class="Fl" title="Fl" id="L">-L</b></a></dt>
+  <dd class="It-tag">Disable the optimization that turns loads of the form
+      <b class="Sy" title="Sy">LD [$FF00+n8],A</b> into the opcode
+      <b class="Sy" title="Sy">LDH [$FF00+n8],A</b> in order to have full
+      control of the result in the final ROM.</dd>
+  <dt class="It-tag">&#x00A0;</dt>
+  <dd class="It-tag">&#x00A0;</dd>
   <dt class="It-tag"><a class="selflink" href="#M"><b class="Fl" title="Fl" id="M">-M</b></a>
     <var class="Ar" title="Ar">dependfile</var></dt>
   <dd class="It-tag">Print <a class="Xr" title="Xr">make(1)</a> dependencies to
@@ -120,7 +127,11 @@ The <b class="Nm" title="Nm">rgbasm</b> program creates an object file from an
 <h1 class="Sh" title="Sh" id="EXAMPLES"><a class="selflink" href="#EXAMPLES">EXAMPLES</a></h1>
 Assembling a basic source file is simple:
 <div class="Pp"></div>
-<div class="D1">$ rgbasm -o bar.o foo.asm</div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+$ rgbasm -o bar.o foo.asm
+</pre>
+</div>
 <div class="Pp"></div>
 The resulting object file is not yet a usable ROM image &#x2014; it must first
   be run through <a class="Xr" title="Xr">rgblink(1)</a> and
@@ -138,7 +149,7 @@ The resulting object file is not yet a usable ROM image &#x2014; it must first
   <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">January 26, 2018</td>
+    <td class="foot-date">February 24, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/docs/rgbasm.5.html
+++ b/docs/rgbasm.5.html
@@ -38,7 +38,11 @@ The syntax is line&#x2010;based, just as in any other assembler, meaning that
 <div class="Pp"></div>
 Example:
 <div class="Pp"></div>
-<div class="D1"><code class="Li">John: ld a,87 ;Weee</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+John: ld a,87 ;Weee
+</pre>
+</div>
 <div class="Pp"></div>
 All pseudo&#x2010;ops, mnemonics and registers (reserved keywords) are
   case&#x2010;insensitive and all labels are case&#x2010;sensitive.
@@ -47,13 +51,40 @@ There are two syntaxes for comments. In both cases, a comment ends at the end of
   the line. The most common one is: anything that follows a semicolon
   &quot;;&quot; (that isn't inside a string) is a comment. There is another
   format: anything that follows a &quot;*&quot; that is placed right at the
-  start of a line is a comment.
+  start of a line is a comment. The assembler removes all comments from the code
+  before doing anything else.
+<div class="Pp"></div>
+Sometimes lines can be too long and it may be necessary to split them. The
+  syntax to do so is the following one:
+<div class="Pp"></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+    DB 1, 2, 3, 4 \ 
+       5, 6, 7, 8
+</pre>
+</div>
+<div class="Pp"></div>
+This works anywhere in the code except inside of strings. To split strings it is
+  needed to use
+<div>&#x00A0;</div>
+like this:
+<div class="Pp"></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+    DB STRCAT(&quot;Hello &quot;, \ 
+              &quot;world!&quot;)
+</pre>
+</div>
 <h2 class="Ss" title="Ss" id="Sections"><a class="selflink" href="#Sections">Sections</a></h2>
 Before you can start writing code, you must define a section. This tells the
   assembler what kind of information follows and, if it is code, where to put
   it.
 <div class="Pp"></div>
-<div class="D1"><code class="Li">SECTION &quot;CoolStuff&quot;,ROMX</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+    SECTION &quot;CoolStuff&quot;,ROMX
+</pre>
+</div>
 <div class="Pp"></div>
 This switches to the section called &quot;CoolStuff&quot; (or creates it if it
   doesn't already exist) and it defines it as a code section. All sections
@@ -139,25 +170,38 @@ If a section is defined with no indications, it is a floating section. The
   obligation to follow any specific rules. The following example defines a
   section that can be placed anywhere in any ROMX bank:
 <div class="Pp"></div>
-<div class="D1"><code class="Li">SECTION &quot;CoolStuff&quot;,ROMX</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+    SECTION &quot;CoolStuff&quot;,ROMX
+</pre>
+</div>
 <div class="Pp"></div>
 If it is needed, the following syntax can be used to fix the base address of the
   section:
 <div class="Pp"></div>
-<div class="D1"><code class="Li">SECTION
-  &quot;CoolStuff&quot;,ROMX[$4567]</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+    SECTION &quot;CoolStuff&quot;,ROMX[$4567]
+</pre>
+</div>
 <div class="Pp"></div>
 It won't, however, fix the bank number, which is left to the linker. If you also
   want to specify the bank you can do:
 <div class="Pp"></div>
-<div class="D1"><code class="Li">SECTION
-  &quot;CoolStuff&quot;,ROMX[$4567],BANK[3]</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+    SECTION &quot;CoolStuff&quot;,ROMX[$4567],BANK[3]
+</pre>
+</div>
 <div class="Pp"></div>
 And if you only want to force the section into a certain bank, and not it's
   position within the bank, that's also possible:
 <div class="Pp"></div>
-<div class="D1"><code class="Li">SECTION
-  &quot;CoolStuff&quot;,ROMX,BANK[7]</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+    SECTION &quot;CoolStuff&quot;,ROMX,BANK[7]
+</pre>
+</div>
 <div class="Pp"></div>
 In addition, you can specify byte alignment for a section. This ensures that the
   section starts at a memory address where the given number of least-significant
@@ -167,11 +211,13 @@ In addition, you can specify byte alignment for a section. This ensures that the
   needed to align the start of an array to 256 bytes to optimize the code that
   accesses it.
 <div class="Pp"></div>
-<div class="D1"><code class="Li">SECTION &quot;OAM Data&quot;,WRAM0,ALIGN[8];
-  align to 256 bytes</code></div>
-<div class="Pp"></div>
-<div class="D1"><code class="Li">SECTION &quot;VRAM
-  Data&quot;,ROMX,BANK[2],ALIGN[4]; align to 16 bytes</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+    SECTION &quot;OAM Data&quot;,WRAM0,ALIGN[8] ; align to 256 bytes 
+ 
+    SECTION &quot;VRAM Data&quot;,ROMX,BANK[2],ALIGN[4] ; align to 16 bytes
+</pre>
+</div>
 <div class="Pp"></div>
 HINT: If you think this is a lot of typing for doing a simple
   <b class="Ic" title="Ic">ORG</b> type thing you can quite easily write an
@@ -260,8 +306,12 @@ ThisWillBeExported.too::
     EQUates are constant symbols. They can, for example, be used for things such
       as bit-definitions of hardware registers.
     <div class="Pp"></div>
-    <div class="D1"><code class="Li">EXIT_OK EQU $00</code></div>
-    <div class="D1"><code class="Li">EXIT_FAILURE EQU $01</code></div>
+    <div class="Bd" style="margin-left: 5.00ex;">
+    <pre class="Li">
+EXIT_OK      EQU $00 
+EXIT_FAILURE EQU $01
+    </pre>
+    </div>
     <div class="Pp"></div>
     Note that a colon (:) following the label-name is not allowed. EQUates
       cannot be exported and imported. They don't change their value during the
@@ -285,7 +335,11 @@ COUNT      SET ARRAY_SIZE+COUNT
       be exported and imported. Alternatively you can use = as a synonym for
       SET.
     <div class="Pp"></div>
-    <div class="D1"><code class="Li">COUNT = 2</code></div>
+    <div class="Bd" style="margin-left: 5.00ex;">
+    <pre class="Li">
+COUNT = 2
+    </pre>
+    </div>
   </dd>
   <dt class="It-hang"><b class="Sy" title="Sy">RSSET</b>,
     <b class="Sy" title="Sy">RSRESET</b>, <b class="Sy" title="Sy">RB</b>,
@@ -378,10 +432,10 @@ str_SIZEOF = 259
     <div class="Bd" style="margin-left: 5.00ex;">
     <pre class="Li">
 COUNTREG EQUS &quot;[hl+]&quot; 
-ld a,COUNTREG 
+    ld a,COUNTREG 
  
 PLAYER_NAME EQUS &quot;\&quot;John\&quot;&quot; 
-db PLAYER_NAME
+    db PLAYER_NAME
     </pre>
     </div>
     <div class="Pp"></div>
@@ -390,13 +444,20 @@ db PLAYER_NAME
     <div class="Pp"></div>
     This will be interpreted as:
     <div class="Pp"></div>
-    <div class="D1"><code class="Li">ld a,[hl+]</code></div>
-    <div class="D1"><code class="Li">db &quot;John&quot;</code></div>
+    <div class="Bd" style="margin-left: 5.00ex;">
+    <pre class="Li">
+    ld a,[hl+] 
+    db &quot;John&quot;
+    </pre>
+    </div>
     <div class="Pp"></div>
     String-symbols can also be used to define small one-line macros:
     <div class="Pp"></div>
-    <div class="D1"><code class="Li">PUSHA EQUS &quot;push af\npush bc\npush
-      de\npush hl\n&quot;</code></div>
+    <div class="Bd" style="margin-left: 5.00ex;">
+    <pre class="Li">
+PUSHA EQUS &quot;push af\npush bc\npush de\npush hl\n&quot;
+    </pre>
+    </div>
     <div class="Pp"></div>
     Note that a colon (:) following the label-name is not allowed. String
       equates can't be exported or imported.
@@ -510,7 +571,11 @@ LoopyMacro: MACRO
       address and the second being a bytecount. The macro will then reset all
       bytes in this range.
     <div class="Pp"></div>
-    <div class="D1"><code class="Li">LoopyMacro MyVars,54</code></div>
+    <div class="Bd" style="margin-left: 5.00ex;">
+    <pre class="Li">
+LoopyMacro MyVars,54
+    </pre>
+    </div>
     <div class="Pp"></div>
     Arguments are passed as string equates. There's no need to enclose them in
       quotes. An expression will not be evaluated first but passed directly.
@@ -524,6 +589,21 @@ LoopyMacro: MACRO
     In reality, up to 256 arguments can be passed to a macro, but you can only
       use the first 9 like this. If you want to use the rest, you need to use
       the keyword <b class="Ic" title="Ic">SHIFT</b>.
+    <div class="Pp"></div>
+    Line continuations work as usual inside macros or lists of arguments of
+      macros. Strings, however, are a bit trickier. The following example shows
+      how to use strings as arguments for a macro:
+    <div class="Pp"></div>
+    <div class="Bd" style="margin-left: 5.00ex;">
+    <pre class="Li">
+PrintMacro : MACRO 
+    PRINTT \1 
+ENDM 
+ 
+    PrintMacro STRCAT(\&quot;Hello\&quot;\,  \ 
+                      \&quot; world\\n\&quot;)
+    </pre>
+    </div>
     <div class="Pp"></div>
     <b class="Ic" title="Ic">SHIFT</b> is a special command only available in
       macros. Very useful in REPT-blocks. It will &quot;shift&quot; the
@@ -710,8 +790,11 @@ The following symbols are defined by the assembler:
 <b class="Ic" title="Ic">DB</b> defines a list of bytes that will be stored in
   the final image. Ideal for tables and text (which is not zero-terminated).
 <div class="Pp"></div>
-<div class="D1"><code class="Li">DB 1,2,3,4,&quot;This is a
-  string&quot;</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+DB 1,2,3,4,&quot;This is a string&quot;
+</pre>
+</div>
 <div class="Pp"></div>
 Alternatively, you can use <b class="Ic" title="Ic">DW</b> to store a list of
   words (16-bits) or <b class="Ic" title="Ic">DL</b> to store a list of
@@ -738,8 +821,11 @@ You can also use <b class="Ic" title="Ic">DB</b>,
   <b class="Ic" title="Ic">DW</b> and <b class="Ic" title="Ic">DL</b> without
   any arguments instead.
 <div class="Pp"></div>
-<div class="D1"><code class="Li">DS str_SIZEOF ;allocate str_SIZEOF
-  bytes</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+DS str_SIZEOF ;allocate str_SIZEOF bytes
+</pre>
+</div>
 <h2 class="Ss" title="Ss" id="Including_binary_files"><a class="selflink" href="#Including_binary_files">Including
   binary files</a></h2>
 You probably have some graphics you'd like to include. Use
@@ -747,17 +833,23 @@ You probably have some graphics you'd like to include. Use
   the file isn't found in the current directory, the include-path list passed to
   the linker on the command line will be searched.
 <div class="Pp"></div>
-<div class="D1"><code class="Li">INCBIN &quot;titlepic.bin&quot;</code></div>
-<div class="D1"><code class="Li">INCBIN &quot;sprites/hero.bin&quot;&#x00A0;;
-  UNIX</code></div>
-<div class="D1"><code class="Li">INCBIN &quot;sprites\\hero.bin&quot;&#x00A0;;
-  Windows</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+INCBIN &quot;titlepic.bin&quot; 
+INCBIN &quot;sprites/hero.bin&quot;&#x00A0;; UNIX 
+INCBIN &quot;sprites\\hero.bin&quot;&#x00A0;; Windows
+</pre>
+</div>
 <div class="Pp"></div>
 You can also include only part of a file with
   <b class="Ic" title="Ic">INCBIN</b>. The example below includes 256 bytes from
   data.bin starting from byte 78.
 <div class="Pp"></div>
-<div class="D1"><code class="Li">INCBIN &quot;data.bin&quot;,78,256</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+INCBIN &quot;data.bin&quot;,78,256
+</pre>
+</div>
 <h2 class="Ss" title="Ss" id="Unions"><a class="selflink" href="#Unions">Unions</a></h2>
 Unions allow multiple memory allocations to share the same space in memory, like
   unions in C. This allows you to easily reuse memory for different purposes,
@@ -872,7 +964,11 @@ Use <b class="Ic" title="Ic">INCLUDE</b> to process another assembler-file and
   <b class="Ic" title="Ic">INCLUDE</b> calls infinitely (or until you run out of
   memory, whichever comes first).
 <div class="Pp"></div>
-<div class="D1"><code class="Li">INCLUDE &quot;irq.inc&quot;</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+    INCLUDE &quot;irq.inc&quot;
+</pre>
+</div>
 <h2 class="Ss" title="Ss" id="Conditional_assembling"><a class="selflink" href="#Conditional_assembling">Conditional
   assembling</a></h2>
 The four commands <b class="Ic" title="Ic">IF</b>,
@@ -929,7 +1025,11 @@ The last one, Gameboy graphics, is quite interesting and useful. The values are
   actually pixel values and it converts the &#x201C;chunky&#x201D; data to
   &#x201C;planar&#x201D; data as used in the Gameboy.
 <div class="Pp"></div>
-<div class="D1"><code class="Li">DW `01012323</code></div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+    DW `01012323
+</pre>
+</div>
 <div class="Pp"></div>
 Admittedly, an expression with just a single number is quite boring. To spice
   things up a bit there are a few operators you can use to perform calculations
@@ -1465,7 +1565,7 @@ The options that OPT can modify are currently: <b class="Sy" title="Sy">b</b>,
   <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">February 24, 2018</td>
+    <td class="foot-date">February 26, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/docs/rgbasm.5.html
+++ b/docs/rgbasm.5.html
@@ -125,7 +125,10 @@ Possible section types are as follows:
       <b class="Sy" title="Sy">LDH [$FF00+n8],A</b> and
       <b class="Sy" title="Sy">LDH A,[$FF00+n8]</b> syntax instead. This forces
       the assembler to emit the correct instruction and the linker to check if
-      the value is in the correct range.</dd>
+      the value is in the correct range. This optimization can be disabled by
+      passing the <b class="Fl" title="Fl">-L</b> flag to
+      <b class="Sy" title="Sy">rgbasm</b> as explained in
+      <a class="Xr" title="Xr">rgbasm(1)</a>.</dd>
 </dl>
 <div class="Pp"></div>
 A section is usually defined as a floating one, but the code can restrict where
@@ -1462,7 +1465,7 @@ The options that OPT can modify are currently: <b class="Sy" title="Sy">b</b>,
   <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
 <table class="foot">
   <tr>
-    <td class="foot-date">January 27, 2018</td>
+    <td class="foot-date">February 24, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/docs/rgbds.7.html
+++ b/docs/rgbds.7.html
@@ -26,9 +26,13 @@
 <h1 class="Sh" title="Sh" id="EXAMPLES"><a class="selflink" href="#EXAMPLES">EXAMPLES</a></h1>
 To get a working ROM image from a single assembly source file:
 <div class="Pp"></div>
-<div class="D1">$ rgbasm -o bar.o foo.asm</div>
-<div class="D1">$ rgblink -o baz.gb bar.o</div>
-<div class="D1">$ rgbfix -v -p 0 baz.gb</div>
+<div class="Bd" style="margin-left: 5.00ex;">
+<pre class="Li">
+$ rgbasm -o bar.o foo.asm 
+$ rgblink -o baz.gb bar.o 
+$ rgbfix -v -p 0 baz.gb
+</pre>
+</div>
 <h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="selflink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <a class="Xr" title="Xr">rgbasm(1)</a>, <a class="Xr" title="Xr">rgbfix(1)</a>,
@@ -58,7 +62,7 @@ To get a working ROM image from a single assembly source file:
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">January 26, 2018</td>
+    <td class="foot-date">February 24, 2018</td>
     <td class="foot-os">RGBDS Manual</td>
   </tr>
 </table>

--- a/include/asm/main.h
+++ b/include/asm/main.h
@@ -15,12 +15,13 @@
 #include "extern/stdnoreturn.h"
 
 struct sOptions {
-	char gbgfx[4];
 	char binary[2];
-	int32_t fillchar;
-	bool verbose;
-	bool haltnop;
+	char gbgfx[4];
 	bool exportall;
+	int32_t fillchar;
+	bool haltnop;
+	bool optimizeloads;
+	bool verbose;
 	bool warnings; /* True to enable warnings, false to disable them. */
 };
 

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1728,7 +1728,8 @@ z80_ld_mem	: T_Z80_LD op_mem_ind comma T_MODE_SP
 		}
 		| T_Z80_LD op_mem_ind comma T_MODE_A
 		{
-			if ((!rpn_isReloc(&$2)) && ($2.nVal >= 0xFF00)) {
+			if (CurrentOptions.optimizeloads &&
+			    (!rpn_isReloc(&$2)) && ($2.nVal >= 0xFF00)) {
 				out_AbsByte(0xE0);
 				out_AbsByte($2.nVal & 0xFF);
 			} else {
@@ -1781,7 +1782,8 @@ z80_ld_a	: T_Z80_LD reg_r comma T_MODE_C_IND
 		| T_Z80_LD reg_r comma op_mem_ind
 		{
 			if ($2 == REG_A) {
-				if ((!rpn_isReloc(&$4)) && ($4.nVal >= 0xFF00)) {
+				if (CurrentOptions.optimizeloads &&
+				    (!rpn_isReloc(&$4)) && ($4.nVal >= 0xFF00)) {
 					out_AbsByte(0xF0);
 					out_AbsByte($4.nVal & 0xFF);
 				} else {

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -763,6 +763,9 @@ static uint32_t yylex_MACROARGS(void)
 			case '\\':
 				ch = '\\';
 				break;
+			case '"':
+				ch = '\"';
+				break;
 			case ',':
 				ch = ',';
 				break;

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -775,6 +775,32 @@ static uint32_t yylex_MACROARGS(void)
 			case '}':
 				ch = '}';
 				break;
+			case ' ':
+				/*
+				 * Look for line continuation character after a
+				 * series of spaces. This is also useful for
+				 * files that use Windows line endings: "\r\n"
+				 * is replaced by " \n" before the lexer has the
+				 * opportunity to see it.
+				 */
+				while (1) {
+					if (*pLexBuffer == ' ') {
+						pLexBuffer++;
+					} else if (*pLexBuffer == '\n') {
+						pLexBuffer++;
+						nLineNo += 1;
+						ch = 0;
+						break;
+					} else {
+						errx(1, "Expected a new line after the continuation character.");
+					}
+				}
+				break;
+			case '\n':
+				/* Line continuation character */
+				nLineNo += 1;
+				ch = 0;
+				break;
 			default:
 				maxLength = MAXSTRLEN - index;
 				length = CopyMacroArg(&yylval.tzString[index],

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -638,6 +638,44 @@ scanagain:
 		}
 	}
 
+	/* Check for line continuation character */
+	if (*pLexBuffer == '\\') {
+
+		/*
+		 * Look for line continuation character after a series of
+		 * spaces. This is also useful for files that use Windows line
+		 * endings: "\r\n" is replaced by " \n" before the lexer has the
+		 * opportunity to see it.
+		 */
+		if (pLexBuffer[1] == ' ') {
+			pLexBuffer += 2;
+			while (1) {
+				if (*pLexBuffer == ' ') {
+					pLexBuffer++;
+				} else if (*pLexBuffer == '\n') {
+					pLexBuffer++;
+					nLineNo += 1;
+					goto scanagain;
+				} else {
+					errx(1, "Expected a new line after the continuation character.");
+				}
+			}
+		}
+
+		/* Line continuation character */
+		if (pLexBuffer[1] == '\n') {
+			pLexBuffer += 2;
+			nLineNo += 1;
+			goto scanagain;
+		}
+
+		/*
+		 * If there isn't a newline character or a space, ignore the
+		 * character '\'. It will eventually be handled by other
+		 * functions like PutMacroArg().
+		 */
+	}
+
 	/*
 	 * Try to match an identifier, macro argument (e.g. \1),
 	 * or numeric literal.

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -282,7 +282,7 @@ void warning(const char *fmt, ...)
 static void print_usage(void)
 {
 	printf(
-"usage: rgbasm [-EhVvw] [-b chars] [-Dname[=value]] [-g chars] [-i path]\n"
+"usage: rgbasm [-EhLVvw] [-b chars] [-Dname[=value]] [-g chars] [-i path]\n"
 "              [-M dependfile] [-o outfile] [-p pad_value] file.asm\n");
 	exit(1);
 }
@@ -316,17 +316,18 @@ int main(int argc, char *argv[])
 	DefaultOptions.gbgfx[3] = '3';
 	DefaultOptions.binary[0] = '0';
 	DefaultOptions.binary[1] = '1';
-	DefaultOptions.fillchar = 0;
-	DefaultOptions.verbose = false;
-	DefaultOptions.haltnop = true;
 	DefaultOptions.exportall = false;
+	DefaultOptions.fillchar = 0;
+	DefaultOptions.optimizeloads = true;
+	DefaultOptions.haltnop = true;
+	DefaultOptions.verbose = false;
 	DefaultOptions.warnings = true;
 
 	opt_SetCurrentOptions(&DefaultOptions);
 
 	newopt = CurrentOptions;
 
-	while ((ch = getopt(argc, argv, "b:D:g:hi:M:o:p:EVvw")) != -1) {
+	while ((ch = getopt(argc, argv, "b:D:Eg:hi:LM:o:p:Vvw")) != -1) {
 		switch (ch) {
 		case 'b':
 			if (strlen(optarg) == 2) {
@@ -357,6 +358,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'i':
 			fstk_AddIncludePath(optarg);
+			break;
+		case 'L':
+			newopt.optimizeloads = false;
 			break;
 		case 'M':
 			dependfile = fopen(optarg, "w");

--- a/src/asm/rgbasm.1
+++ b/src/asm/rgbasm.1
@@ -5,7 +5,7 @@
 .\"
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd January 26, 2018
+.Dd February 24, 2018
 .Dt RGBASM 1
 .Os RGBDS Manual
 .Sh NAME
@@ -13,7 +13,7 @@
 .Nd Game Boy assembler
 .Sh SYNOPSIS
 .Nm rgbasm
-.Op Fl EhVvw
+.Op Fl EhLVvw
 .Op Fl b Ar chars
 .Op Fl D Ar name Ns Op = Ns Ar value
 .Op Fl g Ar chars
@@ -55,6 +55,12 @@ The
 option disables this behavior.
 .It Fl i Ar path
 Add an include path.
+.It Fl L
+Disable the optimization that turns loads of the form
+.Sy LD [$FF00+n8],A
+into the opcode
+.Sy LDH [$FF00+n8],A
+in order to have full control of the result in the final ROM.
 .It Fl M Ar dependfile
 Print
 .Xr make 1
@@ -75,7 +81,9 @@ Disable warning output.
 .Sh EXAMPLES
 Assembling a basic source file is simple:
 .Pp
-.D1 $ rgbasm -o bar.o foo.asm
+.Bd -literal -offset indent
+$ rgbasm -o bar.o foo.asm
+.Ed
 .Pp
 The resulting object file is not yet a usable ROM image \(em it must first be
 run through

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -37,7 +37,27 @@ There are two syntaxes for comments. In both cases, a comment ends at the end of
 the line. The most common one is: anything that follows a semicolon
 \[dq]\&;\[dq] (that isn't inside a string) is a comment. There is another
 format: anything that follows a \[dq]*\[dq] that is placed right at the start of
-a line is a comment.
+a line is a comment. The assembler removes all comments from the code before
+doing anything else.
+.Pp
+Sometimes lines can be too long and it may be necessary to split them. The
+syntax to do so is the following one:
+.Pp
+.Bd -literal -offset indent
+    DB 1, 2, 3, 4 \[rs]
+       5, 6, 7, 8
+.Ed
+.Pp
+This works anywhere in the code except inside of strings. To split strings it is
+needed to use
+.It STRCAT
+like this:
+.Pp
+.Bd -literal -offset indent
+    DB STRCAT("Hello ", \[rs]
+              "world!")
+.Ed
+.Pp
 .Ss Sections
 Before you can start writing code, you must define a section.
 This tells the assembler what kind of information follows and, if it is code,
@@ -502,6 +522,19 @@ you will get the value 5 on screen and not 6 as you might have expected.
 In reality, up to 256 arguments can be passed to a macro, but you can only use
 the first 9 like this. If you want to use the rest, you need to use the keyword
 .Ic SHIFT .
+.Pp
+Line continuations work as usual inside macros or lists of arguments of macros.
+Strings, however, are a bit trickier. The following example shows how to use
+strings as arguments for a macro:
+.Pp
+.Bd -literal -offset indent
+PrintMacro : MACRO
+    PRINTT \[rs]1
+ENDM
+
+    PrintMacro STRCAT(\[rs]\[dq]Hello\[rs]\[dq]\[rs],  \[rs]
+                      \[rs]\[dq] world\[rs]\[rs]n\[rs]\[dq])
+.Ed
 .Pp
 .Ic SHIFT
 is a special command only available in macros.

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -5,7 +5,7 @@
 .\"
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd January 27, 2018
+.Dd February 24, 2018
 .Dt RGBASM 5
 .Os RGBDS Manual
 .Sh NAME
@@ -110,7 +110,13 @@ and
 .Sy LDH A,[$FF00+n8]
 syntax instead.
 This forces the assembler to emit the correct instruction and the linker to
-check if the value is in the correct range.
+check if the value is in the correct range. This optimization can be disabled
+by passing the
+.Fl L
+flag to
+.Sy rgbasm
+as explained in
+.Xr rgbasm 1 .
 .El
 .Pp
 A section is usually defined as a floating one, but the code can restrict where

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -5,7 +5,7 @@
 .\"
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd February 24, 2018
+.Dd February 26, 2018
 .Dt RGBASM 5
 .Os RGBDS Manual
 .Sh NAME
@@ -26,7 +26,9 @@ one instruction or pseudo‐op per line:
 .Pp
 Example:
 .Pp
-.Dl John: ld a,87 ;Weee
+.Bd -literal -offset indent
+John: ld a,87 ;Weee
+.Ed
 .Pp
 All pseudo‐ops, mnemonics and registers (reserved keywords) are case‐insensitive
 and all labels are case‐sensitive.
@@ -41,7 +43,9 @@ Before you can start writing code, you must define a section.
 This tells the assembler what kind of information follows and, if it is code,
 where to put it.
 .Pp
-.Dl SECTION \[dq]CoolStuff\[dq],ROMX
+.Bd -literal -offset indent
+    SECTION \[dq]CoolStuff\[dq],ROMX
+.Ed
 .Pp
 This switches to the section called "CoolStuff" (or creates it if it doesn't
 already exist) and it defines it as a code section.
@@ -128,22 +132,30 @@ obligation to follow any specific rules.
 The following example defines a section that can be placed anywhere in any ROMX
 bank:
 .Pp
-.Dl SECTION \[dq]CoolStuff\[dq],ROMX
+.Bd -literal -offset indent
+    SECTION \[dq]CoolStuff\[dq],ROMX
+.Ed
 .Pp
 If it is needed, the following syntax can be used to fix the base address of the
 section:
 .Pp
-.Dl SECTION \[dq]CoolStuff\[dq],ROMX[$4567]
+.Bd -literal -offset indent
+    SECTION \[dq]CoolStuff\[dq],ROMX[$4567]
+.Ed
 .Pp
 It won't, however, fix the bank number, which is left to the linker.
 If you also want to specify the bank you can do:
 .Pp
-.Dl SECTION \[dq]CoolStuff\[dq],ROMX[$4567],BANK[3]
+.Bd -literal -offset indent
+    SECTION \[dq]CoolStuff\[dq],ROMX[$4567],BANK[3]
+.Ed
 .Pp
 And if you only want to force the section into a certain bank, and not it's
 position within the bank, that's also possible:
 .Pp
-.Dl SECTION \[dq]CoolStuff\[dq],ROMX,BANK[7]
+.Bd -literal -offset indent
+    SECTION \[dq]CoolStuff\[dq],ROMX,BANK[7]
+.Ed
 .Pp
 In addition, you can specify byte alignment for a section.
 This ensures that the section starts at a memory address where the given number
@@ -155,9 +167,11 @@ However, if an alignment is specified, the base address must be left unassigned.
 This can be useful when using DMA to copy data or when it is needed to align the
 start of an array to 256 bytes to optimize the code that accesses it.
 .Pp
-.Dl SECTION \[dq]OAM Data\[dq],WRAM0,ALIGN[8] ; align to 256 bytes
-.Pp
-.Dl SECTION \[dq]VRAM Data\[dq],ROMX,BANK[2],ALIGN[4] ; align to 16 bytes
+.Bd -literal -offset indent
+    SECTION \[dq]OAM Data\[dq],WRAM0,ALIGN[8] ; align to 256 bytes
+
+    SECTION \[dq]VRAM Data\[dq],ROMX,BANK[2],ALIGN[4] ; align to 16 bytes
+.Ed
 .Pp
 HINT: If you think this is a lot of typing for doing a simple
 .Ic ORG
@@ -255,8 +269,10 @@ EQUates are constant symbols.
 They can, for example, be used for things such as bit-definitions of hardware
 registers.
 .Pp
-.Dl EXIT_OK      EQU $00
-.Dl EXIT_FAILURE EQU $01
+.Bd -literal -offset indent
+EXIT_OK      EQU $00
+EXIT_FAILURE EQU $01
+.Ed
 .Pp
 Note that a colon (:) following the label-name is not allowed.
 EQUates cannot be exported and imported.
@@ -278,7 +294,9 @@ Note that a colon (:) following the label-name is not allowed.
 SETs cannot be exported and imported.
 Alternatively you can use = as a synonym for SET.
 .Pp
-.Dl COUNT = 2
+.Bd -literal -offset indent
+COUNT = 2
+.Ed
 .Pp
 .It Sy RSSET , RSRESET , RB , RW
 .Pp
@@ -330,10 +348,10 @@ If you are familiar with C you can think of it as the same as #define.
 .Pp
 .Bd -literal -offset indent
 COUNTREG EQUS "[hl+]"
-ld a,COUNTREG
+    ld a,COUNTREG
 
 PLAYER_NAME EQUS \[dq]\[rs]\[dq]John\[rs]\[dq]\[dq]
-db PLAYER_NAME
+    db PLAYER_NAME
 .Ed
 .Pp
 Note that : following the label-name is not allowed, and that strings must be
@@ -341,12 +359,16 @@ quoted to be useful.
 .Pp
 This will be interpreted as:
 .Pp
-.Dl ld a,[hl+]
-.Dl db \[dq]John\[dq]
+.Bd -literal -offset indent
+    ld a,[hl+]
+    db \[dq]John\[dq]
+.Ed
 .Pp
 String-symbols can also be used to define small one-line macros:
 .Pp
-.Dl PUSHA EQUS \[dq]push af\[rs]npush bc\[rs]npush de\[rs]npush hl\[rs]n\[dq]
+.Bd -literal -offset indent
+PUSHA EQUS \[dq]push af\[rs]npush bc\[rs]npush de\[rs]npush hl\[rs]n\[dq]
+.Ed
 .Pp
 Note that a colon (:) following the label-name is not allowed.
 String equates can't be exported or imported.
@@ -459,7 +481,9 @@ Now I can call the macro specifying two arguments.
 The first being the address and the second being a bytecount.
 The macro will then reset all bytes in this range.
 .Pp
-.Dl LoopyMacro MyVars,54
+.Bd -literal -offset indent
+LoopyMacro MyVars,54
+.Ed
 .Pp
 Arguments are passed as string equates.
 There's no need to enclose them in quotes.
@@ -565,7 +589,9 @@ The following symbols are defined by the assembler:
 defines a list of bytes that will be stored in the final image.
 Ideal for tables and text (which is not zero-terminated).
 .Pp
-.Dl DB 1,2,3,4,\[dq]This is a string\[dq]
+.Bd -literal -offset indent
+DB 1,2,3,4,\[dq]This is a string\[dq]
+.Ed
 .Pp
 Alternatively, you can use
 .Ic DW
@@ -609,7 +635,9 @@ and
 .Ic DL
 without any arguments instead.
 .Pp
-.Dl DS str_SIZEOF ;allocate str_SIZEOF bytes
+.Bd -literal -offset indent
+DS str_SIZEOF ;allocate str_SIZEOF bytes
+.Ed
 .Pp
 .Ss Including binary files
 You probably have some graphics you'd like to include.
@@ -619,15 +647,19 @@ to include a raw binary file as it is.
 If the file isn't found in the current directory, the include-path list passed
 to the linker on the command line will be searched.
 .Pp
-.Dl INCBIN \[dq]titlepic.bin\[dq]
-.Dl INCBIN \[dq]sprites/hero.bin\[dq]\ ; UNIX
-.Dl INCBIN \[dq]sprites\[rs]\[rs]hero.bin\[dq]\ ; Windows
+.Bd -literal -offset indent
+INCBIN \[dq]titlepic.bin\[dq]
+INCBIN \[dq]sprites/hero.bin\[dq]\ ; UNIX
+INCBIN \[dq]sprites\[rs]\[rs]hero.bin\[dq]\ ; Windows
+.Ed
 .Pp
 You can also include only part of a file with
 .Ic INCBIN .
 The example below includes 256 bytes from data.bin starting from byte 78.
 .Pp
-.Dl INCBIN \[dq]data.bin\[dq],78,256
+.Bd -literal -offset indent
+INCBIN \[dq]data.bin\[dq],78,256
+.Ed
 .Ss Unions
 Unions allow multiple memory allocations to share the same space in memory,
 like unions in C.
@@ -755,7 +787,9 @@ You may nest
 .Ic INCLUDE
 calls infinitely (or until you run out of memory, whichever comes first).
 .Pp
-.Dl INCLUDE \[dq]irq.inc\[dq]
+.Bd -literal -offset indent
+    INCLUDE \[dq]irq.inc\[dq]
+.Ed
 .Pp
 .Ss Conditional assembling
 The four commands
@@ -831,7 +865,9 @@ The last one, Gameboy graphics, is quite interesting and useful.
 The values are actually pixel values and it converts the
 .Do chunky Dc data to Do planar Dc data as used in the Gameboy.
 .Pp
-.Dl DW \`01012323
+.Bd -literal -offset indent
+    DW \`01012323
+.Ed
 .Pp
 Admittedly, an expression with just a single number is quite boring.
 To spice things up a bit there are a few operators you can use to perform

--- a/src/gbz80.7
+++ b/src/gbz80.7
@@ -5,7 +5,7 @@
 .\"
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd January 26, 2018
+.Dd February 23, 2018
 .Dt GBZ80 7
 .Os RGBDS Manual
 .Sh NAME
@@ -24,8 +24,10 @@ as destination can omit the destination as it is assumed it's register
 .Sy A .
 The following two lines have the same effect:
 .Pp
-.Dl OR A,B
-.Dl OR B
+.Bd -literal -offset indent
+OR A,B
+OR B
+.Ed
 .Pp
 .Sh LEGEND
 List of abbreviations used in this document.

--- a/src/rgbds.7
+++ b/src/rgbds.7
@@ -5,7 +5,7 @@
 .\"
 .\" SPDX-License-Identifier: MIT
 .\"
-.Dd January 26, 2018
+.Dd February 24, 2018
 .Dt RGBDS 7
 .Os RGBDS Manual
 .Sh NAME
@@ -14,9 +14,11 @@
 .Sh EXAMPLES
 To get a working ROM image from a single assembly source file:
 .Pp
-.D1 $ rgbasm \-o bar.o foo.asm
-.D1 $ rgblink \-o baz.gb bar.o
-.D1 $ rgbfix \-v \-p 0 baz.gb
+.Bd -literal -offset indent
+$ rgbasm \-o bar.o foo.asm
+$ rgblink \-o baz.gb bar.o
+$ rgbfix \-v \-p 0 baz.gb
+.Ed
 .Sh SEE ALSO
 .Xr rgbasm 1 ,
 .Xr rgbfix 1 ,


### PR DESCRIPTION
Fixes https://github.com/rednex/rgbds/issues/231

The PR is missing updates in the documentation, I'll do that over the next few days.

In short, `"\"` can be used now to continue a line, like with C preprocessor macros. I've also added a few fixes so that this can be done in regular code and in list of macro arguments.
```
PrintMacro : MACRO
    PRINTT \1
ENDM

    PrintMacro STRCAT(\"Hello\"\,  \
                      \" world\\n\")
```

There's another change that I'm not sure about. I've made it possible to concatenate strings by just placing them next to each other. The following two lines are equivalent:
```
    DB "Hello world"
    DB "Hello " "world"
```
I'm not sure about what others may think about this, it can already be done by using `STRCAT`, and I'm not sure about how safe this is. I'd rather just remove it, to be honest. It doesn't even work when one of the strings is only one character long.
