### PR TITLE
Fix errors when building with byacc

### DIFF
--- a/include/asm/lexer.h
+++ b/include/asm/lexer.h
@@ -63,7 +63,7 @@ void lex_Init(void);
 void lex_AddStrings(const struct sLexInitString *lex);
 void lex_SetBuffer(char *buffer, uint32_t len);
 int yywrap(void);
-uint32_t yylex(void);
+int yylex(void);
 void yyunput(char c);
 void yyunputstr(char *s);
 void yyskipbytes(uint32_t count);

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -879,7 +879,7 @@ static uint32_t yylex_MACROARGS(void)
 	fatalerror("Internal error in %s", __func__);
 }
 
-uint32_t yylex(void)
+int yylex(void)
 {
 	switch (lexerstate) {
 	case LEX_STATE_NORMAL:


### PR DESCRIPTION
I changed the return type of `yylex()` from `uint32_t` to `int`. This bison documentation also specifies the use of `int` as the return type.

https://www.gnu.org/software/bison/manual/html_node/Calling-Convention.html

Fixes #331.
Fixes #333.