### PR TITLE
Increase version number to 0.3.8

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -11,7 +11,7 @@
 
 #define PACKAGE_VERSION_MAJOR (0)
 #define PACKAGE_VERSION_MINOR (3)
-#define PACKAGE_VERSION_PATCH (7)
+#define PACKAGE_VERSION_PATCH (8)
 
 const char *get_package_version_string(void);
 


### PR DESCRIPTION
Last version released is `0.3.8`, but package version still shows `0.3.7`.