### PR TITLE
Allow JR between sections

### DIFF
--- a/docs/rgbds.5.html
+++ b/docs/rgbds.5.html
@@ -121,6 +121,7 @@ REPT NumberOfSections
             BYTE    Type         ; 0 = BYTE patch. 
                                  ; 1 = little endian WORD patch. 
                                  ; 2 = little endian LONG patch. 
+                                 ; 3 = JR offset value BYTE patch. 
  
             LONG    RPNSize      ; Size of the buffer with the RPN. 
                                  ; expression. 

--- a/include/linkdefs.h
+++ b/include/linkdefs.h
@@ -66,7 +66,8 @@ enum eSymbolType {
 enum ePatchType {
 	PATCH_BYTE	= 0x00,
 	PATCH_WORD_L	= 0x01,
-	PATCH_LONG_L	= 0x02
+	PATCH_LONG_L	= 0x02,
+	PATCH_BYTE_JR	= 0x03
 };
 
 #endif /* RGBDS_LINKDEFS_H */

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -455,7 +455,6 @@ static void updateUnion(void)
 %type	<nConstValue>	const_3bit
 %type	<sVal>		const_8bit
 %type	<sVal>		const_16bit
-%type	<sVal>		const_PCrel
 %type	<nConstValue>	sectiontype
 
 %type	<tzString>	string
@@ -1108,14 +1107,6 @@ constlist_32bit_entry_single : /* empty */
 		}
 ;
 
-const_PCrel	: relocconst
-		{
-			if (!rpn_isPCRelative(&$1))
-				yyerror("Expression must be PC-relative");
-			$$ = $1;
-		}
-;
-
 const_8bit	: relocconst
 		{
 			if( (!rpn_isReloc(&$1)) && (($1.nVal < -128) || ($1.nVal > 255)) )
@@ -1602,12 +1593,12 @@ z80_jp		: T_Z80_JP const_16bit
 		}
 ;
 
-z80_jr		: T_Z80_JR const_PCrel
+z80_jr		: T_Z80_JR const_16bit
 		{
 			out_AbsByte(0x18);
 			out_PCRelByte(&$2);
 		}
-		| T_Z80_JR ccode comma const_PCrel
+		| T_Z80_JR ccode comma const_16bit
 		{
 			out_AbsByte(0x20 | ($2 << 3));
 			out_PCRelByte(&$4);

--- a/src/link/patch.c
+++ b/src/link/patch.c
@@ -267,6 +267,7 @@ void Patch(void)
 		pPatch = pSect->pPatches;
 		while (pPatch) {
 			int32_t t;
+			int32_t nPatchOrg;
 
 			nPC = pSect->nOrg + pPatch->nOffset;
 			t = calcrpn(pPatch);
@@ -305,6 +306,24 @@ void Patch(void)
 					(t >> 16) & 0xFF;
 				pSect->pData[pPatch->nOffset + 3] =
 					(t >> 24) & 0xFF;
+				break;
+			case PATCH_BYTE_JR:
+				/* Calculate absolute address of the patch */
+				nPatchOrg = pSect->nOrg + pPatch->nOffset;
+
+				/* t contains the destination of the jump */
+				t = (int16_t)((t & 0xFFFF) - (nPatchOrg + 1));
+
+				if (t >= -128 && t <= 255) {
+					t &= 0xFF;
+					pSect->pData[pPatch->nOffset] =
+						(uint8_t)t;
+				} else {
+					errx(1,
+					     "%s(%ld) : Value must be 8-bit",
+					     pPatch->pzFilename,
+					     pPatch->nLineNo);
+				}
 				break;
 			}
 

--- a/src/rgbds.5
+++ b/src/rgbds.5
@@ -113,6 +113,7 @@ REPT NumberOfSections
             BYTE    Type         ; 0 = BYTE patch.
                                  ; 1 = little endian WORD patch.
                                  ; 2 = little endian LONG patch.
+                                 ; 3 = JR offset value BYTE patch.
 
             LONG    RPNSize      ; Size of the buffer with the RPN.
                                  ; expression.


### PR DESCRIPTION
Previously, JR was only allowed if the destination label was in the same section as the JR. This patch removes this restriction. The check to see if the relative value overflows is now done when linking the ROM.

Requested in https://github.com/rednex/rgbds/issues/230