### PR TITLE
Replace pointers to ‘dummymem’ with NULL

### DIFF
--- a/src/link/object.c
+++ b/src/link/object.c
@@ -28,7 +28,6 @@
 struct sSymbol **tSymbols;
 struct sSection *pSections;
 struct sSection *pLibSections;
-uint8_t dummymem;
 uint8_t oReadLib;
 
 /*
@@ -209,7 +208,7 @@ struct sSection *obj_ReadRGBSection(FILE *f)
 	if (pSection->nByteSize == 0) {
 		/* Skip number of patches */
 		readlong(f);
-		pSection->pData = &dummymem;
+		pSection->pData = NULL;
 		return pSection;
 	}
 
@@ -283,7 +282,7 @@ void obj_ReadRGB(FILE *pObjfile, char *tzObjectfile)
 		for (i = 0; i < nNumberOfSymbols; i += 1)
 			tSymbols[i] = obj_ReadSymbol(pObjfile, tzObjectfile);
 	} else {
-		tSymbols = (struct sSymbol **)&dummymem;
+		tSymbols = NULL;
 	}
 
 	/* Next we have the sections */


### PR DESCRIPTION
Two variables, `pSection->Data` and `tSymbols`, were previously set to `dummymem`, a global variable that was otherwise not used.

As this can potentially cause alignment warnings on Clang, this commit replaces that mechanism with a plain old `NULL` pointer, which is more generally used as a dummy pointer value.

---

I've not looked into this any further than I had mentioned in #283, so it might be worth ensuring that this pointer can't be accidentally dereferenced.