### PR TITLE
Fix symbol length checking

### DIFF
--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -188,7 +188,7 @@ uint32_t ParseSymbol(char *src, uint32_t size)
 		}
 	}
 
-	if (copied > MAXSYMLEN)
+	if (copied >= MAXSYMLEN)
 		fatalerror("Symbol too long");
 
 	dest[copied] = 0;
@@ -206,7 +206,7 @@ uint32_t ParseSymbol(char *src, uint32_t size)
 		return 0;
 	}
 
-	strcpy(yylval.tzString, dest);
+	strcpy(yylval.tzSym, dest);
 	return 1;
 }
 


### PR DESCRIPTION
When the while loop in `ParseSymbol` stops because of the symbol length,
`copied` will have the value of `MAXSYMLEN`, which is obviously not
greater than `MAXSYMLEN`. Changing the condition to `>=` fixes the
issue.

As a bonus, the correct union field will now be used. It shouldn't
matter, but it's technically UB to use a wrong one.