### PR TITLE
Have a docker file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# This file is part of RGBDS.
+#
+# Copyright (c) 2018-2019, Phil Smith and RGBDS contributors.
+#
+# SPDX-License-Identifier: MIT
+.git
+docs

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -41,3 +41,5 @@ Other contributors
 - YamaArashi <shadow962@live.com>
 
 - yenatch <yenatch@gmail.com>
+
+- phs <phil@philhsmith.com>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# This file is part of RGBDS.
+#
+# Copyright (c) 2018-2019, Phil Smith and RGBDS contributors.
+#
+# SPDX-License-Identifier: MIT
+# docker build -t rgbds:vX.X.X-alpine
+FROM alpine:latest
+RUN apk add --update \
+      build-base \
+      byacc \
+      flex \
+      libpng-dev
+COPY . /rgbds
+WORKDIR /rgbds
+RUN make Q='' all
+
+FROM alpine:latest
+RUN apk add --update \
+      libpng
+COPY --from=0 \
+  /rgbds/rgbasm \
+  /rgbds/rgbfix \
+  /rgbds/rgblink \
+  /rgbds/rgbgfx \
+  /bin/


### PR DESCRIPTION
This allows packaging rgbds as a docker image, which can be useful for CI pipelines.