### PR TITLE
Fix a few problems related to '@' and 'JR'

### DIFF
--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -579,7 +579,7 @@ void setup_lexer(void)
 	lex_FloatAddRange(id, '@', '@');
 	lex_FloatAddRange(id, '#', '#');
 
-	//@ID
+	// "@"
 
 	id = lex_FloatAlloc(&tIDToken);
 	lex_FloatAddFirstRange(id, '@', '@');

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -882,24 +882,16 @@ void out_PCRelByte(struct Expression *expr)
 {
 	checkcodesection();
 	checksectionoverflow(1);
-	if (rpn_isReloc(expr)) {
-		if (nPass == 2) {
-			pCurrentSection->tData[nPC] = 0;
-			createpatch(PATCH_BYTE_JR, expr);
-		}
-		pCurrentSection->nPC += 1;
-		nPC += 1;
-		pPCSymbol->nValue += 1;
-	} else {
-		int32_t b = expr->nVal;
 
-		b = (int16_t)((b & 0xFFFF) - (nPC + 1));
-
-		if (nPass == 2 && ((b < -128) || (b > 127)))
-			yyerror("PC-relative value must be 8-bit");
-
-		out_AbsByte(b & 0xFF);
+	/* Always let the linker calculate the offset. */
+	if (nPass == 2) {
+		pCurrentSection->tData[nPC] = 0;
+		createpatch(PATCH_BYTE_JR, expr);
 	}
+	pCurrentSection->nPC += 1;
+	nPC += 1;
+	pPCSymbol->nValue += 1;
+
 	rpn_Reset(expr);
 }
 

--- a/src/link/mapfile.c
+++ b/src/link/mapfile.c
@@ -120,6 +120,10 @@ void MapfileWriteSection(const struct sSection *pSect)
 	for (i = 0; i < pSect->nNumberOfSymbols; i += 1) {
 		const struct sSymbol *pSym = pSect->tSymbols[i];
 
+		/* Don't print '@' */
+		if (strcmp(pSym->pzName, "@") == 0)
+			continue;
+
 		if ((pSym->pSection == pSect) && (pSym->Type != SYM_IMPORT)) {
 			if (mf) {
 				fprintf(mf, "           $%04X = %s\n",

--- a/src/link/patch.c
+++ b/src/link/patch.c
@@ -314,7 +314,7 @@ void Patch(void)
 				/* t contains the destination of the jump */
 				t = (int16_t)((t & 0xFFFF) - (nPatchOrg + 1));
 
-				if (t >= -128 && t <= 255) {
+				if (t >= -128 && t <= 127) {
 					t &= 0xFF;
 					pSect->pData[pPatch->nOffset] =
 						(uint8_t)t;


### PR DESCRIPTION
Fixes https://github.com/rednex/rgbds/issues/259

This also removes 2 conflicts from the parser of `rgbasm`.

Regarding the warnings of `rgbasm` when the code has lists of values and there is one or more empty elements, it will only be shown once per list.