### PR TITLE
Update a symbol's filename and line when defined

### DIFF
--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -103,6 +103,19 @@ uint32_t calchash(char *s)
 }
 
 /*
+ * Update a symbol's definition filename and line
+ */
+void updateSymbolFilename(struct sSymbol *nsym)
+{
+	if (snprintf(nsym->tzFileName, _MAX_PATH + 1, "%s",
+		     tzCurrentFileName) > _MAX_PATH) {
+		fatalerror("%s: File name is too long: '%s'", __func__,
+			   tzCurrentFileName);
+	}
+	nsym->nFileLine = fstk_GetLine();
+}
+
+/*
  * Create a new symbol by name
  */
 struct sSymbol *createsymbol(char *s)
@@ -133,14 +146,7 @@ struct sSymbol *createsymbol(char *s)
 	(*ppsym)->pMacro = NULL;
 	(*ppsym)->pSection = NULL;
 	(*ppsym)->Callback = NULL;
-
-	if (snprintf((*ppsym)->tzFileName, _MAX_PATH + 1, "%s",
-		     tzCurrentFileName) > _MAX_PATH) {
-		fatalerror("%s: File name is too long: '%s'", __func__,
-			   tzCurrentFileName);
-	}
-
-	(*ppsym)->nFileLine = fstk_GetLine();
+	updateSymbolFilename(*ppsym);
 	return *ppsym;
 }
 
@@ -560,6 +566,7 @@ void sym_AddEqu(char *tzSym, int32_t value)
 			nsym->nValue = value;
 			nsym->nType |= SYMF_EQU | SYMF_DEFINED | SYMF_CONST;
 			nsym->pScope = NULL;
+			updateSymbolFilename(nsym);
 		}
 	}
 }
@@ -633,6 +640,7 @@ void sym_AddSet(char *tzSym, int32_t value)
 		nsym->nValue = value;
 		nsym->nType |= SYMF_SET | SYMF_DEFINED | SYMF_CONST;
 		nsym->pScope = NULL;
+		updateSymbolFilename(nsym);
 	}
 }
 
@@ -710,6 +718,8 @@ void sym_AddReloc(char *tzSym)
 
 			nsym->pScope = scope;
 			nsym->pSection = pCurrentSection;
+
+			updateSymbolFilename(nsym);
 		}
 	}
 	pScope = findsymbol(tzSym, scope);
@@ -840,6 +850,7 @@ void sym_AddMacro(char *tzSym)
 			nsym->pScope = NULL;
 			nsym->ulMacroSize = ulNewMacroSize;
 			nsym->pMacro = tzNewMacro;
+			updateSymbolFilename(nsym);
 		}
 	}
 }

--- a/test/asm/label-redefinition.asm
+++ b/test/asm/label-redefinition.asm
@@ -1,0 +1,7 @@
+SECTION "sec", ROM0
+    dw Sym
+m: MACRO
+Sym::
+ENDM
+    m
+Sym::

--- a/test/asm/label-redefinition.out
+++ b/test/asm/label-redefinition.out
@@ -1,0 +1,3 @@
+ERROR: label-redefinition.asm(7):
+    'Sym' already defined in m(6)
+error: Assembly aborted in pass 1 (1 errors)!


### PR DESCRIPTION
Currently, all symbols are assigned a filename and line when they're
first encountered and added to the internal hash table. This is often
not expected and leads to erroneous error messages.

Fixes #316 