### PR TITLE
Fix the global checksum calculation in rgbfix

### DIFF
--- a/src/fix/main.c
+++ b/src/fix/main.c
@@ -478,9 +478,9 @@ int main(int argc, char *argv[])
 		int byte;
 
 		while ((byte = fgetc(rom)) != EOF) {
-			i++;
-			if (i != 0x150)
+			if (i != 0x14E && i != 0x14F)
 				globalcksum += byte;
+			i++;
 		}
 
 		if (ferror(rom))


### PR DESCRIPTION
_(Looks like it's been almost a year since I last contributed, whoops! Hope I'm not too rusty 😛)_

A regression was spotted in rgbfix 0.3.7, where we would accidentally include the first byte of the existing checksum when calculating a global checksum. We now correctly ignore both of the existing checksum bytes.

This was spotted when running rgbfix on the Pokémon Gold/Silver betas, as they have a non-zero global checksum.

Fixes #280.