### PR TITLE
Dynamically allocate RPN expression buffer

### DIFF
--- a/include/asm/rpn.h
+++ b/include/asm/rpn.h
@@ -13,7 +13,8 @@
 
 struct Expression {
 	int32_t  nVal;
-	uint8_t  tRPN[256];
+	uint8_t  *tRPN;
+	uint32_t nRPNCapacity;
 	uint32_t nRPNLength;
 	uint32_t nRPNOut;
 	uint32_t isReloc;
@@ -69,7 +70,8 @@ uint16_t rpn_PopByte(struct Expression *expr);
 void rpn_BankSymbol(struct Expression *expr, char *tzSym);
 void rpn_BankSection(struct Expression *expr, char *tzSectionName);
 void rpn_BankSelf(struct Expression *expr);
-void rpn_Reset(struct Expression *expr);
+void rpn_Init(struct Expression *expr);
+void rpn_Free(struct Expression *expr);
 void rpn_CheckHRAM(struct Expression *expr, const struct Expression *src);
 
 #endif /* RGBDS_ASM_RPN_H */

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1772,6 +1772,7 @@ z80_ld_mem	: T_Z80_LD op_mem_ind comma T_MODE_SP
 			    (!rpn_isReloc(&$2)) && ($2.nVal >= 0xFF00)) {
 				out_AbsByte(0xE0);
 				out_AbsByte($2.nVal & 0xFF);
+				rpn_Free(&$2);
 			} else {
 				out_AbsByte(0xEA);
 				out_RelWord(&$2);
@@ -1826,12 +1827,14 @@ z80_ld_a	: T_Z80_LD reg_r comma T_MODE_C_IND
 				    (!rpn_isReloc(&$4)) && ($4.nVal >= 0xFF00)) {
 					out_AbsByte(0xF0);
 					out_AbsByte($4.nVal & 0xFF);
+					rpn_Free(&$4);
 				} else {
 					out_AbsByte(0xFA);
 					out_RelWord(&$4);
 				}
 			} else {
 				yyerror("Destination operand must be A");
+				rpn_Free(&$4);
 			}
 		}
 ;
@@ -1964,6 +1967,7 @@ z80_rst		: T_Z80_RST const_8bit
 				yyerror("Invalid address $%x for RST", $2.nVal);
 			else
 				out_AbsByte(0xC7 | $2.nVal);
+			rpn_Free(&$2);
 		}
 ;
 

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -782,7 +782,7 @@ void out_RelByte(struct Expression *expr)
 	} else {
 		out_AbsByte(expr->nVal);
 	}
-	rpn_Reset(expr);
+	rpn_Free(expr);
 }
 
 /*
@@ -825,7 +825,7 @@ void out_RelWord(struct Expression *expr)
 	} else {
 		out_AbsWord(expr->nVal);
 	}
-	rpn_Reset(expr);
+	rpn_Free(expr);
 }
 
 /*
@@ -871,7 +871,7 @@ void out_RelLong(struct Expression *expr)
 	} else {
 		out_AbsLong(expr->nVal);
 	}
-	rpn_Reset(expr);
+	rpn_Free(expr);
 }
 
 /*
@@ -892,7 +892,7 @@ void out_PCRelByte(struct Expression *expr)
 	nPC += 1;
 	pPCSymbol->nValue += 1;
 
-	rpn_Reset(expr);
+	rpn_Free(expr);
 }
 
 /*


### PR DESCRIPTION
The RPN expression buffer can now grow in size. I ran valgrind to ensure that this doesn't introduce any memory leaks.

Fixes #334.