### PR TITLE
Use only one pass

### DIFF
--- a/include/asm/asm.h
+++ b/include/asm/asm.h
@@ -28,7 +28,6 @@
 extern int32_t nLineNo;
 extern uint32_t nTotalLines;
 extern uint32_t nPC;
-extern uint32_t nPass;
 extern uint32_t nIFDepth;
 extern bool skipElif;
 extern uint32_t nUnionDepth;

--- a/include/asm/rpn.h
+++ b/include/asm/rpn.h
@@ -18,11 +18,9 @@ struct Expression {
 	uint32_t nRPNLength;
 	uint32_t nRPNOut;
 	uint32_t isReloc;
-	uint32_t isPCRel;
 };
 
 uint32_t rpn_isReloc(const struct Expression *expr);
-uint32_t rpn_isPCRelative(const struct Expression *expr);
 void rpn_Symbol(struct Expression *expr, char *tzSym);
 void rpn_Number(struct Expression *expr, uint32_t i);
 void rpn_LOGNOT(struct Expression *expr, const struct Expression *src);

--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -38,6 +38,8 @@ struct sSymbol {
 #define SYMF_SET	0x004
 /* Symbol should be exported */
 #define SYMF_EXPORT	0x008
+/* Symbol referenced in RPN expression */
+#define SYMF_REF	0x010
 /* Symbol is a local symbol */
 #define SYMF_LOCAL	0x020
 /* Symbol has been defined, not only referenced */
@@ -74,7 +76,7 @@ void sym_UseCurrentMacroArgs(void);
 void sym_SetMacroArgID(uint32_t nMacroCount);
 uint32_t sym_isString(char *tzSym);
 void sym_AddMacro(char *tzSym);
-void sym_AddForwardRef(char *tzSym);
+void sym_Ref(char *tzSym);
 void sym_ShiftCurrentMacroArgs(void);
 void sym_AddString(char *tzSym, char *tzValue);
 uint32_t sym_GetDefinedValue(char *s);

--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -38,8 +38,6 @@ struct sSymbol {
 #define SYMF_SET	0x004
 /* Symbol should be exported */
 #define SYMF_EXPORT	0x008
-/* Symbol is imported, it's value is unknown */
-#define SYMF_IMPORT	0x010
 /* Symbol is a local symbol */
 #define SYMF_LOCAL	0x020
 /* Symbol has been defined, not only referenced */
@@ -53,8 +51,6 @@ struct sSymbol {
 
 uint32_t calchash(char *s);
 void sym_SetExportAll(uint8_t set);
-void sym_PrepPass1(void);
-void sym_PrepPass2(void);
 void sym_AddLocalReloc(char *tzSym);
 void sym_AddReloc(char *tzSym);
 void sym_Export(char *tzSym);
@@ -72,16 +68,15 @@ void sym_Init(void);
 uint32_t sym_GetConstantValue(char *s);
 uint32_t sym_isConstant(char *s);
 struct sSymbol *sym_FindSymbol(char *tzName);
-void sym_Global(char *tzSym);
 char *sym_FindMacroArg(int32_t i);
 char *sym_GetStringValue(char *tzSym);
 void sym_UseCurrentMacroArgs(void);
 void sym_SetMacroArgID(uint32_t nMacroCount);
 uint32_t sym_isString(char *tzSym);
 void sym_AddMacro(char *tzSym);
+void sym_AddForwardRef(char *tzSym);
 void sym_ShiftCurrentMacroArgs(void);
 void sym_AddString(char *tzSym, char *tzValue);
-uint32_t sym_GetValue(char *s);
 uint32_t sym_GetDefinedValue(char *s);
 uint32_t sym_isDefined(char *tzName);
 void sym_Purge(char *tzName);

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -799,7 +799,7 @@ ds		: T_POP_DS uconst
 ;
 
 db		: T_POP_DB constlist_8bit_entry comma constlist_8bit {
-			if ((nPass == 1) && (nListCountEmpty > 0)) {
+			if (nListCountEmpty > 0) {
 				warning("Empty entry in list of 8-bit elements (treated as 0).");
 			}
 		}
@@ -807,7 +807,7 @@ db		: T_POP_DB constlist_8bit_entry comma constlist_8bit {
 ;
 
 dw		: T_POP_DW constlist_16bit_entry comma constlist_16bit {
-			if ((nPass == 1) && (nListCountEmpty > 0)) {
+			if (nListCountEmpty > 0) {
 				warning("Empty entry in list of 16-bit elements (treated as 0).");
 			}
 		}
@@ -815,7 +815,7 @@ dw		: T_POP_DW constlist_16bit_entry comma constlist_16bit {
 ;
 
 dl		: T_POP_DL constlist_32bit_entry comma constlist_32bit {
-			if ((nPass == 1) && (nListCountEmpty > 0)) {
+			if (nListCountEmpty > 0) {
 				warning("Empty entry in list of 32-bit elements (treated as 0).");
 			}
 		}
@@ -852,8 +852,7 @@ import_list_entry : T_ID
 			 * This is done automatically if the label isn't found
 			 * in the list of defined symbols.
 			 */
-			if (nPass == 1)
-				warning("IMPORT is a deprecated keyword with no effect: %s", $1);
+			warning("IMPORT is a deprecated keyword with no effect: %s", $1);
 		}
 ;
 
@@ -879,7 +878,7 @@ global_list	: global_list_entry
 
 global_list_entry : T_ID
 		{
-			sym_Global($1);
+			sym_Export($1);
 		}
 ;
 
@@ -929,29 +928,25 @@ charmap		: T_POP_CHARMAP string comma string
 
 printt		: T_POP_PRINTT string
 		{
-			if (nPass == 1)
-				printf("%s", $2);
+			printf("%s", $2);
 		}
 ;
 
 printv		: T_POP_PRINTV const
 		{
-			if (nPass == 1)
-				printf("$%X", constexpr_GetConstantValue(&$2));
+			printf("$%X", constexpr_GetConstantValue(&$2));
 		}
 ;
 
 printi		: T_POP_PRINTI const
 		{
-			if (nPass == 1)
-				printf("%d", constexpr_GetConstantValue(&$2));
+			printf("%d", constexpr_GetConstantValue(&$2));
 		}
 ;
 
 printf		: T_POP_PRINTF const
 		{
-			if (nPass == 1)
-				math_Print(constexpr_GetConstantValue(&$2));
+			math_Print(constexpr_GetConstantValue(&$2));
 		}
 ;
 
@@ -1126,20 +1121,17 @@ relocconst	: T_ID
 				struct Expression sTemp, sOffset;
 
 				rpn_Symbol(&sTemp, $1);
-				sTemp.nVal = sym_GetValue($1);
 
 				rpn_Number(&sOffset, nPCOffset);
 
 				rpn_SUB(&$$, &sTemp, &sOffset);
 			} else {
 				rpn_Symbol(&$$, $1);
-				$$.nVal = sym_GetValue($1);
 			}
 		}
 		| T_NUMBER
 		{
 			rpn_Number(&$$, $1);
-			$$.nVal = $1;
 		}
 		| string
 		{
@@ -1149,7 +1141,6 @@ relocconst	: T_ID
 
 			free(s);
 			rpn_Number(&$$, r);
-			$$.nVal = r;
 		}
 		| T_OP_LOGICNOT relocconst %prec NEG	{ rpn_LOGNOT(&$$, &$2); }
 		| relocconst T_OP_LOGICOR relocconst	{ rpn_LOGOR(&$$, &$1, &$3); }
@@ -1179,12 +1170,10 @@ relocconst	: T_ID
 		{
 			/* '@' is also a T_ID, it is handled here. */
 			rpn_BankSymbol(&$$, $3);
-			$$.nVal = 0;
 		}
 		| T_OP_BANK '(' string ')'
 		{
 			rpn_BankSection(&$$, $3);
-			$$.nVal = 0;
 		}
 		| T_OP_DEF {
 				oDontExpandStrings = true;
@@ -1637,8 +1626,7 @@ z80_jp		: T_Z80_JP const_16bit
 		| T_Z80_JP T_MODE_HL_IND
 		{
 			out_AbsByte(0xE9);
-			if (nPass == 1)
-				warning("'JP [HL]' is obsolete, use 'JP HL' instead.");
+			warning("'JP [HL]' is obsolete, use 'JP HL' instead.");
 		}
 		| T_Z80_JP T_MODE_HL
 		{
@@ -1665,8 +1653,7 @@ z80_ldi		: T_Z80_LDI T_MODE_HL_IND comma T_MODE_A
 		| T_Z80_LDI T_MODE_A comma T_MODE_HL
 		{
 			out_AbsByte(0x0A | (2 << 4));
-			if (nPass == 1)
-				warning("'LDI A,HL' is obsolete, use 'LDI A,[HL]' or 'LD A,[HL+] instead.");
+			warning("'LDI A,HL' is obsolete, use 'LDI A,[HL]' or 'LD A,[HL+] instead.");
 		}
 		| T_Z80_LDI T_MODE_A comma T_MODE_HL_IND
 		{
@@ -1681,8 +1668,7 @@ z80_ldd		: T_Z80_LDD T_MODE_HL_IND comma T_MODE_A
 		| T_Z80_LDD T_MODE_A comma T_MODE_HL
 		{
 			out_AbsByte(0x0A | (3 << 4));
-			if (nPass == 1)
-				warning("'LDD A,HL' is obsolete, use 'LDD A,[HL]' or 'LD A,[HL-] instead.");
+			warning("'LDD A,HL' is obsolete, use 'LDD A,[HL]' or 'LD A,[HL-] instead.");
 		}
 		| T_Z80_LDD T_MODE_A comma T_MODE_HL_IND
 		{

--- a/src/asm/charmap.c
+++ b/src/asm/charmap.c
@@ -62,9 +62,6 @@ int32_t charmap_Add(char *input, uint8_t output)
 		charmap = &globalCharmap;
 	}
 
-	if (nPass == 2)
-		return charmap->count;
-
 	if (charmap->count > MAXCHARMAPS || strlen(input) > CHARMAPLENGTH)
 		return -1;
 

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -37,7 +37,7 @@ char **cldefines;
 
 clock_t nStartClock, nEndClock;
 int32_t nLineNo;
-uint32_t nTotalLines, nPass, nPC, nIFDepth, nUnionDepth, nErrors;
+uint32_t nTotalLines, nPC, nIFDepth, nUnionDepth, nErrors;
 bool skipElif;
 uint32_t unionStart[128], unionSize[128];
 
@@ -432,21 +432,17 @@ int main(int argc, char *argv[])
 	skipElif = true;
 	nUnionDepth = 0;
 	nPC = 0;
-	nPass = 1;
 	nErrors = 0;
-	sym_PrepPass1();
+	sym_Init();
 	sym_SetExportAll(CurrentOptions.exportall);
 	fstk_Init(tzMainfile);
 	opt_ParseDefines();
-
-	if (CurrentOptions.verbose)
-		printf("Pass 1...\n");
 
 	yy_set_state(LEX_STATE_NORMAL);
 	opt_SetCurrentOptions(&DefaultOptions);
 
 	if (yyparse() != 0 || nErrors != 0)
-		errx(1, "Assembly aborted in pass 1 (%ld errors)!", nErrors);
+		errx(1, "Assembly aborted (%ld errors)!", nErrors);
 
 	if (nIFDepth != 0)
 		errx(1, "Unterminated IF construct (%ld levels)!", nIFDepth);
@@ -455,27 +451,6 @@ int main(int argc, char *argv[])
 		errx(1, "Unterminated UNION construct (%ld levels)!",
 		     nUnionDepth);
 	}
-
-	nTotalLines = 0;
-	nLineNo = 1;
-	nIFDepth = 0;
-	skipElif = true;
-	nUnionDepth = 0;
-	nPC = 0;
-	nPass = 2;
-	nErrors = 0;
-	sym_PrepPass2();
-	out_PrepPass2();
-	fstk_Init(tzMainfile);
-	yy_set_state(LEX_STATE_NORMAL);
-	opt_SetCurrentOptions(&DefaultOptions);
-	opt_ParseDefines();
-
-	if (CurrentOptions.verbose)
-		printf("Pass 2...\n");
-
-	if (yyparse() != 0 || nErrors != 0)
-		errx(1, "Assembly aborted in pass 2 (%ld errors)!", nErrors);
 
 	double timespent;
 

--- a/src/asm/rpn.c
+++ b/src/asm/rpn.c
@@ -138,7 +138,7 @@ void rpn_Symbol(struct Expression *expr, char *tzSym)
 {
 	if (!sym_isConstant(tzSym)) {
 		rpn_Init(expr);
-		sym_AddForwardRef(tzSym);
+		sym_Ref(tzSym);
 		expr->isReloc = 1;
 		pushbyte(expr, RPN_SYM);
 		while (*tzSym)
@@ -172,7 +172,7 @@ void rpn_BankSymbol(struct Expression *expr, char *tzSym)
 
 	if (!sym_isConstant(tzSym)) {
 		rpn_Init(expr);
-		sym_AddForwardRef(tzSym);
+		sym_Ref(tzSym);
 		expr->isReloc = 1;
 		pushbyte(expr, RPN_BANK_SYM);
 		while (*tzSym)

--- a/src/asm/rpn.c
+++ b/src/asm/rpn.c
@@ -55,7 +55,6 @@ void mergetwoexpressions(struct Expression *expr, const struct Expression *src1,
 
 	expr->nRPNLength = len;
 	expr->isReloc = src1->isReloc || src2->isReloc;
-	expr->isPCRel = src1->isPCRel || src2->isPCRel;
 }
 
 #define joinexpr() mergetwoexpressions(expr, src1, src2)
@@ -91,7 +90,6 @@ void rpn_Init(struct Expression *expr)
 	expr->nRPNLength = 0;
 	expr->nRPNOut = 0;
 	expr->isReloc = 0;
-	expr->isPCRel = 0;
 }
 
 /*
@@ -123,14 +121,6 @@ uint32_t rpn_isReloc(const struct Expression *expr)
 }
 
 /*
- * Determine if the current expression can be pc-relative
- */
-uint32_t rpn_isPCRelative(const struct Expression *expr)
-{
-	return expr->isPCRel;
-}
-
-/*
  * Add symbols, constants and operators to expression
  */
 void rpn_Number(struct Expression *expr, uint32_t i)
@@ -147,15 +137,8 @@ void rpn_Number(struct Expression *expr, uint32_t i)
 void rpn_Symbol(struct Expression *expr, char *tzSym)
 {
 	if (!sym_isConstant(tzSym)) {
-		const struct sSymbol *psym;
-
 		rpn_Init(expr);
-
-		psym = sym_FindSymbol(tzSym);
-
-		if (psym == NULL || psym->pSection == pCurrentSection
-		    || psym->pSection == NULL)
-			expr->isPCRel = 1;
+		sym_AddForwardRef(tzSym);
 		expr->isReloc = 1;
 		pushbyte(expr, RPN_SYM);
 		while (*tzSym)
@@ -189,13 +172,7 @@ void rpn_BankSymbol(struct Expression *expr, char *tzSym)
 
 	if (!sym_isConstant(tzSym)) {
 		rpn_Init(expr);
-
-		/*
-		 * Check that the symbol exists by evaluating and discarding the
-		 * value.
-		 */
-		sym_GetValue(tzSym);
-
+		sym_AddForwardRef(tzSym);
 		expr->isReloc = 1;
 		pushbyte(expr, RPN_BANK_SYM);
 		while (*tzSym)

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -298,7 +298,7 @@ char *sym_GetStringValue(char *tzSym)
 	if (pSym != NULL)
 		return pSym->pMacro;
 
-	yyerror("Stringsymbol '%s' not defined", tzSym);
+	yyerror("String symbol '%s' not defined", tzSym);
 
 	return NULL;
 }

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -154,12 +154,14 @@ struct sSymbol *createsymbol(char *s)
  * Creates the full name of a local symbol in a given scope, by prepending
  * the name with the parent symbol's name.
  */
-static size_t fullSymbolName(char *output, size_t outputSize, char *localName,
-			     const struct sSymbol *scope)
+static void fullSymbolName(char *output, size_t outputSize, char *localName,
+			   const struct sSymbol *scope)
 {
 	const struct sSymbol *parent = scope->pScope ? scope->pScope : scope;
+	int n = snprintf(output, outputSize, "%s%s", parent->tzName, localName);
 
-	return snprintf(output, outputSize, "%s%s", parent->tzName, localName);
+	if (n >= (int)outputSize)
+		fatalerror("Symbol too long");
 }
 
 /*
@@ -561,9 +563,6 @@ void sym_AddSet(char *tzSym, int32_t value)
 void sym_AddLocalReloc(char *tzSym)
 {
 	if (pScope) {
-		if (strlen(tzSym) + strlen(pScope->tzName) > MAXSYMLEN)
-			fatalerror("Symbol too long");
-
 		char fullname[MAXSYMLEN + 1];
 
 		fullSymbolName(fullname, sizeof(fullname), tzSym, pScope);

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -207,7 +207,7 @@ struct sSymbol *findsymbol(char *s, struct sSymbol *scope)
 }
 
 /*
- * Find a symbol by name and scope
+ * Find a symbol by name, with automatically determined scope
  */
 struct sSymbol *sym_FindSymbol(char *tzName)
 {
@@ -256,14 +256,7 @@ void sym_Purge(char *tzName)
  */
 uint32_t sym_isConstDefined(char *tzName)
 {
-	struct sSymbol *psym, *pscope;
-
-	if (*tzName == '.')
-		pscope = pScope;
-	else
-		pscope = NULL;
-
-	psym = findsymbol(tzName, pscope);
+	struct sSymbol *psym = sym_FindSymbol(tzName);
 
 	if (psym && (psym->nType & SYMF_DEFINED)) {
 		uint32_t mask = SYMF_EQU | SYMF_SET | SYMF_MACRO | SYMF_STRING;
@@ -280,19 +273,9 @@ uint32_t sym_isConstDefined(char *tzName)
 
 uint32_t sym_isDefined(char *tzName)
 {
-	struct sSymbol *psym, *pscope;
+	struct sSymbol *psym = sym_FindSymbol(tzName);
 
-	if (*tzName == '.')
-		pscope = pScope;
-	else
-		pscope = NULL;
-
-	psym = findsymbol(tzName, pscope);
-
-	if (psym && (psym->nType & SYMF_DEFINED))
-		return 1;
-	else
-		return 0;
+	return (psym && (psym->nType & SYMF_DEFINED));
 }
 
 /*
@@ -300,21 +283,9 @@ uint32_t sym_isDefined(char *tzName)
  */
 uint32_t sym_isConstant(char *s)
 {
-	struct sSymbol *psym, *pscope;
+	struct sSymbol *psym = sym_FindSymbol(s);
 
-	if (*s == '.')
-		pscope = pScope;
-	else
-		pscope = NULL;
-
-	psym = findsymbol(s, pscope);
-
-	if (psym != NULL) {
-		if (psym->nType & SYMF_CONST)
-			return 1;
-	}
-
-	return 0;
+	return (psym && (psym->nType & SYMF_CONST));
 }
 
 /*
@@ -337,14 +308,7 @@ char *sym_GetStringValue(char *tzSym)
  */
 uint32_t sym_GetConstantValue(char *s)
 {
-	struct sSymbol *psym, *pscope;
-
-	if (*s == '.')
-		pscope = pScope;
-	else
-		pscope = NULL;
-
-	psym = findsymbol(s, pscope);
+	struct sSymbol *psym = sym_FindSymbol(s);
 
 	if (psym != NULL) {
 		if (psym->nType & SYMF_CONST)
@@ -363,14 +327,7 @@ uint32_t sym_GetConstantValue(char *s)
  */
 uint32_t sym_GetDefinedValue(char *s)
 {
-	struct sSymbol *psym, *pscope;
-
-	if (*s == '.')
-		pscope = pScope;
-	else
-		pscope = NULL;
-
-	psym = findsymbol(s, pscope);
+	struct sSymbol *psym = sym_FindSymbol(s);
 
 	if (psym != NULL) {
 		if ((psym->nType & SYMF_DEFINED)) {

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -714,7 +714,6 @@ void sym_AddMacro(char *tzSym)
 	struct sSymbol *nsym = createNonrelocSymbol(tzSym);
 
 	if (nsym) {
-		nsym->nValue = nPC;
 		nsym->nType |= SYMF_MACRO | SYMF_DEFINED;
 		nsym->pScope = NULL;
 		nsym->ulMacroSize = ulNewMacroSize;

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -161,7 +161,8 @@ static void fullSymbolName(char *output, size_t outputSize, char *localName,
 	int n = snprintf(output, outputSize, "%s%s", parent->tzName, localName);
 
 	if (n >= (int)outputSize)
-		fatalerror("Symbol too long");
+		fatalerror("Symbol name is too long: '%s%s'",
+			   parent->tzName, localName);
 }
 
 /*

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -359,50 +359,6 @@ uint32_t sym_GetConstantValue(char *s)
 }
 
 /*
- * Return a symbols value... "estimated" if not defined yet
- */
-uint32_t sym_GetValue(char *s)
-{
-	struct sSymbol *psym, *pscope;
-
-	if (*s == '.')
-		pscope = pScope;
-	else
-		pscope = NULL;
-
-	psym = findsymbol(s, pscope);
-
-	if (psym != NULL) {
-		if (psym->nType & SYMF_DEFINED) {
-			if (psym->nType & (SYMF_MACRO | SYMF_STRING))
-				yyerror("'%s' is a macro or string symbol", s);
-
-			return getvaluefield(psym);
-		}
-
-		if (nPass == 2) {
-			/*
-			 * Assume undefined symbols are imported from
-			 * somwehere else
-			 */
-			psym->nType |= SYMF_IMPORT;
-		}
-
-		/* 0x80 seems like a good default value... */
-		return 0x80;
-	}
-
-	if (nPass == 1) {
-		createsymbol(s);
-		return 0x80;
-	}
-
-	yyerror("'%s' not defined", s);
-
-	return 0;
-}
-
-/*
  * Return a defined symbols value... aborts if not defined yet
  */
 uint32_t sym_GetDefinedValue(char *s)
@@ -549,26 +505,24 @@ struct sSymbol *sym_FindMacro(char *s)
  */
 void sym_AddEqu(char *tzSym, int32_t value)
 {
-	if ((nPass == 1) || ((nPass == 2) && (sym_isDefined(tzSym) == 0))) {
-		/* only add equated symbols in pass 1 */
-		struct sSymbol *nsym = findsymbol(tzSym, NULL);
+	struct sSymbol *nsym = findsymbol(tzSym, NULL);
 
-		if (nsym != NULL) {
-			if (nsym->nType & SYMF_DEFINED) {
-				yyerror("'%s' already defined in %s(%d)", tzSym,
-					nsym->tzFileName, nsym->nFileLine);
-			}
-		} else {
-			nsym = createsymbol(tzSym);
+	if (nsym != NULL) {
+		if (nsym->nType & SYMF_DEFINED) {
+			yyerror("'%s' already defined in %s(%d)", tzSym,
+				nsym->tzFileName, nsym->nFileLine);
 		}
-
-		if (nsym) {
-			nsym->nValue = value;
-			nsym->nType |= SYMF_EQU | SYMF_DEFINED | SYMF_CONST;
-			nsym->pScope = NULL;
-			updateSymbolFilename(nsym);
-		}
+	} else {
+		nsym = createsymbol(tzSym);
 	}
+
+	if (nsym) {
+		nsym->nValue = value;
+		nsym->nType |= SYMF_EQU | SYMF_DEFINED | SYMF_CONST;
+		nsym->pScope = NULL;
+		updateSymbolFilename(nsym);
+	}
+
 }
 
 /*
@@ -669,59 +623,55 @@ void sym_AddLocalReloc(char *tzSym)
 void sym_AddReloc(char *tzSym)
 {
 	struct sSymbol *scope = NULL;
+	struct sSymbol *nsym;
+	char *localPtr = strchr(tzSym, '.');
 
-	if ((nPass == 1)
-	    || ((nPass == 2) && (sym_isDefined(tzSym) == 0))) {
-		/* only add reloc symbols in pass 1 */
-		struct sSymbol *nsym;
-		char *localPtr = strchr(tzSym, '.');
+	if (localPtr != NULL) {
+		if (!pScope)
+			fatalerror("Local label in main scope");
 
-		if (localPtr != NULL) {
-			if (!pScope)
-				fatalerror("Local label in main scope");
+		struct sSymbol *parent = pScope->pScope ?
+					 pScope->pScope : pScope;
+		uint32_t parentLen = localPtr - tzSym;
 
-			struct sSymbol *parent = pScope->pScope ?
-						 pScope->pScope : pScope;
-			uint32_t parentLen = localPtr - tzSym;
-
-			if (strchr(localPtr + 1, '.') != NULL) {
-				fatalerror("'%s' is a nonsensical reference to a nested local symbol",
-					   tzSym);
-			} else if (strlen(parent->tzName) != parentLen
-				   || strncmp(tzSym, parent->tzName, parentLen) != 0) {
-				yyerror("Not currently in the scope of '%.*s'",
-					parentLen, tzSym);
-			}
-
-			scope = parent;
+		if (strchr(localPtr + 1, '.') != NULL) {
+			fatalerror("'%s' is a nonsensical reference to a nested local symbol",
+				   tzSym);
+		} else if (strlen(parent->tzName) != parentLen
+			   || strncmp(tzSym, parent->tzName, parentLen) != 0) {
+			yyerror("Not currently in the scope of '%.*s'",
+				parentLen, tzSym);
 		}
 
-		nsym = findsymbol(tzSym, scope);
-
-		if (nsym != NULL) {
-			if (nsym->nType & SYMF_DEFINED) {
-				yyerror("'%s' already defined in %s(%d)", tzSym,
-					nsym->tzFileName, nsym->nFileLine);
-			}
-		} else {
-			nsym = createsymbol(tzSym);
-		}
-
-		if (nsym) {
-			nsym->nValue = nPC;
-			nsym->nType |= SYMF_RELOC | SYMF_DEFINED;
-			if (localPtr)
-				nsym->nType |= SYMF_LOCAL;
-
-			if (exportall)
-				nsym->nType |= SYMF_EXPORT;
-
-			nsym->pScope = scope;
-			nsym->pSection = pCurrentSection;
-
-			updateSymbolFilename(nsym);
-		}
+		scope = parent;
 	}
+
+	nsym = findsymbol(tzSym, scope);
+
+	if (nsym != NULL) {
+		if (nsym->nType & SYMF_DEFINED) {
+			yyerror("'%s' already defined in %s(%d)", tzSym,
+				nsym->tzFileName, nsym->nFileLine);
+		}
+	} else {
+		nsym = createsymbol(tzSym);
+	}
+
+	if (nsym) {
+		nsym->nValue = nPC;
+		nsym->nType |= SYMF_RELOC | SYMF_DEFINED;
+		if (localPtr)
+			nsym->nType |= SYMF_LOCAL;
+
+		if (exportall)
+			nsym->nType |= SYMF_EXPORT;
+
+		nsym->pScope = scope;
+		nsym->pSection = pCurrentSection;
+
+		updateSymbolFilename(nsym);
+	}
+
 	pScope = findsymbol(tzSym, scope);
 }
 
@@ -734,10 +684,6 @@ void sym_AddReloc(char *tzSym)
  */
 int32_t sym_IsRelocDiffDefined(char *tzSym1, char *tzSym2)
 {
-	/* Do nothing the first pass. */
-	if (nPass != 2)
-		return 1;
-
 	const struct sSymbol *nsym1 = sym_FindSymbol(tzSym1);
 	const struct sSymbol *nsym2 = sym_FindSymbol(tzSym2);
 
@@ -781,46 +727,13 @@ int32_t sym_IsRelocDiffDefined(char *tzSym1, char *tzSym2)
  */
 void sym_Export(char *tzSym)
 {
-	if (nPass == 1) {
-		/* only export symbols in pass 1 */
-		struct sSymbol *nsym = sym_FindSymbol(tzSym);
+	struct sSymbol *nsym = sym_FindSymbol(tzSym);
 
-		if (nsym == NULL)
-			nsym = createsymbol(tzSym);
+	if (nsym == NULL)
+		nsym = createsymbol(tzSym);
 
-		if (nsym)
-			nsym->nType |= SYMF_EXPORT;
-	} else {
-		const struct sSymbol *nsym = sym_FindSymbol(tzSym);
-
-		if (nsym != NULL) {
-			if (nsym->nType & SYMF_DEFINED)
-				return;
-		}
-		yyerror("'%s' not defined", tzSym);
-	}
-}
-
-/*
- * Globalize a symbol (export if defined, import if not)
- */
-void sym_Global(char *tzSym)
-{
-	if (nPass == 2) {
-		/* only globalize symbols in pass 2 */
-		struct sSymbol *nsym = sym_FindSymbol(tzSym);
-
-		if ((nsym == NULL) || ((nsym->nType & SYMF_DEFINED) == 0)) {
-			if (nsym == NULL)
-				nsym = createsymbol(tzSym);
-
-			if (nsym)
-				nsym->nType |= SYMF_IMPORT;
-		} else {
-			if (nsym)
-				nsym->nType |= SYMF_EXPORT;
-		}
-	}
+	if (nsym)
+		nsym->nType |= SYMF_EXPORT;
 }
 
 /*
@@ -828,30 +741,50 @@ void sym_Global(char *tzSym)
  */
 void sym_AddMacro(char *tzSym)
 {
-	if ((nPass == 1) || ((nPass == 2) && (sym_isDefined(tzSym) == 0))) {
-		/* only add macros in pass 1 */
-		struct sSymbol *nsym;
+	struct sSymbol *nsym;
 
-		nsym = findsymbol(tzSym, NULL);
+	nsym = findsymbol(tzSym, NULL);
 
-		if (nsym != NULL) {
-			if (nsym->nType & SYMF_DEFINED) {
-				yyerror("'%s' already defined in %s(%d)",
-					tzSym, nsym->tzFileName,
-					nsym->nFileLine);
-			}
-		} else {
-			nsym = createsymbol(tzSym);
+	if (nsym != NULL) {
+		if (nsym->nType & SYMF_DEFINED) {
+			yyerror("'%s' already defined in %s(%d)",
+				tzSym, nsym->tzFileName,
+				nsym->nFileLine);
+		}
+	} else {
+		nsym = createsymbol(tzSym);
+	}
+
+	if (nsym) {
+		nsym->nValue = nPC;
+		nsym->nType |= SYMF_MACRO | SYMF_DEFINED;
+		nsym->pScope = NULL;
+		nsym->ulMacroSize = ulNewMacroSize;
+		nsym->pMacro = tzNewMacro;
+		updateSymbolFilename(nsym);
+	}
+}
+
+/*
+ * Add a symbol that is being referenced ahead of its definition
+ */
+void sym_AddForwardRef(char *tzSym)
+{
+	if (sym_FindSymbol(tzSym) == NULL) {
+		char fullname[MAXSYMLEN + 1];
+		int isLocal = 0;
+
+		if (*tzSym == '.') {
+			fullSymbolName(fullname, sizeof(fullname), tzSym,
+				       pScope);
+			tzSym = fullname;
+			isLocal = 1;
 		}
 
-		if (nsym) {
-			nsym->nValue = nPC;
-			nsym->nType |= SYMF_MACRO | SYMF_DEFINED;
-			nsym->pScope = NULL;
-			nsym->ulMacroSize = ulNewMacroSize;
-			nsym->pMacro = tzNewMacro;
-			updateSymbolFilename(nsym);
-		}
+		struct sSymbol *nsym = createsymbol(tzSym);
+
+		if (nsym && isLocal)
+			nsym->nType |= SYMF_LOCAL;
 	}
 }
 
@@ -861,66 +794,6 @@ void sym_AddMacro(char *tzSym)
 void sym_SetExportAll(uint8_t set)
 {
 	exportall = set;
-}
-
-/*
- * Prepare for pass #1
- */
-void sym_PrepPass1(void)
-{
-	sym_Init();
-}
-
-/*
- * Prepare for pass #2
- */
-void sym_PrepPass2(void)
-{
-	int32_t i;
-
-	for (i = 0; i < HASHSIZE; i += 1) {
-		struct sSymbol **ppSym = &(tHashedSymbols[i]);
-
-		while (*ppSym) {
-			uint32_t mask = SYMF_SET | SYMF_STRING | SYMF_EQU;
-
-			if ((*ppSym)->nType & mask) {
-				struct sSymbol *pTemp;
-
-				pTemp = (*ppSym)->pNext;
-				free(*ppSym);
-				*ppSym = pTemp;
-			} else {
-				ppSym = &((*ppSym)->pNext);
-			}
-		}
-	}
-	pScope = NULL;
-	pPCSymbol->nValue = 0;
-
-	sym_AddString("__TIME__", SavedTIME);
-	sym_AddString("__DATE__", SavedDATE);
-	sym_AddString("__ISO_8601_LOCAL__", SavedTIMESTAMP_ISO8601_LOCAL);
-	sym_AddString("__ISO_8601_UTC__", SavedTIMESTAMP_ISO8601_UTC);
-	sym_AddString("__UTC_DAY__", SavedDAY);
-	sym_AddString("__UTC_MONTH__", SavedMONTH);
-	sym_AddString("__UTC_YEAR__", SavedYEAR);
-	sym_AddString("__UTC_HOUR__", SavedHOUR);
-	sym_AddString("__UTC_MINUTE__", SavedMINUTE);
-	sym_AddString("__UTC_SECOND__", SavedSECOND);
-	sym_AddEqu("__RGBDS_MAJOR__", PACKAGE_VERSION_MAJOR);
-	sym_AddEqu("__RGBDS_MINOR__", PACKAGE_VERSION_MINOR);
-	sym_AddEqu("__RGBDS_PATCH__", PACKAGE_VERSION_PATCH);
-	sym_AddSet("_RS", 0);
-
-	sym_AddEqu("_NARG", 0);
-	p_NARGSymbol = findsymbol("_NARG", NULL);
-	p_NARGSymbol->Callback = Callback_NARG;
-	sym_AddEqu("__LINE__", 0);
-	p__LINE__Symbol = findsymbol("__LINE__", NULL);
-	p__LINE__Symbol->Callback = Callback__LINE__;
-
-	math_DefinePI();
 }
 
 /*

--- a/test/asm/label-redefinition.out
+++ b/test/asm/label-redefinition.out
@@ -1,3 +1,3 @@
 ERROR: label-redefinition.asm(7):
     'Sym' already defined in m(6)
-error: Assembly aborted in pass 1 (1 errors)!
+error: Assembly aborted (1 errors)!

--- a/test/asm/local-wrong-parent.out
+++ b/test/asm/local-wrong-parent.out
@@ -1,3 +1,3 @@
 ERROR: local-wrong-parent.asm(5):
     Not currently in the scope of 'WrongParent'
-error: Assembly aborted in pass 1 (1 errors)!
+error: Assembly aborted (1 errors)!

--- a/test/asm/reference-undefined-sym.asm
+++ b/test/asm/reference-undefined-sym.asm
@@ -1,0 +1,4 @@
+SECTION "sec", ROM0
+	db X
+
+X = 2

--- a/test/asm/reference-undefined-sym.out
+++ b/test/asm/reference-undefined-sym.out
@@ -1,0 +1,3 @@
+ERROR: reference-undefined-sym.asm(4):
+    'X' already referenced at reference-undefined-sym.asm(2)
+error: Assembly aborted (1 errors)!

--- a/test/asm/undefined-dot.out
+++ b/test/asm/undefined-dot.out
@@ -1,3 +1,1 @@
-ERROR: undefined-dot.asm(3):
-    '.' not defined
-error: Assembly aborted in pass 2 (1 errors)!
+error: undefined-dot.asm(3) : '.' not defined


### PR DESCRIPTION
I'm not sure if this should actually be done. It's more of a proof of concept right now. I've tested it and everything seems to work fine.

The only difference I've seen is that local labels which are undefined now have to be reported when outputting patches instead of the time when the offending instruction is being processed. This required the error output for the "undefined-dot" test to change.