### PR TITLE
Allow test repos to be kept locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ rgbgfx
 *.o
 *.exe
 .checkpatch-camelcase.*
+
+test/pokecrystal/*
+test/pokered/*
+test/ucity/*

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -18,27 +18,30 @@ popd
 # When adding new ones, don't forget to add them to the .gitignore!
 
 if [ ! -d pokecrystal ]; then
-	git clone https://github.com/pret/pokecrystal.git --depth=1
+	git clone https://github.com/pret/pokecrystal.git --shallow-since=2018-06-04 --single-branch
 fi
 pushd pokecrystal
-git pull
+git fetch
+git checkout 06e169d
 make -j
 make compare
 popd
 
 if [ ! -d pokered ]; then
-	git clone --recursive https://github.com/pret/pokered.git --depth=1
+	git clone --recursive https://github.com/pret/pokered.git --shallow-since=2018-03-23 --single-branch
 fi
 pushd pokered
-git pull
+git fetch
+git checkout 98f09b6
 make -j
 make compare
 popd
 
 if [ ! -d ucity ]; then
-	git clone https://github.com/AntonioND/ucity.git --depth=1
+	git clone https://github.com/AntonioND/ucity.git --shallow-since=2018-06-05 --single-branch
 fi
 pushd ucity
-git pull
+git fetch
+git checkout 9fc8f27
 make -j
 popd

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -15,20 +15,30 @@ pushd link
 popd
 
 # Test some significant external projects that use RGBDS
+# When adding new ones, don't forget to add them to the .gitignore!
 
-git clone https://github.com/pret/pokecrystal.git --depth=1
+if [ ! -d pokecrystal ]; then
+	git clone https://github.com/pret/pokecrystal.git --depth=1
+fi
 pushd pokecrystal
+git pull
 make -j
 make compare
 popd
 
-git clone --recursive https://github.com/pret/pokered.git --depth=1
+if [ ! -d pokered ]; then
+	git clone --recursive https://github.com/pret/pokered.git --depth=1
+fi
 pushd pokered
+git pull
 make -j
 make compare
 popd
 
-git clone https://github.com/AntonioND/ucity.git --depth=1
+if [ ! -d ucity ]; then
+	git clone https://github.com/AntonioND/ucity.git --depth=1
+fi
 pushd ucity
+git pull
 make -j
 popd


### PR DESCRIPTION
*(I thought I submitted this PR a few days ago…)*

We no longer assume that the test repos don’t exist when we run `run-tests.sh`. This allows developers to choose to keep them, to allow them to run the tests more quickly.

- Add the test repos to the .gitignore.
- Check if the directory for each repo already exists, before trying to clone it.
- Do a `git pull` for each repo, to ensure that existing copies of repos are up-to-date.