### PR TITLE
Introduce command PRINTI to print integers

### DIFF
--- a/docs/rgbasm.5.html
+++ b/docs/rgbasm.5.html
@@ -791,17 +791,20 @@ These three instructions type text and values to stdout. Useful for debugging
 <div class="Bd" style="margin-left: 5.00ex;">
 <pre class="Li">
 PRINTT &quot;I'm the greatest programmer in the whole wide world\n&quot; 
-PRINTV (2+3)/5 
-PRINTF MUL(3.14,3987.0)
+PRINTI (2 + 3) / 5 
+PRINTV $FF00 + $F0 
+PRINTF MUL(3.14, 3987.0)
 </pre>
 </div>
 <dl class="Bl-inset">
   <dt class="It-inset"><a class="selflink" href="#PRINTT"><b class="Ic" title="Ic" id="PRINTT">PRINTT</b></a></dt>
   <dd class="It-inset">prints out a string.</dd>
   <dt class="It-inset"><a class="selflink" href="#PRINTV"><b class="Ic" title="Ic" id="PRINTV">PRINTV</b></a></dt>
-  <dd class="It-inset">prints out an integer value or, as in the example, the
-      result of a calculation. Unsurprisingly, you can also print out a constant
-      symbols value.</dd>
+  <dd class="It-inset">prints out an integer value in hexadecimal or, as in the
+      example, the result of a calculation. Unsurprisingly, you can also print
+      out a constant symbols value.</dd>
+  <dt class="It-inset"><a class="selflink" href="#PRINTI"><b class="Ic" title="Ic" id="PRINTI">PRINTI</b></a></dt>
+  <dd class="It-inset">prints out a signed integer value.</dd>
   <dt class="It-inset"><a class="selflink" href="#PRINTF"><b class="Ic" title="Ic" id="PRINTF">PRINTF</b></a></dt>
   <dd class="It-inset">prints out a fixed point value.</dd>
 </dl>
@@ -1376,6 +1379,8 @@ The options that OPT can modify are currently: <b class="Sy" title="Sy">b</b>,
   <dt class="It-inset"><a class="Sx" title="Sx" href="#POPS">POPS</a></dt>
   <dd class="It-inset"></dd>
   <dt class="It-inset"><a class="Sx" title="Sx" href="#PRINTF">PRINTF</a></dt>
+  <dd class="It-inset"></dd>
+  <dt class="It-inset"><a class="Sx" title="Sx" href="#PRINTI">PRINTI</a></dt>
   <dd class="It-inset"></dd>
   <dt class="It-inset"><a class="Sx" title="Sx" href="#PRINTT">PRINTT</a></dt>
   <dd class="It-inset"></dd>

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -504,7 +504,7 @@ static void updateUnion(void)
 %token	<tzSym> T_POP_SET
 %token	<tzSym> T_POP_EQUS
 
-%token	T_POP_INCLUDE T_POP_PRINTF T_POP_PRINTT T_POP_PRINTV
+%token	T_POP_INCLUDE T_POP_PRINTF T_POP_PRINTT T_POP_PRINTV T_POP_PRINTI
 %token	T_POP_IF T_POP_ELIF T_POP_ELSE T_POP_ENDC
 %token	T_POP_IMPORT T_POP_EXPORT T_POP_GLOBAL
 %token	T_POP_DB T_POP_DS T_POP_DW T_POP_DL
@@ -648,6 +648,7 @@ simple_pseudoop : include
 		| printf
 		| printt
 		| printv
+		| printi
 		| if
 		| elif
 		| else
@@ -930,6 +931,13 @@ printv		: T_POP_PRINTV const
 		{
 			if (nPass == 1)
 				printf("$%X", $2);
+		}
+;
+
+printi		: T_POP_PRINTI const
+		{
+			if (nPass == 1)
+				printf("%d", $2);
 		}
 ;
 

--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -368,6 +368,7 @@ const struct sLexInitString lexer_strings[] = {
 
 	{"include", T_POP_INCLUDE},
 	{"printt", T_POP_PRINTT},
+	{"printi", T_POP_PRINTI},
 	{"printv", T_POP_PRINTV},
 	{"printf", T_POP_PRINTF},
 	{"export", T_POP_EXPORT},

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -660,16 +660,19 @@ some important information.
 .Pp
 .Bd -literal -offset indent
 PRINTT \[dq]I'm the greatest programmer in the whole wide world\[rs]n\[dq]
-PRINTV (2+3)/5
-PRINTF MUL(3.14,3987.0)
+PRINTI (2 + 3) / 5
+PRINTV $FF00 + $F0
+PRINTF MUL(3.14, 3987.0)
 .Ed
 .Pp
 .Bl -inset
 .It Ic PRINTT
 prints out a string.
 .It Ic PRINTV
-prints out an integer value or, as in the example, the result of a calculation.
-Unsurprisingly, you can also print out a constant symbols value.
+prints out an integer value in hexadecimal or, as in the example, the result of
+a calculation. Unsurprisingly, you can also print out a constant symbols value.
+.It Ic PRINTI
+prints out a signed integer value.
 .It Ic PRINTF
 prints out a fixed point value.
 .El
@@ -1068,6 +1071,7 @@ machine.
 .It Sx POPO
 .It Sx POPS
 .It Sx PRINTF
+.It Sx PRINTI
 .It Sx PRINTT
 .It Sx PRINTV
 .It Sx PURGE


### PR DESCRIPTION
PRINTV prints integers in hexadecimal, PRINTI prints them in signed decimal. For example:
```
    PRINTT "Error at line "
    PRINTI __LINE__
    PRINTT "\n"
```
Fixes https://github.com/rednex/rgbds/issues/206

I know that this isn't a perfect solution. Ideally, we would have something like https://github.com/rednex/rgbds/issues/178, but that's quite tricky to implement in comparison.