### PR TITLE
rgbasm: Allow variations of 'ld [$FF00+c],a'

### DIFF
--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1707,6 +1707,14 @@ z80_ldio	: T_Z80_LDIO T_MODE_A comma op_mem_ind
 			$2.nVal &= 0xFF;
 			out_RelByte(&$2);
 		}
+		| T_Z80_LDIO T_MODE_A comma T_MODE_C_IND
+		{
+			out_AbsByte(0xF2);
+		}
+		| T_Z80_LDIO T_MODE_C_IND comma T_MODE_A
+		{
+			out_AbsByte(0xE2);
+		}
 ;
 
 z80_ld		: z80_ld_mem

--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -312,6 +312,7 @@ const struct sLexInitString lexer_strings[] = {
 	{"sp", T_MODE_SP},
 	{"[c]", T_MODE_C_IND},
 	{"[$ff00+c]", T_MODE_C_IND},
+	{"[$ff00 + c]", T_MODE_C_IND},
 
 	{"a", T_TOKEN_A},
 	{"b", T_TOKEN_B},


### PR DESCRIPTION
The following mnemonics are now valid:

    - ld
    - ldh
    - ldio

The following are valid as operands:

    - [$ff00+c]
    - [$ff00 + c]
    - [c]

This is done for consistency with 'ld [$FF00+n],a' and variations of it.

Fixes https://github.com/rednex/rgbds/issues/276