### PR TITLE
Handle newlines and comments correctly

### DIFF
--- a/docs/rgbasm.5.html
+++ b/docs/rgbasm.5.html
@@ -42,6 +42,12 @@ Example:
 <div class="Pp"></div>
 All pseudo&#x2010;ops, mnemonics and registers (reserved keywords) are
   case&#x2010;insensitive and all labels are case&#x2010;sensitive.
+<div class="Pp"></div>
+There are two syntaxes for comments. In both cases, a comment ends at the end of
+  the line. The most common one is: anything that follows a semicolon
+  &quot;;&quot; (that isn't inside a string) is a comment. There is another
+  format: anything that follows a &quot;*&quot; that is placed right at the
+  start of a line is a comment.
 <h2 class="Ss" title="Ss" id="Sections"><a class="selflink" href="#Sections">Sections</a></h2>
 Before you can start writing code, you must define a section. This tells the
   assembler what kind of information follows and, if it is code, where to put

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -30,6 +30,12 @@ Example:
 .Pp
 All pseudo‐ops, mnemonics and registers (reserved keywords) are case‐insensitive
 and all labels are case‐sensitive.
+.Pp
+There are two syntaxes for comments. In both cases, a comment ends at the end of
+the line. The most common one is: anything that follows a semicolon
+\[dq]\&;\[dq] (that isn't inside a string) is a comment. There is another
+format: anything that follows a \[dq]*\[dq] that is placed right at the start of
+a line is a comment.
 .Ss Sections
 Before you can start writing code, you must define a section.
 This tells the assembler what kind of information follows and, if it is code,


### PR DESCRIPTION
Newlines have to be handled before comments or comments won't be able to handle line endings that don't include at least one LF character.

Also, document an obscure comment syntax: Anything that follows a '*' placed at the start of a line is also a comment until the end of the line.

Fixes https://github.com/rednex/rgbds/issues/236