### PR TITLE
gfx: Add mirrored tile check when generating tilemap

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -36,6 +36,8 @@ Other contributors
 
 - The OpenBSD Project <http://www.openbsd.org>
 
+- Quint Guvernator <quint@guvernator.net>
+
 - Sanqui <gsanky@gmail.com>
 
 - YamaArashi <shadow962@live.com>

--- a/docs/gbz80.7.html
+++ b/docs/gbz80.7.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html>
+<!-- This is an automatically generated file.  Do not edit.
+   This file is part of RGBDS.
+
+   Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
+
+   SPDX-License-Identifier: MIT
+   -->
 <head>
   <meta charset="utf-8"/>
-  <style>
-    table.head, table.foot { width: 100%; }
-    td.head-rtitle, td.foot-os { text-align: right; }
-    td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-  </style>
   <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
   <title>GBZ80(7)</title>
 </head>
@@ -20,1691 +21,1442 @@
   </tr>
 </table>
 <div class="manual-text">
-<h1 class="Sh" title="Sh" id="NAME"><a class="selflink" href="#NAME">NAME</a></h1>
-<b class="Nm" title="Nm">gbz80</b> &#x2014; <span class="Nd" title="Nd">CPU
-  opcode reference</span>
-<h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="selflink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-This is the list of opcodes supported by <a class="Xr" title="Xr">rgbasm(1)</a>,
-  including a short description, the number of bytes needed to encode them and
-  the number of CPU cycles at 1MHz (or 2MHz in GBC dual speed mode) needed to
-  complete them.
-<div class="Pp"></div>
-Note: All arithmetic/logic operations that use register
-  <b class="Sy" title="Sy">A</b> as destination can omit the destination as it
-  is assumed it's register <b class="Sy" title="Sy">A</b>. The following two
-  lines have the same effect:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-OR A,B 
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<code class="Nm">gbz80</code> &#x2014;
+<div class="Nd">CPU opcode reference</div>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+This is the list of opcodes supported by <a class="Xr">rgbasm(1)</a>, including
+  a short description, the number of bytes needed to encode them and the number
+  of CPU cycles at 1MHz (or 2MHz in GBC dual speed mode) needed to complete
+  them.
+<p class="Pp">Note: All arithmetic/logic operations that use register
+    <b class="Sy">A</b> as destination can omit the destination as it is assumed
+    it's register <b class="Sy">A</b>. The following two lines have the same
+    effect:</p>
+<div class="Bd Pp Bd-indent">
+<pre>
+OR A,B
 OR B
 </pre>
 </div>
-<h1 class="Sh" title="Sh" id="LEGEND"><a class="selflink" href="#LEGEND">LEGEND</a></h1>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="LEGEND"><a class="permalink" href="#LEGEND">LEGEND</a></h1>
 List of abbreviations used in this document.
 <dl class="Bl-tag">
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><var class="Ar" title="Ar">r8</var></dt>
-  <dd class="It-tag">Any of the 8-bit registers (<b class="Sy" title="Sy">A</b>,
-      <b class="Sy" title="Sy">B</b>, <b class="Sy" title="Sy">C</b>,
-      <b class="Sy" title="Sy">D</b>, <b class="Sy" title="Sy">E</b>,
-      <b class="Sy" title="Sy">H</b>, <b class="Sy" title="Sy">L</b>).</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><var class="Ar" title="Ar">r16</var></dt>
-  <dd class="It-tag">Any of the general-purpose 16-bit registers
-      (<b class="Sy" title="Sy">BC</b>, <b class="Sy" title="Sy">DE</b>,
-      <b class="Sy" title="Sy">HL</b>).</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><var class="Ar" title="Ar">n8</var></dt>
-  <dd class="It-tag">8-bit integer constant.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><var class="Ar" title="Ar">n16</var></dt>
-  <dd class="It-tag">16-bit integer constant.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><var class="Ar" title="Ar">e8</var></dt>
-  <dd class="It-tag">8-bit offset
-      (<b class="Fl" title="Fl">-</b><b class="Sy" title="Sy">128</b> to
-      <b class="Sy" title="Sy">127</b>).</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><var class="Ar" title="Ar">u3</var></dt>
-  <dd class="It-tag">3-bit unsigned integer constant
-      (<b class="Sy" title="Sy">0</b> to <b class="Sy" title="Sy">7</b>).</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><var class="Ar" title="Ar">cc</var></dt>
-  <dd class="It-tag">Condition codes:
+  <dt><var class="Ar">r8</var></dt>
+  <dd>Any of the 8-bit registers (<b class="Sy">A</b>, <b class="Sy">B</b>,
+      <b class="Sy">C</b>, <b class="Sy">D</b>, <b class="Sy">E</b>,
+      <b class="Sy">H</b>, <b class="Sy">L</b>).</dd>
+  <dt><var class="Ar">r16</var></dt>
+  <dd>Any of the general-purpose 16-bit registers (<b class="Sy">BC</b>,
+      <b class="Sy">DE</b>, <b class="Sy">HL</b>).</dd>
+  <dt><var class="Ar">n8</var></dt>
+  <dd>8-bit integer constant.</dd>
+  <dt><var class="Ar">n16</var></dt>
+  <dd>16-bit integer constant.</dd>
+  <dt><var class="Ar">e8</var></dt>
+  <dd>8-bit offset (<code class="Fl">-</code><b class="Sy">128</b> to
+      <b class="Sy">127</b>).</dd>
+  <dt><var class="Ar">u3</var></dt>
+  <dd>3-bit unsigned integer constant (<b class="Sy">0</b> to
+      <b class="Sy">7</b>).</dd>
+  <dt><var class="Ar">cc</var></dt>
+  <dd>Condition codes:
     <dl class="Bl-tag Bl-compact">
-      <dt class="It-tag"><b class="Sy" title="Sy">Z</b>:</dt>
-      <dd class="It-tag">Execute if Z is set.</dd>
-      <dt class="It-tag"><b class="Sy" title="Sy">NZ</b>:</dt>
-      <dd class="It-tag">Execute if Z is not set.</dd>
-      <dt class="It-tag"><b class="Sy" title="Sy">C</b>:</dt>
-      <dd class="It-tag">Execute if C is set.</dd>
-      <dt class="It-tag"><b class="Sy" title="Sy">NC</b>:</dt>
-      <dd class="It-tag">Execute if C is not set.</dd>
+      <dt><b class="Sy">Z</b>:</dt>
+      <dd>Execute if Z is set.</dd>
+      <dt><b class="Sy">NZ</b>:</dt>
+      <dd>Execute if Z is not set.</dd>
+      <dt><b class="Sy">C</b>:</dt>
+      <dd>Execute if C is set.</dd>
+      <dt><b class="Sy">NC</b>:</dt>
+      <dd>Execute if C is not set.</dd>
     </dl>
   </dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><var class="Ar" title="Ar">vec</var></dt>
-  <dd class="It-tag">One of the <var class="Ar" title="Ar">RST</var> vectors
-      (<b class="Sy" title="Sy">0x00</b>, <b class="Sy" title="Sy">0x08</b>,
-      <b class="Sy" title="Sy">0x10</b>, <b class="Sy" title="Sy">0x18</b>,
-      <b class="Sy" title="Sy">0x20</b>, <b class="Sy" title="Sy">0x28</b>,
-      <b class="Sy" title="Sy">0x30</b> and
-    <b class="Sy" title="Sy">0x38</b>).</dd>
+  <dt><var class="Ar">vec</var></dt>
+  <dd>One of the <var class="Ar">RST</var> vectors (<b class="Sy">0x00</b>,
+      <b class="Sy">0x08</b>, <b class="Sy">0x10</b>, <b class="Sy">0x18</b>,
+      <b class="Sy">0x20</b>, <b class="Sy">0x28</b>, <b class="Sy">0x30</b> and
+      <b class="Sy">0x38</b>).</dd>
 </dl>
-<h1 class="Sh" title="Sh" id="INSTRUCTION_OVERVIEW"><a class="selflink" href="#INSTRUCTION_OVERVIEW">INSTRUCTION
+</section>
+<section class="Sh">
+<h1 class="Sh" id="INSTRUCTION_OVERVIEW"><a class="permalink" href="#INSTRUCTION_OVERVIEW">INSTRUCTION
   OVERVIEW</a></h1>
-<h2 class="Ss" title="Ss" id="8-bit_Arithmetic_and_Logic_Instructions"><a class="selflink" href="#8-bit_Arithmetic_and_Logic_Instructions">8-bit
+<section class="Ss">
+<h2 class="Ss" id="8-bit_Arithmetic_and_Logic_Instructions"><a class="permalink" href="#8-bit_Arithmetic_and_Logic_Instructions">8-bit
   Arithmetic and Logic Instructions</a></h2>
 <dl class="Bl-inset Bl-compact">
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#ADC_A,r8">ADC
-    A,r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#ADC_A,[HL]">ADC
-    A,[HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#ADC_A,n8">ADC
-    A,n8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#ADD_A,r8">ADD
-    A,r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#ADD_A,[HL]">ADD
-    A,[HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#ADD_A,n8">ADD
-    A,n8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#AND_A,r8">AND
-    A,r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#AND_A,[HL]">AND
-    A,[HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#AND_A,n8">AND
-    A,n8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#CP_A,r8">CP A,r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#CP_A,[HL]">CP
-    A,[HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#CP_A,n8">CP A,n8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#DEC_r8">DEC r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#DEC_[HL]">DEC
-    [HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#INC_r8">INC r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#INC_[HL]">INC
-    [HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#OR_A,r8">OR A,r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#OR_A,[HL]">OR
-    A,[HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#OR_A,n8">OR A,n8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SBC_A,r8">SBC
-    A,r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SBC_A,[HL]">SBC
-    A,[HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SBC_A,n8">SBC
-    A,n8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SUB_A,r8">SUB
-    A,r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SUB_A,[HL]">SUB
-    A,[HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SUB_A,n8">SUB
-    A,n8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#XOR_A,r8">XOR
-    A,r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#XOR_A,[HL]">XOR
-    A,[HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#XOR_A,n8">XOR
-    A,n8</a></dt>
-  <dd class="It-inset"></dd>
+  <dt><a class="Sx" href="#ADC_A,r8">ADC A,r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#ADC_A,_HL_">ADC A,[HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#ADC_A,n8">ADC A,n8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#ADD_A,r8">ADD A,r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#ADD_A,_HL_">ADD A,[HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#ADD_A,n8">ADD A,n8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#AND_A,r8">AND A,r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#AND_A,_HL_">AND A,[HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#AND_A,n8">AND A,n8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#CP_A,r8">CP A,r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#CP_A,_HL_">CP A,[HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#CP_A,n8">CP A,n8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#DEC_r8">DEC r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#DEC__HL_">DEC [HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#INC_r8">INC r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#INC__HL_">INC [HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#OR_A,r8">OR A,r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#OR_A,_HL_">OR A,[HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#OR_A,n8">OR A,n8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SBC_A,r8">SBC A,r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SBC_A,_HL_">SBC A,[HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SBC_A,n8">SBC A,n8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SUB_A,r8">SUB A,r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SUB_A,_HL_">SUB A,[HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SUB_A,n8">SUB A,n8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#XOR_A,r8">XOR A,r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#XOR_A,_HL_">XOR A,[HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#XOR_A,n8">XOR A,n8</a></dt>
+  <dd></dd>
 </dl>
-<h2 class="Ss" title="Ss" id="16-bit_Arithmetic_Instructions"><a class="selflink" href="#16-bit_Arithmetic_Instructions">16-bit
+</section>
+<section class="Ss">
+<h2 class="Ss" id="16-bit_Arithmetic_Instructions"><a class="permalink" href="#16-bit_Arithmetic_Instructions">16-bit
   Arithmetic Instructions</a></h2>
 <dl class="Bl-inset Bl-compact">
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#ADD_HL,r16">ADD
-    HL,r16</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#DEC_r16">DEC r16</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#INC_r16">INC r16</a></dt>
-  <dd class="It-inset"></dd>
+  <dt><a class="Sx" href="#ADD_HL,r16">ADD HL,r16</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#DEC_r16">DEC r16</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#INC_r16">INC r16</a></dt>
+  <dd></dd>
 </dl>
-<h2 class="Ss" title="Ss" id="Bit_Operations_Instructions"><a class="selflink" href="#Bit_Operations_Instructions">Bit
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Bit_Operations_Instructions"><a class="permalink" href="#Bit_Operations_Instructions">Bit
   Operations Instructions</a></h2>
 <dl class="Bl-inset Bl-compact">
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#BIT_u3,r8">BIT
-    u3,r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#BIT_u3,[HL]">BIT
-    u3,[HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RES_u3,r8">RES
-    u3,r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RES_u3,[HL]">RES
-    u3,[HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SET_u3,r8">SET
-    u3,r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SET_u3,[HL]">SET
-    u3,[HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SWAP_r8">SWAP r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SWAP_[HL]">SWAP
-    [HL]</a></dt>
-  <dd class="It-inset"></dd>
+  <dt><a class="Sx" href="#BIT_u3,r8">BIT u3,r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#BIT_u3,_HL_">BIT u3,[HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RES_u3,r8">RES u3,r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RES_u3,_HL_">RES u3,[HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SET_u3,r8">SET u3,r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SET_u3,_HL_">SET u3,[HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SWAP_r8">SWAP r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SWAP__HL_">SWAP [HL]</a></dt>
+  <dd></dd>
 </dl>
-<h2 class="Ss" title="Ss" id="Bit_Shift_Instructions"><a class="selflink" href="#Bit_Shift_Instructions">Bit
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Bit_Shift_Instructions"><a class="permalink" href="#Bit_Shift_Instructions">Bit
   Shift Instructions</a></h2>
 <dl class="Bl-inset Bl-compact">
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RL_r8">RL r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RL_[HL]">RL [HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RLA">RLA</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RLC_r8">RLC r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RLC_[HL]">RLC
-    [HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RLCA">RLCA</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RR_r8">RR r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RR_[HL]">RR [HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RRA">RRA</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RRC_r8">RRC r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RRC_[HL]">RRC
-    [HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RRCA">RRCA</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SLA_r8">SLA r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SLA_[HL]">SLA
-    [HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SRA_r8">SRA r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SRA_[HL]">SRA
-    [HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SRL_r8">SRL r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SRL_[HL]">SRL
-    [HL]</a></dt>
-  <dd class="It-inset"></dd>
+  <dt><a class="Sx" href="#RL_r8">RL r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RL__HL_">RL [HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RLA">RLA</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RLC_r8">RLC r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RLC__HL_">RLC [HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RLCA">RLCA</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RR_r8">RR r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RR__HL_">RR [HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RRA">RRA</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RRC_r8">RRC r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RRC__HL_">RRC [HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RRCA">RRCA</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SLA_r8">SLA r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SLA__HL_">SLA [HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SRA_r8">SRA r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SRA__HL_">SRA [HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SRL_r8">SRL r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SRL__HL_">SRL [HL]</a></dt>
+  <dd></dd>
 </dl>
-<h2 class="Ss" title="Ss" id="Load_Instructions"><a class="selflink" href="#Load_Instructions">Load
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Load_Instructions"><a class="permalink" href="#Load_Instructions">Load
   Instructions</a></h2>
 <dl class="Bl-inset Bl-compact">
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_r8,r8">LD
-    r8,r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_r8,n8">LD
-    r8,n8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_r16,n16">LD
-    r16,n16</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_[HL],r8">LD
-    [HL],r8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_[HL],n8">LD
-    [HL],n8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_r8,[HL]">LD
-    r8,[HL]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_[r16],A">LD
-    [r16],A</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_[n16],A">LD
-    [n16],A</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_[$FF00+n8],A">LD
-    [$FF00+n8],A</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_[$FF00+C],A">LD
-    [$FF00+C],A</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_A,[r16]">LD
-    A,[r16]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_A,[n16]">LD
-    A,[n16]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_A,[$FF00+n8]">LD
-    A,[$FF00+n8]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_A,[$FF00+C]">LD
-    A,[$FF00+C]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_[HL+],A">LD
-    [HL+],A</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_[HL-],A">LD
-    [HL-],A</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_A,[HL+]">LD
-    A,[HL+]</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_A,[HL-]">LD
-    A,[HL-]</a></dt>
-  <dd class="It-inset"></dd>
+  <dt><a class="Sx" href="#LD_r8,r8">LD r8,r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD_r8,n8">LD r8,n8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD_r16,n16">LD r16,n16</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD__HL_,r8">LD [HL],r8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD__HL_,n8">LD [HL],n8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD_r8,_HL_">LD r8,[HL]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD__r16_,A">LD [r16],A</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD__n16_,A">LD [n16],A</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD__$FF00+n8_,A">LD [$FF00+n8],A</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD__$FF00+C_,A">LD [$FF00+C],A</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD_A,_r16_">LD A,[r16]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD_A,_n16_">LD A,[n16]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD_A,_$FF00+n8_">LD A,[$FF00+n8]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD_A,_$FF00+C_">LD A,[$FF00+C]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD__HL+_,A">LD [HL+],A</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD__HL-_,A">LD [HL-],A</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD_A,_HL+_">LD A,[HL+]</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD_A,_HL-_">LD A,[HL-]</a></dt>
+  <dd></dd>
 </dl>
-<h2 class="Ss" title="Ss" id="Jumps_and_Subroutines"><a class="selflink" href="#Jumps_and_Subroutines">Jumps
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Jumps_and_Subroutines"><a class="permalink" href="#Jumps_and_Subroutines">Jumps
   and Subroutines</a></h2>
 <dl class="Bl-inset Bl-compact">
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#CALL_n16">CALL
-    n16</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#CALL_cc,n16">CALL
-    cc,n16</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#JP_HL">JP HL</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#JP_n16">JP n16</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#JP_cc,n16">JP
-    cc,n16</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#JR_e8">JR e8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#JR_cc,e8">JR
-    cc,e8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RET_cc">RET cc</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RET">RET</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RETI">RETI</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#RST_vec">RST vec</a></dt>
-  <dd class="It-inset"></dd>
+  <dt><a class="Sx" href="#CALL_n16">CALL n16</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#CALL_cc,n16">CALL cc,n16</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#JP_HL">JP HL</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#JP_n16">JP n16</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#JP_cc,n16">JP cc,n16</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#JR_e8">JR e8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#JR_cc,e8">JR cc,e8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RET_cc">RET cc</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RET">RET</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RETI">RETI</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#RST_vec">RST vec</a></dt>
+  <dd></dd>
 </dl>
-<h2 class="Ss" title="Ss" id="Stack_Operations_Instructions"><a class="selflink" href="#Stack_Operations_Instructions">Stack
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Stack_Operations_Instructions"><a class="permalink" href="#Stack_Operations_Instructions">Stack
   Operations Instructions</a></h2>
 <dl class="Bl-inset Bl-compact">
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#ADD_HL,SP">ADD
-    HL,SP</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#ADD_SP,e8">ADD
-    SP,e8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#DEC_SP">DEC SP</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#INC_SP">INC SP</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_SP,n16">LD
-    SP,n16</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_[n16],SP">LD
-    [n16],SP</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_HL,SP+e8">LD
-    HL,SP+e8</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#LD_SP,HL">LD
-    SP,HL</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#POP_AF">POP AF</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#POP_r16">POP r16</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#PUSH_AF">PUSH AF</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#PUSH_r16">PUSH
-    r16</a></dt>
-  <dd class="It-inset"></dd>
+  <dt><a class="Sx" href="#ADD_HL,SP">ADD HL,SP</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#ADD_SP,e8">ADD SP,e8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#DEC_SP">DEC SP</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#INC_SP">INC SP</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD_SP,n16">LD SP,n16</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD__n16_,SP">LD [n16],SP</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD_HL,SP+e8">LD HL,SP+e8</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#LD_SP,HL">LD SP,HL</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#POP_AF">POP AF</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#POP_r16">POP r16</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#PUSH_AF">PUSH AF</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#PUSH_r16">PUSH r16</a></dt>
+  <dd></dd>
 </dl>
-<h2 class="Ss" title="Ss" id="Miscellaneous_Instructions"><a class="selflink" href="#Miscellaneous_Instructions">Miscellaneous
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Miscellaneous_Instructions"><a class="permalink" href="#Miscellaneous_Instructions">Miscellaneous
   Instructions</a></h2>
 <dl class="Bl-inset Bl-compact">
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#CCF">CCF</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#CPL">CPL</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#DAA">DAA</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#DI">DI</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#EI">EI</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#HALT">HALT</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#NOP">NOP</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#SCF">SCF</a></dt>
-  <dd class="It-inset"></dd>
-  <dt class="It-inset"><a class="Sx" title="Sx" href="#STOP">STOP</a></dt>
-  <dd class="It-inset"></dd>
+  <dt><a class="Sx" href="#CCF">CCF</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#CPL">CPL</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#DAA">DAA</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#DI">DI</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#EI">EI</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#HALT">HALT</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#NOP">NOP</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#SCF">SCF</a></dt>
+  <dd></dd>
+  <dt><a class="Sx" href="#STOP">STOP</a></dt>
+  <dd></dd>
 </dl>
-<h1 class="Sh" title="Sh" id="INSTRUCTION_REFERENCE"><a class="selflink" href="#INSTRUCTION_REFERENCE">INSTRUCTION
+</section>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="INSTRUCTION_REFERENCE"><a class="permalink" href="#INSTRUCTION_REFERENCE">INSTRUCTION
   REFERENCE</a></h1>
-<h2 class="Ss" title="Ss" id="ADC_A,r8"><a class="selflink" href="#ADC_A,r8">ADC
+<section class="Ss">
+<h2 class="Ss" id="ADC_A,r8"><a class="permalink" href="#ADC_A,r8">ADC
   A,r8</a></h2>
-Add the value in <var class="Ar" title="Ar">r8</var> plus the carry flag to
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Add the value in <var class="Ar">r8</var> plus the carry flag to
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: Set if overflow from bit
-      3.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set if overflow from bit
-      7.</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: Set if overflow from bit 3.</li>
+  <li><b class="Sy">C</b>: Set if overflow from bit 7.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="ADC_A,[HL]"><a class="selflink" href="#ADC_A,[HL]">ADC
+</section>
+<section class="Ss">
+<h2 class="Ss" id="ADC_A,_HL_"><a class="permalink" href="#ADC_A,_HL_">ADC
   A,[HL]</a></h2>
-Add the value pointed by <b class="Sy" title="Sy">HL</b> plus the carry flag to
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#ADC_A,r8">ADC A,r8</a>
-<h2 class="Ss" title="Ss" id="ADC_A,n8"><a class="selflink" href="#ADC_A,n8">ADC
+Add the value pointed by <b class="Sy">HL</b> plus the carry flag to
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: See <a class="Sx" href="#ADC_A,r8">ADC A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="ADC_A,n8"><a class="permalink" href="#ADC_A,n8">ADC
   A,n8</a></h2>
-Add the value <var class="Ar" title="Ar">n8</var> plus the carry flag to
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#ADC_A,r8">ADC A,r8</a>
-<h2 class="Ss" title="Ss" id="ADD_A,r8"><a class="selflink" href="#ADD_A,r8">ADD
+Add the value <var class="Ar">n8</var> plus the carry flag to
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#ADC_A,r8">ADC A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="ADD_A,r8"><a class="permalink" href="#ADD_A,r8">ADD
   A,r8</a></h2>
-Add the value in <var class="Ar" title="Ar">r8</var> to
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Add the value in <var class="Ar">r8</var> to <b class="Sy">A</b>.
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: Set if overflow from bit
-      3.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set if overflow from bit
-      7.</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: Set if overflow from bit 3.</li>
+  <li><b class="Sy">C</b>: Set if overflow from bit 7.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="ADD_A,[HL]"><a class="selflink" href="#ADD_A,[HL]">ADD
+</section>
+<section class="Ss">
+<h2 class="Ss" id="ADD_A,_HL_"><a class="permalink" href="#ADD_A,_HL_">ADD
   A,[HL]</a></h2>
-Add the value pointed by <b class="Sy" title="Sy">HL</b> to
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#ADD_A,r8">ADD A,r8</a>
-<h2 class="Ss" title="Ss" id="ADD_A,n8"><a class="selflink" href="#ADD_A,n8">ADD
+Add the value pointed by <b class="Sy">HL</b> to <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: See <a class="Sx" href="#ADD_A,r8">ADD A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="ADD_A,n8"><a class="permalink" href="#ADD_A,n8">ADD
   A,n8</a></h2>
-Add the value <var class="Ar" title="Ar">n8</var> to
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#ADD_A,r8">ADD A,r8</a>
-<h2 class="Ss" title="Ss" id="ADD_HL,r16"><a class="selflink" href="#ADD_HL,r16">ADD
+Add the value <var class="Ar">n8</var> to <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#ADD_A,r8">ADD A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="ADD_HL,r16"><a class="permalink" href="#ADD_HL,r16">ADD
   HL,r16</a></h2>
-Add the value in <var class="Ar" title="Ar">r16</var> to
-  <b class="Sy" title="Sy">HL</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Add the value in <var class="Ar">r16</var> to <b class="Sy">HL</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: Set if overflow from bit
-      11.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set if overflow from bit
-      15.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: Set if overflow from bit 11.</li>
+  <li><b class="Sy">C</b>: Set if overflow from bit 15.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="ADD_HL,SP"><a class="selflink" href="#ADD_HL,SP">ADD
+</section>
+<section class="Ss">
+<h2 class="Ss" id="ADD_HL,SP"><a class="permalink" href="#ADD_HL,SP">ADD
   HL,SP</a></h2>
-Add the value in <b class="Sy" title="Sy">SP</b> to
-  <b class="Sy" title="Sy">HL</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#ADD_HL,r16">ADD HL,r16</a>
-<h2 class="Ss" title="Ss" id="ADD_SP,e8"><a class="selflink" href="#ADD_SP,e8">ADD
+Add the value in <b class="Sy">SP</b> to <b class="Sy">HL</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: See <a class="Sx" href="#ADD_HL,r16">ADD HL,r16</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="ADD_SP,e8"><a class="permalink" href="#ADD_SP,e8">ADD
   SP,e8</a></h2>
-Add the signed value <var class="Ar" title="Ar">e8</var> to
-  <b class="Sy" title="Sy">SP</b>.
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags:
+Add the signed value <var class="Ar">e8</var> to <b class="Sy">SP</b>.
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: Set if overflow from bit
-      3.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set if overflow from bit
-      7.</li>
+  <li><b class="Sy">Z</b>: 0</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: Set if overflow from bit 3.</li>
+  <li><b class="Sy">C</b>: Set if overflow from bit 7.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="AND_A,r8"><a class="selflink" href="#AND_A,r8">AND
+</section>
+<section class="Ss">
+<h2 class="Ss" id="AND_A,r8"><a class="permalink" href="#AND_A,r8">AND
   A,r8</a></h2>
-Bitwise AND between the value in <var class="Ar" title="Ar">r8</var> and
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Bitwise AND between the value in <var class="Ar">r8</var> and
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 1</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: 0</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 1</li>
+  <li><b class="Sy">C</b>: 0</li>
 </ul>
-<h2 class="Ss" title="Ss" id="AND_A,[HL]"><a class="selflink" href="#AND_A,[HL]">AND
+</section>
+<section class="Ss">
+<h2 class="Ss" id="AND_A,_HL_"><a class="permalink" href="#AND_A,_HL_">AND
   A,[HL]</a></h2>
-Bitwise AND between the value pointed by <b class="Sy" title="Sy">HL</b> and
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#AND_A,r8">AND A,r8</a>
-<h2 class="Ss" title="Ss" id="AND_A,n8"><a class="selflink" href="#AND_A,n8">AND
+Bitwise AND between the value pointed by <b class="Sy">HL</b> and
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: See <a class="Sx" href="#AND_A,r8">AND A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="AND_A,n8"><a class="permalink" href="#AND_A,n8">AND
   A,n8</a></h2>
-Bitwise AND between the value in <var class="Ar" title="Ar">n8</var> and
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#AND_A,r8">AND A,r8</a>
-<h2 class="Ss" title="Ss" id="BIT_u3,r8"><a class="selflink" href="#BIT_u3,r8">BIT
+Bitwise AND between the value in <var class="Ar">n8</var> and
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#AND_A,r8">AND A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="BIT_u3,r8"><a class="permalink" href="#BIT_u3,r8">BIT
   u3,r8</a></h2>
-Test bit <var class="Ar" title="Ar">u3</var> in register
-  <var class="Ar" title="Ar">r8</var>, set the zero flag if bit not set.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags:
+Test bit <var class="Ar">u3</var> in register <var class="Ar">r8</var>, set the
+  zero flag if bit not set.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if the selected bit
-      is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 1</li>
+  <li><b class="Sy">Z</b>: Set if the selected bit is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 1</li>
 </ul>
-<h2 class="Ss" title="Ss" id="BIT_u3,[HL]"><a class="selflink" href="#BIT_u3,[HL]">BIT
+</section>
+<section class="Ss">
+<h2 class="Ss" id="BIT_u3,_HL_"><a class="permalink" href="#BIT_u3,_HL_">BIT
   u3,[HL]</a></h2>
-Test bit <var class="Ar" title="Ar">u3</var> in the byte pointed by
-  <b class="Sy" title="Sy">HL</b>, set the zero flag if bit not set.
-<div class="Pp"></div>
-Cycles: 3
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#BIT_u3,r8">BIT u3,r8</a>
-<h2 class="Ss" title="Ss" id="CALL_n16"><a class="selflink" href="#CALL_n16">CALL
+Test bit <var class="Ar">u3</var> in the byte pointed by <b class="Sy">HL</b>,
+  set the zero flag if bit not set.
+<p class="Pp">Cycles: 3</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#BIT_u3,r8">BIT u3,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="CALL_n16"><a class="permalink" href="#CALL_n16">CALL
   n16</a></h2>
-Call address <var class="Ar" title="Ar">n16</var>.
-<div class="Pp"></div>
-Cycles: 6
-<div class="Pp"></div>
-Bytes: 3
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="CALL_cc,n16"><a class="selflink" href="#CALL_cc,n16">CALL
+Call address <var class="Ar">n16</var>.
+<p class="Pp">Cycles: 6</p>
+<p class="Pp">Bytes: 3</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="CALL_cc,n16"><a class="permalink" href="#CALL_cc,n16">CALL
   cc,n16</a></h2>
-Call address <var class="Ar" title="Ar">n16</var> if condition
-  <var class="Ar" title="Ar">cc</var> is met.
-<div class="Pp"></div>
-Cycles: 6/3
-<div class="Pp"></div>
-Bytes: 3
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="CCF"><a class="selflink" href="#CCF">CCF</a></h2>
+Call address <var class="Ar">n16</var> if condition <var class="Ar">cc</var> is
+  met.
+<p class="Pp">Cycles: 6/3</p>
+<p class="Pp">Bytes: 3</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="CCF"><a class="permalink" href="#CCF">CCF</a></h2>
 Complement Carry Flag.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Complemented.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: Complemented.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="CP_A,r8"><a class="selflink" href="#CP_A,r8">CP
+</section>
+<section class="Ss">
+<h2 class="Ss" id="CP_A,r8"><a class="permalink" href="#CP_A,r8">CP
   A,r8</a></h2>
-Subtract the value in <var class="Ar" title="Ar">r8</var> from
-  <b class="Sy" title="Sy">A</b> and set flags accordingly, but don't store the
-  result.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Subtract the value in <var class="Ar">r8</var> from <b class="Sy">A</b> and set
+  flags accordingly, but don't store the result.
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 1</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: Set if no borrow from
-      bit 4.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set if no borrow (set if
-      <var class="Ar" title="Ar">r8</var> &gt;
-    <b class="Sy" title="Sy">A</b>).</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 1</li>
+  <li><b class="Sy">H</b>: Set if no borrow from bit 4.</li>
+  <li><b class="Sy">C</b>: Set if no borrow (set if <var class="Ar">r8</var>
+      &gt; <b class="Sy">A</b>).</li>
 </ul>
-<h2 class="Ss" title="Ss" id="CP_A,[HL]"><a class="selflink" href="#CP_A,[HL]">CP
+</section>
+<section class="Ss">
+<h2 class="Ss" id="CP_A,_HL_"><a class="permalink" href="#CP_A,_HL_">CP
   A,[HL]</a></h2>
-Subtract the value pointed by <b class="Sy" title="Sy">HL</b> from
-  <b class="Sy" title="Sy">A</b> and set flags accordingly, but don't store the
-  result.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#CP_A,r8">CP A,r8</a>
-<h2 class="Ss" title="Ss" id="CP_A,n8"><a class="selflink" href="#CP_A,n8">CP
+Subtract the value pointed by <b class="Sy">HL</b> from <b class="Sy">A</b> and
+  set flags accordingly, but don't store the result.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: See <a class="Sx" href="#CP_A,r8">CP A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="CP_A,n8"><a class="permalink" href="#CP_A,n8">CP
   A,n8</a></h2>
-Subtract the value <var class="Ar" title="Ar">n8</var> from
-  <b class="Sy" title="Sy">A</b> and set flags accordingly, but don't store the
-  result.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#CP_A,r8">CP A,r8</a>
-<h2 class="Ss" title="Ss" id="CPL"><a class="selflink" href="#CPL">CPL</a></h2>
-Complement accumulator (<b class="Sy" title="Sy">A</b> =
-  <b class="Sy" title="Sy">~A</b>).
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Subtract the value <var class="Ar">n8</var> from <b class="Sy">A</b> and set
+  flags accordingly, but don't store the result.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#CP_A,r8">CP A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="CPL"><a class="permalink" href="#CPL">CPL</a></h2>
+Complement accumulator (<b class="Sy">A</b> = <b class="Sy">~A</b>).
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 1</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 1</li>
+  <li><b class="Sy">N</b>: 1</li>
+  <li><b class="Sy">H</b>: 1</li>
 </ul>
-<h2 class="Ss" title="Ss" id="DAA"><a class="selflink" href="#DAA">DAA</a></h2>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="DAA"><a class="permalink" href="#DAA">DAA</a></h2>
 Decimal adjust register A to get a correct BCD representation after an
   arithmetic instruction.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set or reset depending
-      on the operation.</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: Set or reset depending on the operation.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="DEC_r8"><a class="selflink" href="#DEC_r8">DEC
-  r8</a></h2>
-Decrement value in register <var class="Ar" title="Ar">r8</var> by 1.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+</section>
+<section class="Ss">
+<h2 class="Ss" id="DEC_r8"><a class="permalink" href="#DEC_r8">DEC r8</a></h2>
+Decrement value in register <var class="Ar">r8</var> by 1.
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 1</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: Set if no borrow from
-      bit 4.</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 1</li>
+  <li><b class="Sy">H</b>: Set if no borrow from bit 4.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="DEC_[HL]"><a class="selflink" href="#DEC_[HL]">DEC
+</section>
+<section class="Ss">
+<h2 class="Ss" id="DEC__HL_"><a class="permalink" href="#DEC__HL_">DEC
   [HL]</a></h2>
-Decrement the value pointed by <b class="Sy" title="Sy">HL</b> by 1.
-<div class="Pp"></div>
-Cycles: 3
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#DEC_r8">DEC r8</a>
-<h2 class="Ss" title="Ss" id="DEC_r16"><a class="selflink" href="#DEC_r16">DEC
+Decrement the value pointed by <b class="Sy">HL</b> by 1.
+<p class="Pp">Cycles: 3</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: See <a class="Sx" href="#DEC_r8">DEC r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="DEC_r16"><a class="permalink" href="#DEC_r16">DEC
   r16</a></h2>
-Decrement value in register <var class="Ar" title="Ar">r16</var> by 1.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="DEC_SP"><a class="selflink" href="#DEC_SP">DEC
-  SP</a></h2>
-Decrement value in register <b class="Sy" title="Sy">SP</b> by 1.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="DI"><a class="selflink" href="#DI">DI</a></h2>
+Decrement value in register <var class="Ar">r16</var> by 1.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="DEC_SP"><a class="permalink" href="#DEC_SP">DEC SP</a></h2>
+Decrement value in register <b class="Sy">SP</b> by 1.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="DI"><a class="permalink" href="#DI">DI</a></h2>
 Disable Interrupts.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="EI"><a class="selflink" href="#EI">EI</a></h2>
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="EI"><a class="permalink" href="#EI">EI</a></h2>
 Enable Interrupts.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="HALT"><a class="selflink" href="#HALT">HALT</a></h2>
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="HALT"><a class="permalink" href="#HALT">HALT</a></h2>
 Enter CPU low power mode.
-<div class="Pp"></div>
-Cycles: -
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="INC_r8"><a class="selflink" href="#INC_r8">INC
-  r8</a></h2>
-Increment value in register <var class="Ar" title="Ar">r8</var> by 1.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+<p class="Pp">Cycles: -</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="INC_r8"><a class="permalink" href="#INC_r8">INC r8</a></h2>
+Increment value in register <var class="Ar">r8</var> by 1.
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: Set if overflow from bit
-      3.</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: Set if overflow from bit 3.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="INC_[HL]"><a class="selflink" href="#INC_[HL]">INC
+</section>
+<section class="Ss">
+<h2 class="Ss" id="INC__HL_"><a class="permalink" href="#INC__HL_">INC
   [HL]</a></h2>
-Increment the value pointed by <b class="Sy" title="Sy">HL</b> by 1.
-<div class="Pp"></div>
-Cycles: 3
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#INC_r8">INC r8</a>
-<h2 class="Ss" title="Ss" id="INC_r16"><a class="selflink" href="#INC_r16">INC
+Increment the value pointed by <b class="Sy">HL</b> by 1.
+<p class="Pp">Cycles: 3</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: See <a class="Sx" href="#INC_r8">INC r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="INC_r16"><a class="permalink" href="#INC_r16">INC
   r16</a></h2>
-Increment value in register <var class="Ar" title="Ar">r16</var> by 1.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="INC_SP"><a class="selflink" href="#INC_SP">INC
-  SP</a></h2>
-Increment value in register <b class="Sy" title="Sy">SP</b> by 1.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="JP_n16"><a class="selflink" href="#JP_n16">JP
-  n16</a></h2>
-Absolute jump to address <var class="Ar" title="Ar">n16</var>.
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 3
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="JP_cc,n16"><a class="selflink" href="#JP_cc,n16">JP
+Increment value in register <var class="Ar">r16</var> by 1.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="INC_SP"><a class="permalink" href="#INC_SP">INC SP</a></h2>
+Increment value in register <b class="Sy">SP</b> by 1.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="JP_n16"><a class="permalink" href="#JP_n16">JP n16</a></h2>
+Absolute jump to address <var class="Ar">n16</var>.
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 3</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="JP_cc,n16"><a class="permalink" href="#JP_cc,n16">JP
   cc,n16</a></h2>
-Absolute jump to address <var class="Ar" title="Ar">n16</var> if condition
-  <var class="Ar" title="Ar">cc</var> is met.
-<div class="Pp"></div>
-Cycles: 4/3
-<div class="Pp"></div>
-Bytes: 3
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="JP_HL"><a class="selflink" href="#JP_HL">JP
-  HL</a></h2>
-Jump to address in <b class="Sy" title="Sy">HL</b>, that is, load
-  <b class="Sy" title="Sy">PC</b> with value in register
-  <b class="Sy" title="Sy">HL</b>.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="JR_e8"><a class="selflink" href="#JR_e8">JR
-  e8</a></h2>
-Relative jump by adding <var class="Ar" title="Ar">e8</var> to the current
-  address.
-<div class="Pp"></div>
-Cycles: 3
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="JR_cc,e8"><a class="selflink" href="#JR_cc,e8">JR
+Absolute jump to address <var class="Ar">n16</var> if condition
+  <var class="Ar">cc</var> is met.
+<p class="Pp">Cycles: 4/3</p>
+<p class="Pp">Bytes: 3</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="JP_HL"><a class="permalink" href="#JP_HL">JP HL</a></h2>
+Jump to address in <b class="Sy">HL</b>, that is, load <b class="Sy">PC</b> with
+  value in register <b class="Sy">HL</b>.
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="JR_e8"><a class="permalink" href="#JR_e8">JR e8</a></h2>
+Relative jump by adding <var class="Ar">e8</var> to the current address.
+<p class="Pp">Cycles: 3</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="JR_cc,e8"><a class="permalink" href="#JR_cc,e8">JR
   cc,e8</a></h2>
-Relative jump by adding <var class="Ar" title="Ar">e8</var> to the current
-  address if condition <var class="Ar" title="Ar">cc</var> is met.
-<div class="Pp"></div>
-Cycles: 3/2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_r8,r8"><a class="selflink" href="#LD_r8,r8">LD
+Relative jump by adding <var class="Ar">e8</var> to the current address if
+  condition <var class="Ar">cc</var> is met.
+<p class="Pp">Cycles: 3/2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD_r8,r8"><a class="permalink" href="#LD_r8,r8">LD
   r8,r8</a></h2>
 Store value in register on the right into register on the left.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_r8,n8"><a class="selflink" href="#LD_r8,n8">LD
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD_r8,n8"><a class="permalink" href="#LD_r8,n8">LD
   r8,n8</a></h2>
-Load value <var class="Ar" title="Ar">n8</var> into register
-  <var class="Ar" title="Ar">r8</var>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_r16,n16"><a class="selflink" href="#LD_r16,n16">LD
+Load value <var class="Ar">n8</var> into register <var class="Ar">r8</var>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD_r16,n16"><a class="permalink" href="#LD_r16,n16">LD
   r16,n16</a></h2>
-Load value <var class="Ar" title="Ar">n16</var> into register
-  <var class="Ar" title="Ar">r16</var>.
-<div class="Pp"></div>
-Cycles: 3
-<div class="Pp"></div>
-Bytes: 3
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_[HL],r8"><a class="selflink" href="#LD_[HL],r8">LD
+Load value <var class="Ar">n16</var> into register <var class="Ar">r16</var>.
+<p class="Pp">Cycles: 3</p>
+<p class="Pp">Bytes: 3</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD__HL_,r8"><a class="permalink" href="#LD__HL_,r8">LD
   [HL],r8</a></h2>
-Store value in register <var class="Ar" title="Ar">r8</var> into byte pointed by
-  register <b class="Sy" title="Sy">HL</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_[HL],n8"><a class="selflink" href="#LD_[HL],n8">LD
+Store value in register <var class="Ar">r8</var> into byte pointed by register
+  <b class="Sy">HL</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD__HL_,n8"><a class="permalink" href="#LD__HL_,n8">LD
   [HL],n8</a></h2>
-Store value <var class="Ar" title="Ar">n8</var> into byte pointed by register
-  <b class="Sy" title="Sy">HL</b>.
-<div class="Pp"></div>
-Cycles: 3
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_r8,[HL]"><a class="selflink" href="#LD_r8,[HL]">LD
+Store value <var class="Ar">n8</var> into byte pointed by register
+  <b class="Sy">HL</b>.
+<p class="Pp">Cycles: 3</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD_r8,_HL_"><a class="permalink" href="#LD_r8,_HL_">LD
   r8,[HL]</a></h2>
-Load value into register <var class="Ar" title="Ar">r8</var> from byte pointed
-  by register <b class="Sy" title="Sy">HL</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_[r16],A"><a class="selflink" href="#LD_[r16],A">LD
+Load value into register <var class="Ar">r8</var> from byte pointed by register
+  <b class="Sy">HL</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD__r16_,A"><a class="permalink" href="#LD__r16_,A">LD
   [r16],A</a></h2>
-Store value in register <b class="Sy" title="Sy">A</b> into address pointed by
-  register <var class="Ar" title="Ar">r16</var>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_[n16],A"><a class="selflink" href="#LD_[n16],A">LD
+Store value in register <b class="Sy">A</b> into address pointed by register
+  <var class="Ar">r16</var>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD__n16_,A"><a class="permalink" href="#LD__n16_,A">LD
   [n16],A</a></h2>
-Store value in register <b class="Sy" title="Sy">A</b> into address
-  <var class="Ar" title="Ar">n16</var>.
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 3
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_[$FF00+n8],A"><a class="selflink" href="#LD_[$FF00+n8],A">LD
+Store value in register <b class="Sy">A</b> into address
+  <var class="Ar">n16</var>.
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 3</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD__$FF00+n8_,A"><a class="permalink" href="#LD__$FF00+n8_,A">LD
   [$FF00+n8],A</a></h2>
-Store value in register <b class="Sy" title="Sy">A</b> into high RAM or I/O
-  registers.
-<div class="Pp"></div>
-The following synonym forces this encoding: <b class="Sy" title="Sy">LDH
-  [$FF00+n8],A</b>
-<div class="Pp"></div>
-Cycles: 3
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_[$FF00+C],A"><a class="selflink" href="#LD_[$FF00+C],A">LD
+Store value in register <b class="Sy">A</b> into high RAM or I/O registers.
+<p class="Pp">The following synonym forces this encoding: <b class="Sy">LDH
+    [$FF00+n8],A</b></p>
+<p class="Pp">Cycles: 3</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD__$FF00+C_,A"><a class="permalink" href="#LD__$FF00+C_,A">LD
   [$FF00+C],A</a></h2>
-Store value in register <b class="Sy" title="Sy">A</b> into high RAM or I/O
-  registers.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_A,[r16]"><a class="selflink" href="#LD_A,[r16]">LD
+Store value in register <b class="Sy">A</b> into high RAM or I/O registers.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD_A,_r16_"><a class="permalink" href="#LD_A,_r16_">LD
   A,[r16]</a></h2>
-Load value in register <b class="Sy" title="Sy">A</b> from address pointed by
-  register <var class="Ar" title="Ar">r16</var>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_A,[n16]"><a class="selflink" href="#LD_A,[n16]">LD
+Load value in register <b class="Sy">A</b> from address pointed by register
+  <var class="Ar">r16</var>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD_A,_n16_"><a class="permalink" href="#LD_A,_n16_">LD
   A,[n16]</a></h2>
-Load value in register <b class="Sy" title="Sy">A</b> from address
-  <var class="Ar" title="Ar">n16</var>.
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 3
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_A,[$FF00+n8]"><a class="selflink" href="#LD_A,[$FF00+n8]">LD
+Load value in register <b class="Sy">A</b> from address
+  <var class="Ar">n16</var>.
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 3</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD_A,_$FF00+n8_"><a class="permalink" href="#LD_A,_$FF00+n8_">LD
   A,[$FF00+n8]</a></h2>
-Load value in register <b class="Sy" title="Sy">A</b> from high RAM or I/O
-  registers.
-<div class="Pp"></div>
-The following synonym forces this encoding: <b class="Sy" title="Sy">LDH
-  A,[$FF00+n8]</b>
-<div class="Pp"></div>
-Cycles: 3
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_A,[$FF00+C]"><a class="selflink" href="#LD_A,[$FF00+C]">LD
+Load value in register <b class="Sy">A</b> from high RAM or I/O registers.
+<p class="Pp">The following synonym forces this encoding: <b class="Sy">LDH
+    A,[$FF00+n8]</b></p>
+<p class="Pp">Cycles: 3</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD_A,_$FF00+C_"><a class="permalink" href="#LD_A,_$FF00+C_">LD
   A,[$FF00+C]</a></h2>
-Load value in register <b class="Sy" title="Sy">A</b> from high RAM or I/O
-  registers.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_[HL+],A"><a class="selflink" href="#LD_[HL+],A">LD
+Load value in register <b class="Sy">A</b> from high RAM or I/O registers.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD__HL+_,A"><a class="permalink" href="#LD__HL+_,A">LD
   [HL+],A</a></h2>
-Store value in register <b class="Sy" title="Sy">A</b> into byte pointed by
-  <b class="Sy" title="Sy">HL</b> and post-increment
-  <b class="Sy" title="Sy">HL</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_[HL-],A"><a class="selflink" href="#LD_[HL-],A">LD
+Store value in register <b class="Sy">A</b> into byte pointed by
+  <b class="Sy">HL</b> and post-increment <b class="Sy">HL</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD__HL-_,A"><a class="permalink" href="#LD__HL-_,A">LD
   [HL-],A</a></h2>
-Store value in register <b class="Sy" title="Sy">A</b> into byte pointed by
-  <b class="Sy" title="Sy">HL</b> and post-decrement
-  <b class="Sy" title="Sy">HL</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_A,[HL+]"><a class="selflink" href="#LD_A,[HL+]">LD
+Store value in register <b class="Sy">A</b> into byte pointed by
+  <b class="Sy">HL</b> and post-decrement <b class="Sy">HL</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD_A,_HL+_"><a class="permalink" href="#LD_A,_HL+_">LD
   A,[HL+]</a></h2>
-Load value into register <b class="Sy" title="Sy">A</b> from byte pointed by
-  <b class="Sy" title="Sy">HL</b> and post-increment
-  <b class="Sy" title="Sy">HL</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_A,[HL-]"><a class="selflink" href="#LD_A,[HL-]">LD
+Load value into register <b class="Sy">A</b> from byte pointed by
+  <b class="Sy">HL</b> and post-increment <b class="Sy">HL</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD_A,_HL-_"><a class="permalink" href="#LD_A,_HL-_">LD
   A,[HL-]</a></h2>
-Load value into register <b class="Sy" title="Sy">A</b> from byte pointed by
-  <b class="Sy" title="Sy">HL</b> and post-decrement
-  <b class="Sy" title="Sy">HL</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_SP,n16"><a class="selflink" href="#LD_SP,n16">LD
+Load value into register <b class="Sy">A</b> from byte pointed by
+  <b class="Sy">HL</b> and post-decrement <b class="Sy">HL</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD_SP,n16"><a class="permalink" href="#LD_SP,n16">LD
   SP,n16</a></h2>
-Load value <var class="Ar" title="Ar">n16</var> into register
-  <b class="Sy" title="Sy">SP</b>.
-<div class="Pp"></div>
-Cycles: 3
-<div class="Pp"></div>
-Bytes: 3
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_[n16],SP"><a class="selflink" href="#LD_[n16],SP">LD
+Load value <var class="Ar">n16</var> into register <b class="Sy">SP</b>.
+<p class="Pp">Cycles: 3</p>
+<p class="Pp">Bytes: 3</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD__n16_,SP"><a class="permalink" href="#LD__n16_,SP">LD
   [n16],SP</a></h2>
-Store <b class="Sy" title="Sy">SP</b> into addresses
-  <var class="Ar" title="Ar">n16</var> (LSB) and
-  <var class="Ar" title="Ar">n16</var> + 1 (MSB).
-<div class="Pp"></div>
-Cycles: 5
-<div class="Pp"></div>
-Bytes: 3
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="LD_HL,SP+e8"><a class="selflink" href="#LD_HL,SP+e8">LD
+Store <b class="Sy">SP</b> into addresses <var class="Ar">n16</var> (LSB) and
+  <var class="Ar">n16</var> + 1 (MSB).
+<p class="Pp">Cycles: 5</p>
+<p class="Pp">Bytes: 3</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD_HL,SP+e8"><a class="permalink" href="#LD_HL,SP+e8">LD
   HL,SP+e8</a></h2>
-Add the signed value <var class="Ar" title="Ar">e8</var> to
-  <b class="Sy" title="Sy">SP</b> and store the result in
-  <b class="Sy" title="Sy">HL.</b>
-<div class="Pp"></div>
-Cycles: 3
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags:
+Add the signed value <var class="Ar">e8</var> to <b class="Sy">SP</b> and store
+  the result in <b class="Sy">HL.</b>
+<p class="Pp">Cycles: 3</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: Set if overflow from bit
-      3.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set if overflow from bit
-      7.</li>
+  <li><b class="Sy">Z</b>: 0</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: Set if overflow from bit 3.</li>
+  <li><b class="Sy">C</b>: Set if overflow from bit 7.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="LD_SP,HL"><a class="selflink" href="#LD_SP,HL">LD
+</section>
+<section class="Ss">
+<h2 class="Ss" id="LD_SP,HL"><a class="permalink" href="#LD_SP,HL">LD
   SP,HL</a></h2>
-Load register <b class="Sy" title="Sy">HL</b> into register
-  <b class="Sy" title="Sy">SP</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="NOP"><a class="selflink" href="#NOP">NOP</a></h2>
+Load register <b class="Sy">HL</b> into register <b class="Sy">SP</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="NOP"><a class="permalink" href="#NOP">NOP</a></h2>
 No operation.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="OR_A,r8"><a class="selflink" href="#OR_A,r8">OR
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="OR_A,r8"><a class="permalink" href="#OR_A,r8">OR
   A,r8</a></h2>
-Bitwise OR between the value in <var class="Ar" title="Ar">r8</var> and
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Bitwise OR between the value in <var class="Ar">r8</var> and
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: 0</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: 0</li>
 </ul>
-<h2 class="Ss" title="Ss" id="OR_A,[HL]"><a class="selflink" href="#OR_A,[HL]">OR
+</section>
+<section class="Ss">
+<h2 class="Ss" id="OR_A,_HL_"><a class="permalink" href="#OR_A,_HL_">OR
   A,[HL]</a></h2>
-Bitwise OR between the value pointed by <b class="Sy" title="Sy">HL</b> and
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#OR_A,r8">OR A,r8</a>
-<h2 class="Ss" title="Ss" id="OR_A,n8"><a class="selflink" href="#OR_A,n8">OR
+Bitwise OR between the value pointed by <b class="Sy">HL</b> and
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: See <a class="Sx" href="#OR_A,r8">OR A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="OR_A,n8"><a class="permalink" href="#OR_A,n8">OR
   A,n8</a></h2>
-Bitwise OR between the value in <var class="Ar" title="Ar">n8</var> and
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#OR_A,r8">OR A,r8</a>
-<h2 class="Ss" title="Ss" id="POP_AF"><a class="selflink" href="#POP_AF">POP
-  AF</a></h2>
-Pop register <b class="Sy" title="Sy">AF</b> from the stack.
-<div class="Pp"></div>
-Cycles: 3
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Bitwise OR between the value in <var class="Ar">n8</var> and
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#OR_A,r8">OR A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="POP_AF"><a class="permalink" href="#POP_AF">POP AF</a></h2>
+Pop register <b class="Sy">AF</b> from the stack.
+<p class="Pp">Cycles: 3</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set from bit 7 of the
-      popped low byte.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: Set from bit 6 of the
-      popped low byte.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: Set from bit 5 of the
-      popped low byte.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set from bit 4 of the
-      popped low byte.</li>
+  <li><b class="Sy">Z</b>: Set from bit 7 of the popped low byte.</li>
+  <li><b class="Sy">N</b>: Set from bit 6 of the popped low byte.</li>
+  <li><b class="Sy">H</b>: Set from bit 5 of the popped low byte.</li>
+  <li><b class="Sy">C</b>: Set from bit 4 of the popped low byte.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="POP_r16"><a class="selflink" href="#POP_r16">POP
+</section>
+<section class="Ss">
+<h2 class="Ss" id="POP_r16"><a class="permalink" href="#POP_r16">POP
   r16</a></h2>
-Pop register <var class="Ar" title="Ar">r16</var> from the stack.
-<div class="Pp"></div>
-Cycles: 3
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="PUSH_AF"><a class="selflink" href="#PUSH_AF">PUSH
+Pop register <var class="Ar">r16</var> from the stack.
+<p class="Pp">Cycles: 3</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="PUSH_AF"><a class="permalink" href="#PUSH_AF">PUSH
   AF</a></h2>
-Push register <b class="Sy" title="Sy">AF</b> into the stack. The low byte's bit
-  7 corresponds to the <b class="Sy" title="Sy">Z</b> flag, its bit 6 to the
-  <b class="Sy" title="Sy">N</b> flag, bit 5 to the
-  <b class="Sy" title="Sy">H</b> flag, and bit 4 to the
-  <b class="Sy" title="Sy">C</b> flag. Bits 3 to 0 are reset.
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="PUSH_r16"><a class="selflink" href="#PUSH_r16">PUSH
+Push register <b class="Sy">AF</b> into the stack. The low byte's bit 7
+  corresponds to the <b class="Sy">Z</b> flag, its bit 6 to the
+  <b class="Sy">N</b> flag, bit 5 to the <b class="Sy">H</b> flag, and bit 4 to
+  the <b class="Sy">C</b> flag. Bits 3 to 0 are reset.
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="PUSH_r16"><a class="permalink" href="#PUSH_r16">PUSH
   r16</a></h2>
-Push register <var class="Ar" title="Ar">r16</var> into the stack.
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="RES_u3,r8"><a class="selflink" href="#RES_u3,r8">RES
+Push register <var class="Ar">r16</var> into the stack.
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RES_u3,r8"><a class="permalink" href="#RES_u3,r8">RES
   u3,r8</a></h2>
-Set bit <var class="Ar" title="Ar">u3</var> in register
-  <var class="Ar" title="Ar">r8</var> to 0.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="RES_u3,[HL]"><a class="selflink" href="#RES_u3,[HL]">RES
+Set bit <var class="Ar">u3</var> in register <var class="Ar">r8</var> to 0.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RES_u3,_HL_"><a class="permalink" href="#RES_u3,_HL_">RES
   u3,[HL]</a></h2>
-Set bit <var class="Ar" title="Ar">u3</var> in the byte pointed by
-  <b class="Sy" title="Sy">HL</b> to 0.
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="RET"><a class="selflink" href="#RET">RET</a></h2>
+Set bit <var class="Ar">u3</var> in the byte pointed by <b class="Sy">HL</b> to
+  0.
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RET"><a class="permalink" href="#RET">RET</a></h2>
 Return from subroutine.
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="RET_cc"><a class="selflink" href="#RET_cc">RET
-  cc</a></h2>
-Return from subroutine if condition <var class="Ar" title="Ar">cc</var> is met.
-<div class="Pp"></div>
-Cycles: 5/2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="RETI"><a class="selflink" href="#RETI">RETI</a></h2>
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RET_cc"><a class="permalink" href="#RET_cc">RET cc</a></h2>
+Return from subroutine if condition <var class="Ar">cc</var> is met.
+<p class="Pp">Cycles: 5/2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RETI"><a class="permalink" href="#RETI">RETI</a></h2>
 Return from subroutine and enable interrupts.
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="RL_r8"><a class="selflink" href="#RL_r8">RL
-  r8</a></h2>
-Rotate register <var class="Ar" title="Ar">r8</var> left through carry.
-<div class="Pp"></div>
-<div class="D1">C &lt;- [7 &lt;- 0] &lt;- C</div>
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags:
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RL_r8"><a class="permalink" href="#RL_r8">RL r8</a></h2>
+Rotate register <var class="Ar">r8</var> left through carry.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">C &lt;- [7 &lt;- 0] &lt;- C</div>
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set according to
-    result.</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: Set according to result.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="RL_[HL]"><a class="selflink" href="#RL_[HL]">RL
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RL__HL_"><a class="permalink" href="#RL__HL_">RL
   [HL]</a></h2>
-Rotate value pointed by <b class="Sy" title="Sy">HL</b> left through carry.
-<div class="Pp"></div>
-<div class="D1">C &lt;- [7 &lt;- 0] &lt;- C</div>
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#RL_r8">RL r8</a>
-<h2 class="Ss" title="Ss" id="RLA"><a class="selflink" href="#RLA">RLA</a></h2>
-Rotate register <b class="Sy" title="Sy">A</b> left through carry.
-<div class="Pp"></div>
-<div class="D1">C &lt;- [7 &lt;- 0] &lt;- C</div>
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Rotate value pointed by <b class="Sy">HL</b> left through carry.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">C &lt;- [7 &lt;- 0] &lt;- C</div>
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#RL_r8">RL r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RLA"><a class="permalink" href="#RLA">RLA</a></h2>
+Rotate register <b class="Sy">A</b> left through carry.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">C &lt;- [7 &lt;- 0] &lt;- C</div>
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set according to
-    result.</li>
+  <li><b class="Sy">Z</b>: 0</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: Set according to result.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="RLC_r8"><a class="selflink" href="#RLC_r8">RLC
-  r8</a></h2>
-Rotate register <var class="Ar" title="Ar">r8</var> left.
-<div class="Pp"></div>
-<div class="D1">C &lt;- [7 &lt;- 0] &lt;- [7]</div>
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags:
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RLC_r8"><a class="permalink" href="#RLC_r8">RLC r8</a></h2>
+Rotate register <var class="Ar">r8</var> left.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">C &lt;- [7 &lt;- 0] &lt;- [7]</div>
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set according to
-    result.</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: Set according to result.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="RLC_[HL]"><a class="selflink" href="#RLC_[HL]">RLC
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RLC__HL_"><a class="permalink" href="#RLC__HL_">RLC
   [HL]</a></h2>
-Rotate value pointed by <b class="Sy" title="Sy">HL</b> left.
-<div class="Pp"></div>
-<div class="D1">C &lt;- [7 &lt;- 0] &lt;- [7]</div>
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#RLC_r8">RLC r8</a>
-<h2 class="Ss" title="Ss" id="RLCA"><a class="selflink" href="#RLCA">RLCA</a></h2>
-Rotate register <b class="Sy" title="Sy">A</b> left.
-<div class="Pp"></div>
-<div class="D1">C &lt;- [7 &lt;- 0] &lt;- [7]</div>
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Rotate value pointed by <b class="Sy">HL</b> left.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">C &lt;- [7 &lt;- 0] &lt;- [7]</div>
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#RLC_r8">RLC r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RLCA"><a class="permalink" href="#RLCA">RLCA</a></h2>
+Rotate register <b class="Sy">A</b> left.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">C &lt;- [7 &lt;- 0] &lt;- [7]</div>
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set according to
-    result.</li>
+  <li><b class="Sy">Z</b>: 0</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: Set according to result.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="RR_r8"><a class="selflink" href="#RR_r8">RR
-  r8</a></h2>
-Rotate register <var class="Ar" title="Ar">r8</var> right through carry.
-<div class="Pp"></div>
-<div class="D1">C -&gt; [7 -&gt; 0] -&gt; C</div>
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags:
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RR_r8"><a class="permalink" href="#RR_r8">RR r8</a></h2>
+Rotate register <var class="Ar">r8</var> right through carry.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">C -&gt; [7 -&gt; 0] -&gt; C</div>
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set according to
-    result.</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: Set according to result.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="RR_[HL]"><a class="selflink" href="#RR_[HL]">RR
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RR__HL_"><a class="permalink" href="#RR__HL_">RR
   [HL]</a></h2>
-Rotate value pointed by <b class="Sy" title="Sy">HL</b> right through carry.
-<div class="Pp"></div>
-<div class="D1">C -&gt; [7 -&gt; 0] -&gt; C</div>
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#RR_r8">RR r8</a>
-<h2 class="Ss" title="Ss" id="RRA"><a class="selflink" href="#RRA">RRA</a></h2>
-Rotate register <b class="Sy" title="Sy">A</b> right through carry.
-<div class="Pp"></div>
-<div class="D1">C -&gt; [7 -&gt; 0] -&gt; C</div>
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Rotate value pointed by <b class="Sy">HL</b> right through carry.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">C -&gt; [7 -&gt; 0] -&gt; C</div>
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#RR_r8">RR r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RRA"><a class="permalink" href="#RRA">RRA</a></h2>
+Rotate register <b class="Sy">A</b> right through carry.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">C -&gt; [7 -&gt; 0] -&gt; C</div>
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set according to
-    result.</li>
+  <li><b class="Sy">Z</b>: 0</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: Set according to result.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="RRC_r8"><a class="selflink" href="#RRC_r8">RRC
-  r8</a></h2>
-Rotate register <var class="Ar" title="Ar">r8</var> right.
-<div class="Pp"></div>
-<div class="D1">[0] -&gt; [7 -&gt; 0] -&gt; C</div>
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags:
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RRC_r8"><a class="permalink" href="#RRC_r8">RRC r8</a></h2>
+Rotate register <var class="Ar">r8</var> right.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">[0] -&gt; [7 -&gt; 0] -&gt; C</div>
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set according to
-    result.</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: Set according to result.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="RRC_[HL]"><a class="selflink" href="#RRC_[HL]">RRC
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RRC__HL_"><a class="permalink" href="#RRC__HL_">RRC
   [HL]</a></h2>
-Rotate value pointed by <b class="Sy" title="Sy">HL</b> right.
-<div class="Pp"></div>
-<div class="D1">[0] -&gt; [7 -&gt; 0] -&gt; C</div>
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#RRC_r8">RRC r8</a>
-<h2 class="Ss" title="Ss" id="RRCA"><a class="selflink" href="#RRCA">RRCA</a></h2>
-Rotate register <b class="Sy" title="Sy">A</b> right.
-<div class="Pp"></div>
-<div class="D1">[0] -&gt; [7 -&gt; 0] -&gt; C</div>
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Rotate value pointed by <b class="Sy">HL</b> right.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">[0] -&gt; [7 -&gt; 0] -&gt; C</div>
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#RRC_r8">RRC r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RRCA"><a class="permalink" href="#RRCA">RRCA</a></h2>
+Rotate register <b class="Sy">A</b> right.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">[0] -&gt; [7 -&gt; 0] -&gt; C</div>
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set according to
-    result.</li>
+  <li><b class="Sy">Z</b>: 0</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: Set according to result.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="RST_vec"><a class="selflink" href="#RST_vec">RST
+</section>
+<section class="Ss">
+<h2 class="Ss" id="RST_vec"><a class="permalink" href="#RST_vec">RST
   vec</a></h2>
-Call restart vector <var class="Ar" title="Ar">vec</var>.
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="SBC_A,r8"><a class="selflink" href="#SBC_A,r8">SBC
+Call restart vector <var class="Ar">vec</var>.
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SBC_A,r8"><a class="permalink" href="#SBC_A,r8">SBC
   A,r8</a></h2>
-Subtract the value in <var class="Ar" title="Ar">r8</var> and the carry flag
-  from <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Subtract the value in <var class="Ar">r8</var> and the carry flag from
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 1</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: Set if no borrow from
-      bit 4.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set if no borrow (set if
-      <var class="Ar" title="Ar">r8</var> &gt;
-    <b class="Sy" title="Sy">A</b>).</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 1</li>
+  <li><b class="Sy">H</b>: Set if no borrow from bit 4.</li>
+  <li><b class="Sy">C</b>: Set if no borrow (set if <var class="Ar">r8</var>
+      &gt; <b class="Sy">A</b>).</li>
 </ul>
-<h2 class="Ss" title="Ss" id="SBC_A,[HL]"><a class="selflink" href="#SBC_A,[HL]">SBC
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SBC_A,_HL_"><a class="permalink" href="#SBC_A,_HL_">SBC
   A,[HL]</a></h2>
-Subtract the value pointed by <b class="Sy" title="Sy">HL</b> and the carry flag
-  from <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#SBC_A,r8">SBC A,r8</a>
-<h2 class="Ss" title="Ss" id="SBC_A,n8"><a class="selflink" href="#SBC_A,n8">SBC
+Subtract the value pointed by <b class="Sy">HL</b> and the carry flag from
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: See <a class="Sx" href="#SBC_A,r8">SBC A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SBC_A,n8"><a class="permalink" href="#SBC_A,n8">SBC
   A,n8</a></h2>
-Subtract the value <var class="Ar" title="Ar">n8</var> and the carry flag from
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#SBC_A,r8">SBC A,r8</a>
-<h2 class="Ss" title="Ss" id="SCF"><a class="selflink" href="#SCF">SCF</a></h2>
+Subtract the value <var class="Ar">n8</var> and the carry flag from
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#SBC_A,r8">SBC A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SCF"><a class="permalink" href="#SCF">SCF</a></h2>
 Set Carry Flag.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: 1</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: 1</li>
 </ul>
-<h2 class="Ss" title="Ss" id="SET_u3,r8"><a class="selflink" href="#SET_u3,r8">SET
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SET_u3,r8"><a class="permalink" href="#SET_u3,r8">SET
   u3,r8</a></h2>
-Set bit <var class="Ar" title="Ar">u3</var> in register
-  <var class="Ar" title="Ar">r8</var> to 1.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="SET_u3,[HL]"><a class="selflink" href="#SET_u3,[HL]">SET
+Set bit <var class="Ar">u3</var> in register <var class="Ar">r8</var> to 1.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SET_u3,_HL_"><a class="permalink" href="#SET_u3,_HL_">SET
   u3,[HL]</a></h2>
-Set bit <var class="Ar" title="Ar">u3</var> in the byte pointed by
-  <b class="Sy" title="Sy">HL</b> to 1.
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="SLA_r8"><a class="selflink" href="#SLA_r8">SLA
-  r8</a></h2>
-Shift left arithmetic register <var class="Ar" title="Ar">r8</var>.
-<div class="Pp"></div>
-<div class="D1">C &lt;- [7 &lt;- 0] &lt;- 0</div>
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags:
+Set bit <var class="Ar">u3</var> in the byte pointed by <b class="Sy">HL</b> to
+  1.
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SLA_r8"><a class="permalink" href="#SLA_r8">SLA r8</a></h2>
+Shift left arithmetic register <var class="Ar">r8</var>.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">C &lt;- [7 &lt;- 0] &lt;- 0</div>
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set according to
-    result.</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: Set according to result.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="SLA_[HL]"><a class="selflink" href="#SLA_[HL]">SLA
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SLA__HL_"><a class="permalink" href="#SLA__HL_">SLA
   [HL]</a></h2>
-Shift left arithmetic value pointed by <b class="Sy" title="Sy">HL</b>.
-<div class="Pp"></div>
-<div class="D1">C &lt;- [7 &lt;- 0] &lt;- 0</div>
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#SLA_r8">SLA r8</a>
-<h2 class="Ss" title="Ss" id="SRA_r8"><a class="selflink" href="#SRA_r8">SRA
-  r8</a></h2>
-Shift right arithmetic register <var class="Ar" title="Ar">r8</var>.
-<div class="Pp"></div>
-<div class="D1">[7] -&gt; [7 -&gt; 0] -&gt; C</div>
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags:
+Shift left arithmetic value pointed by <b class="Sy">HL</b>.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">C &lt;- [7 &lt;- 0] &lt;- 0</div>
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#SLA_r8">SLA r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SRA_r8"><a class="permalink" href="#SRA_r8">SRA r8</a></h2>
+Shift right arithmetic register <var class="Ar">r8</var>.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">[7] -&gt; [7 -&gt; 0] -&gt; C</div>
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set according to
-    result.</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: Set according to result.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="SRA_[HL]"><a class="selflink" href="#SRA_[HL]">SRA
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SRA__HL_"><a class="permalink" href="#SRA__HL_">SRA
   [HL]</a></h2>
-Shift right arithmetic value pointed by <b class="Sy" title="Sy">HL</b>.
-<div class="Pp"></div>
-<div class="D1">[7] -&gt; [7 -&gt; 0] -&gt; C</div>
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#SRA_r8">SRA r8</a>
-<h2 class="Ss" title="Ss" id="SRL_r8"><a class="selflink" href="#SRL_r8">SRL
-  r8</a></h2>
-Shift right logic register <var class="Ar" title="Ar">r8</var>.
-<div class="Pp"></div>
-<div class="D1">0 -&gt; [7 -&gt; 0] -&gt; C</div>
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags:
+Shift right arithmetic value pointed by <b class="Sy">HL</b>.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">[7] -&gt; [7 -&gt; 0] -&gt; C</div>
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#SRA_r8">SRA r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SRL_r8"><a class="permalink" href="#SRL_r8">SRL r8</a></h2>
+Shift right logic register <var class="Ar">r8</var>.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">0 -&gt; [7 -&gt; 0] -&gt; C</div>
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set according to
-    result.</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: Set according to result.</li>
 </ul>
-<h2 class="Ss" title="Ss" id="SRL_[HL]"><a class="selflink" href="#SRL_[HL]">SRL
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SRL__HL_"><a class="permalink" href="#SRL__HL_">SRL
   [HL]</a></h2>
-Shift right logic value pointed by <b class="Sy" title="Sy">HL</b>.
-<div class="Pp"></div>
-<div class="D1">0 -&gt; [7 -&gt; 0] -&gt; C</div>
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#SRA_r8">SRA r8</a>
-<h2 class="Ss" title="Ss" id="STOP"><a class="selflink" href="#STOP">STOP</a></h2>
+Shift right logic value pointed by <b class="Sy">HL</b>.
+<p class="Pp"></p>
+<div class="Bd Bd-indent">0 -&gt; [7 -&gt; 0] -&gt; C</div>
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#SRA_r8">SRA r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="STOP"><a class="permalink" href="#STOP">STOP</a></h2>
 Enter CPU very low power mode. Also used to switch between double and normal
   speed CPU modes in GBC.
-<div class="Pp"></div>
-Cycles: -
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: None affected.
-<h2 class="Ss" title="Ss" id="SUB_A,r8"><a class="selflink" href="#SUB_A,r8">SUB
+<p class="Pp">Cycles: -</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: None affected.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SUB_A,r8"><a class="permalink" href="#SUB_A,r8">SUB
   A,r8</a></h2>
-Subtract the value in <var class="Ar" title="Ar">r8</var> from
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Subtract the value in <var class="Ar">r8</var> from <b class="Sy">A</b>.
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 1</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: Set if no borrow from
-      bit 4.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: Set if no borrow (set if
-      <var class="Ar" title="Ar">r8</var> &gt;
-    <b class="Sy" title="Sy">A</b>).</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 1</li>
+  <li><b class="Sy">H</b>: Set if no borrow from bit 4.</li>
+  <li><b class="Sy">C</b>: Set if no borrow (set if <var class="Ar">r8</var>
+      &gt; <b class="Sy">A</b>).</li>
 </ul>
-<h2 class="Ss" title="Ss" id="SUB_A,[HL]"><a class="selflink" href="#SUB_A,[HL]">SUB
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SUB_A,_HL_"><a class="permalink" href="#SUB_A,_HL_">SUB
   A,[HL]</a></h2>
-Subtract the value pointed by <b class="Sy" title="Sy">HL</b> from
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#SUB_A,r8">SUB A,r8</a>
-<h2 class="Ss" title="Ss" id="SUB_A,n8"><a class="selflink" href="#SUB_A,n8">SUB
+Subtract the value pointed by <b class="Sy">HL</b> from <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: See <a class="Sx" href="#SUB_A,r8">SUB A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SUB_A,n8"><a class="permalink" href="#SUB_A,n8">SUB
   A,n8</a></h2>
-Subtract the value <var class="Ar" title="Ar">n8</var> from
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#SUB_A,r8">SUB A,r8</a>
-<h2 class="Ss" title="Ss" id="SWAP_r8"><a class="selflink" href="#SWAP_r8">SWAP
+Subtract the value <var class="Ar">n8</var> from <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#SUB_A,r8">SUB A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SWAP_r8"><a class="permalink" href="#SWAP_r8">SWAP
   r8</a></h2>
-Swap upper 4 bits in register <var class="Ar" title="Ar">r8</var> and the lower
-  ones.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags:
+Swap upper 4 bits in register <var class="Ar">r8</var> and the lower ones.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: 0</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: 0</li>
 </ul>
-<h2 class="Ss" title="Ss" id="SWAP_[HL]"><a class="selflink" href="#SWAP_[HL]">SWAP
+</section>
+<section class="Ss">
+<h2 class="Ss" id="SWAP__HL_"><a class="permalink" href="#SWAP__HL_">SWAP
   [HL]</a></h2>
-Swap upper 4 bits in the byte pointed by <b class="Sy" title="Sy">HL</b> and the
-  lower ones.
-<div class="Pp"></div>
-Cycles: 4
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#SWAP_r8">SWAP r8</a>
-<h2 class="Ss" title="Ss" id="XOR_A,r8"><a class="selflink" href="#XOR_A,r8">XOR
+Swap upper 4 bits in the byte pointed by <b class="Sy">HL</b> and the lower
+  ones.
+<p class="Pp">Cycles: 4</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#SWAP_r8">SWAP r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="XOR_A,r8"><a class="permalink" href="#XOR_A,r8">XOR
   A,r8</a></h2>
-Bitwise XOR between the value in <var class="Ar" title="Ar">r8</var> and
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 1
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags:
+Bitwise XOR between the value in <var class="Ar">r8</var> and
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 1</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags:</p>
 <ul class="Bl-bullet Bl-compact">
-  <li class="It-bullet"><b class="Sy" title="Sy">Z</b>: Set if result is 0.</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">N</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">H</b>: 0</li>
-  <li class="It-bullet"><b class="Sy" title="Sy">C</b>: 0</li>
+  <li><b class="Sy">Z</b>: Set if result is 0.</li>
+  <li><b class="Sy">N</b>: 0</li>
+  <li><b class="Sy">H</b>: 0</li>
+  <li><b class="Sy">C</b>: 0</li>
 </ul>
-<h2 class="Ss" title="Ss" id="XOR_A,[HL]"><a class="selflink" href="#XOR_A,[HL]">XOR
+</section>
+<section class="Ss">
+<h2 class="Ss" id="XOR_A,_HL_"><a class="permalink" href="#XOR_A,_HL_">XOR
   A,[HL]</a></h2>
-Bitwise XOR between the value pointed by <b class="Sy" title="Sy">HL</b> and
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 1
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#XOR_A,r8">XOR A,r8</a>
-<h2 class="Ss" title="Ss" id="XOR_A,n8"><a class="selflink" href="#XOR_A,n8">XOR
+Bitwise XOR between the value pointed by <b class="Sy">HL</b> and
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 1</p>
+<p class="Pp">Flags: See <a class="Sx" href="#XOR_A,r8">XOR A,r8</a></p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="XOR_A,n8"><a class="permalink" href="#XOR_A,n8">XOR
   A,n8</a></h2>
-Bitwise XOR between the value in <var class="Ar" title="Ar">n8</var> and
-  <b class="Sy" title="Sy">A</b>.
-<div class="Pp"></div>
-Cycles: 2
-<div class="Pp"></div>
-Bytes: 2
-<div class="Pp"></div>
-Flags: See <a class="Sx" title="Sx" href="#XOR_A,r8">XOR A,r8</a>
-<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="selflink" href="#SEE_ALSO">SEE
+Bitwise XOR between the value in <var class="Ar">n8</var> and
+  <b class="Sy">A</b>.
+<p class="Pp">Cycles: 2</p>
+<p class="Pp">Bytes: 2</p>
+<p class="Pp">Flags: See <a class="Sx" href="#XOR_A,r8">XOR A,r8</a></p>
+</section>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" title="Xr">rgbasm(1)</a>, <a class="Xr" title="Xr">rgbds(7)</a>
-<h1 class="Sh" title="Sh" id="HISTORY"><a class="selflink" href="#HISTORY">HISTORY</a></h1>
-<b class="Nm" title="Nm">rgbds</b> was originally written by Carsten
-  S&#x00F8;rensen as part of the ASMotor package, and was later packaged in
-  RGBDS by Justin Lloyd. It is now maintained by a number of contributors at
-  <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
+<a class="Xr">rgbasm(1)</a>, <a class="Xr">rgbds(7)</a>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="HISTORY"><a class="permalink" href="#HISTORY">HISTORY</a></h1>
+<code class="Nm">rgbds</code> was originally written by Carsten S&#x00F8;rensen
+  as part of the ASMotor package, and was later packaged in RGBDS by Justin
+  Lloyd. It is now maintained by a number of contributors at
+  <a class="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.
+</section>
+</div>
 <table class="foot">
   <tr>
     <td class="foot-date">February 23, 2018</td>

--- a/docs/rgbasm.1.html
+++ b/docs/rgbasm.1.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html>
+<!-- This is an automatically generated file.  Do not edit.
+   This file is part of RGBDS.
+
+   Copyright (c) 2010-2018, Anthony J. Bentley and RGBDS contributors.
+
+   SPDX-License-Identifier: MIT
+   -->
 <head>
   <meta charset="utf-8"/>
-  <style>
-    table.head, table.foot { width: 100%; }
-    td.head-rtitle, td.foot-os { text-align: right; }
-    td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-  </style>
   <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
   <title>RGBASM(1)</title>
 </head>
@@ -20,133 +21,105 @@
   </tr>
 </table>
 <div class="manual-text">
-<h1 class="Sh" title="Sh" id="NAME"><a class="selflink" href="#NAME">NAME</a></h1>
-<b class="Nm" title="Nm">rgbasm</b> &#x2014; <span class="Nd" title="Nd">Game
-  Boy assembler</span>
-<h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="selflink" href="#SYNOPSIS">SYNOPSIS</a></h1>
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<code class="Nm">rgbasm</code> &#x2014;
+<div class="Nd">Game Boy assembler</div>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <table class="Nm">
   <tr>
-    <td><b class="Nm" title="Nm">rgbasm</b></td>
-    <td>[<span class="Op"><b class="Fl" title="Fl">-EhLVvw</b></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-b</b>
-      <var class="Ar" title="Ar">chars</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-D</b>
-      <var class="Ar" title="Ar">name</var>[<span class="Op">=<var class="Ar" title="Ar">value</var></span>]</span>]
-      [<span class="Op"><b class="Fl" title="Fl">-g</b>
-      <var class="Ar" title="Ar">chars</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-i</b>
-      <var class="Ar" title="Ar">path</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-M</b>
-      <var class="Ar" title="Ar">dependfile</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-o</b>
-      <var class="Ar" title="Ar">outfile</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-p</b>
-      <var class="Ar" title="Ar">pad_value</var></span>]
-      <var class="Ar" title="Ar">file</var></td>
+    <td><code class="Nm">rgbasm</code></td>
+    <td>[<code class="Fl">-EhLVvw</code>] [<code class="Fl">-b</code>
+      <var class="Ar">chars</var>] [<code class="Fl">-D</code>
+      <var class="Ar">name</var>[=<var class="Ar">value</var>]]
+      [<code class="Fl">-g</code> <var class="Ar">chars</var>]
+      [<code class="Fl">-i</code> <var class="Ar">path</var>]
+      [<code class="Fl">-M</code> <var class="Ar">dependfile</var>]
+      [<code class="Fl">-o</code> <var class="Ar">outfile</var>]
+      [<code class="Fl">-p</code> <var class="Ar">pad_value</var>]
+      <var class="Ar">file</var></td>
   </tr>
 </table>
-<h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="selflink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-The <b class="Nm" title="Nm">rgbasm</b> program creates an object file from an
+</section>
+<section class="Sh">
+<h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+The <code class="Nm">rgbasm</code> program creates an object file from an
   assembly source file. Its arguments are as follows:
 <dl class="Bl-tag">
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#b"><b class="Fl" title="Fl" id="b">-b</b></a>
-    <var class="Ar" title="Ar">chars</var></dt>
-  <dd class="It-tag">Change the two characters used for binary constants. The
-      defaults are 01.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#D"><b class="Fl" title="Fl" id="D">-D</b></a>
-    <var class="Ar" title="Ar">name</var>[<span class="Op">=<var class="Ar" title="Ar">value</var></span>]</dt>
-  <dd class="It-tag">Add string symbol to the compiled source code. This is
-      equivalent to <var class="Ar" title="Ar">name</var>
-      <b class="Cm" title="Cm">EQUS</b>
-      &#x201C;<var class="Ar" title="Ar">value</var>&#x201D; in code. If a value
-      is not specified, a value of 1 is given.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#E"><b class="Fl" title="Fl" id="E">-E</b></a></dt>
-  <dd class="It-tag">Export all labels, including unreferenced and local
-    labels.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#g"><b class="Fl" title="Fl" id="g">-g</b></a>
-    <var class="Ar" title="Ar">chars</var></dt>
-  <dd class="It-tag">Change the four characters used for binary constants. The
-      defaults are 0123.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#h"><b class="Fl" title="Fl" id="h">-h</b></a></dt>
-  <dd class="It-tag">By default, <b class="Nm" title="Nm">rgbasm</b> inserts a
-      &#x2018;nop&#x2019; instruction immediately after any &#x2018;halt&#x2019;
-      instruction. The <b class="Fl" title="Fl">-h</b> option disables this
-      behavior.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#i"><b class="Fl" title="Fl" id="i">-i</b></a>
-    <var class="Ar" title="Ar">path</var></dt>
-  <dd class="It-tag">Add an include path.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#L"><b class="Fl" title="Fl" id="L">-L</b></a></dt>
-  <dd class="It-tag">Disable the optimization that turns loads of the form
-      <b class="Sy" title="Sy">LD [$FF00+n8],A</b> into the opcode
-      <b class="Sy" title="Sy">LDH [$FF00+n8],A</b> in order to have full
-      control of the result in the final ROM.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#M"><b class="Fl" title="Fl" id="M">-M</b></a>
-    <var class="Ar" title="Ar">dependfile</var></dt>
-  <dd class="It-tag">Print <a class="Xr" title="Xr">make(1)</a> dependencies to
-      <var class="Ar" title="Ar">dependfile</var>.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#o"><b class="Fl" title="Fl" id="o">-o</b></a>
-    <var class="Ar" title="Ar">outfile</var></dt>
-  <dd class="It-tag">Write an object file to the given filename.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#p"><b class="Fl" title="Fl" id="p">-p</b></a>
-    <var class="Ar" title="Ar">pad_value</var></dt>
-  <dd class="It-tag">When padding an image, pad with this value. The default is
-      0x00.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#V"><b class="Fl" title="Fl" id="V">-V</b></a></dt>
-  <dd class="It-tag">Print the version of the program and exit.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#v"><b class="Fl" title="Fl" id="v">-v</b></a></dt>
-  <dd class="It-tag">Be verbose.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#w"><b class="Fl" title="Fl" id="w">-w</b></a></dt>
-  <dd class="It-tag">Disable warning output.</dd>
+  <dt><a class="permalink" href="#b"><code class="Fl" id="b">-b</code></a>
+    <var class="Ar">chars</var></dt>
+  <dd>Change the two characters used for binary constants. The defaults are
+    01.</dd>
+  <dt><a class="permalink" href="#D"><code class="Fl" id="D">-D</code></a>
+    <var class="Ar">name</var>[=<var class="Ar">value</var>]</dt>
+  <dd>Add string symbol to the compiled source code. This is equivalent to
+      <var class="Ar">name</var> <code class="Cm">EQUS</code>
+      &#x201C;<var class="Ar">value</var>&#x201D; in code. If a value is not
+      specified, a value of 1 is given.</dd>
+  <dt><a class="permalink" href="#E"><code class="Fl" id="E">-E</code></a></dt>
+  <dd>Export all labels, including unreferenced and local labels.</dd>
+  <dt><a class="permalink" href="#g"><code class="Fl" id="g">-g</code></a>
+    <var class="Ar">chars</var></dt>
+  <dd>Change the four characters used for binary constants. The defaults are
+      0123.</dd>
+  <dt><a class="permalink" href="#h"><code class="Fl" id="h">-h</code></a></dt>
+  <dd>By default, <code class="Nm">rgbasm</code> inserts a &#x2018;nop&#x2019;
+      instruction immediately after any &#x2018;halt&#x2019; instruction. The
+      <code class="Fl">-h</code> option disables this behavior.</dd>
+  <dt><a class="permalink" href="#i"><code class="Fl" id="i">-i</code></a>
+    <var class="Ar">path</var></dt>
+  <dd>Add an include path.</dd>
+  <dt><a class="permalink" href="#L"><code class="Fl" id="L">-L</code></a></dt>
+  <dd>Disable the optimization that turns loads of the form <b class="Sy">LD
+      [$FF00+n8],A</b> into the opcode <b class="Sy">LDH [$FF00+n8],A</b> in
+      order to have full control of the result in the final ROM.</dd>
+  <dt><a class="permalink" href="#M"><code class="Fl" id="M">-M</code></a>
+    <var class="Ar">dependfile</var></dt>
+  <dd>Print <a class="Xr">make(1)</a> dependencies to
+      <var class="Ar">dependfile</var>.</dd>
+  <dt><a class="permalink" href="#o"><code class="Fl" id="o">-o</code></a>
+    <var class="Ar">outfile</var></dt>
+  <dd>Write an object file to the given filename.</dd>
+  <dt><a class="permalink" href="#p"><code class="Fl" id="p">-p</code></a>
+    <var class="Ar">pad_value</var></dt>
+  <dd>When padding an image, pad with this value. The default is 0x00.</dd>
+  <dt><a class="permalink" href="#V"><code class="Fl" id="V">-V</code></a></dt>
+  <dd>Print the version of the program and exit.</dd>
+  <dt><a class="permalink" href="#v"><code class="Fl" id="v">-v</code></a></dt>
+  <dd>Be verbose.</dd>
+  <dt><a class="permalink" href="#w"><code class="Fl" id="w">-w</code></a></dt>
+  <dd>Disable warning output.</dd>
 </dl>
-<h1 class="Sh" title="Sh" id="EXAMPLES"><a class="selflink" href="#EXAMPLES">EXAMPLES</a></h1>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
 Assembling a basic source file is simple:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
+<div class="Bd Pp Bd-indent">
+<pre>
 $ rgbasm -o bar.o foo.asm
 </pre>
 </div>
-<div class="Pp"></div>
-The resulting object file is not yet a usable ROM image &#x2014; it must first
-  be run through <a class="Xr" title="Xr">rgblink(1)</a> and
-  <a class="Xr" title="Xr">rgbfix(1)</a>.
-<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="selflink" href="#SEE_ALSO">SEE
+<p class="Pp">The resulting object file is not yet a usable ROM image &#x2014;
+    it must first be run through <a class="Xr">rgblink(1)</a> and
+    <a class="Xr">rgbfix(1)</a>.</p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" title="Xr">rgbasm(5)</a>, <a class="Xr" title="Xr">rgbfix(1)</a>,
-  <a class="Xr" title="Xr">rgblink(1)</a>,
-  <a class="Xr" title="Xr">rgbds(5)</a>, <a class="Xr" title="Xr">rgbds(7)</a>,
-  <a class="Xr" title="Xr">gbz80(7)</a>
-<h1 class="Sh" title="Sh" id="HISTORY"><a class="selflink" href="#HISTORY">HISTORY</a></h1>
-<b class="Nm" title="Nm">rgbasm</b> was originally written by Carsten
-  S&#x00F8;rensen as part of the ASMotor package, and was later packaged in
-  RGBDS by Justin Lloyd. It is now maintained by a number of contributors at
-  <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
+<a class="Xr">rgbasm(5)</a>, <a class="Xr">rgbfix(1)</a>,
+  <a class="Xr">rgblink(1)</a>, <a class="Xr">rgbds(5)</a>,
+  <a class="Xr">rgbds(7)</a>, <a class="Xr">gbz80(7)</a>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="HISTORY"><a class="permalink" href="#HISTORY">HISTORY</a></h1>
+<code class="Nm">rgbasm</code> was originally written by Carsten S&#x00F8;rensen
+  as part of the ASMotor package, and was later packaged in RGBDS by Justin
+  Lloyd. It is now maintained by a number of contributors at
+  <a class="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.
+</section>
+</div>
 <table class="foot">
   <tr>
     <td class="foot-date">February 24, 2018</td>

--- a/docs/rgbasm.5.html
+++ b/docs/rgbasm.5.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html>
+<!-- This is an automatically generated file.  Do not edit.
+   This file is part of RGBDS.
+
+   Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
+
+   SPDX-License-Identifier: MIT
+   -->
 <head>
   <meta charset="utf-8"/>
-  <style>
-    table.head, table.foot { width: 100%; }
-    td.head-rtitle, td.foot-os { text-align: right; }
-    td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-  </style>
   <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
   <title>RGBASM(5)</title>
 </head>
@@ -20,1121 +21,1010 @@
   </tr>
 </table>
 <div class="manual-text">
-<h1 class="Sh" title="Sh" id="NAME"><a class="selflink" href="#NAME">NAME</a></h1>
-<b class="Nm" title="Nm">rgbasm</b> &#x2014;
-  <span class="Nd" title="Nd">language documentation</span>
-<h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="selflink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<code class="Nm">rgbasm</code> &#x2014;
+<div class="Nd">language documentation</div>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 This is the full description of the language used by
-  <a class="Xr" title="Xr">rgbasm(1)</a>. The description of the instructions
-  supported by the GameBoy CPU is in <a class="Xr" title="Xr">gbz80(7)</a>.
-<h1 class="Sh" title="Sh" id="GENERAL"><a class="selflink" href="#GENERAL">GENERAL</a></h1>
-<h2 class="Ss" title="Ss" id="Syntax"><a class="selflink" href="#Syntax">Syntax</a></h2>
+  <a class="Xr">rgbasm(1)</a>. The description of the instructions supported by
+  the GameBoy CPU is in <a class="Xr">gbz80(7)</a>.
+</section>
+<section class="Sh">
+<h1 class="Sh" id="GENERAL"><a class="permalink" href="#GENERAL">GENERAL</a></h1>
+<section class="Ss">
+<h2 class="Ss" id="Syntax"><a class="permalink" href="#Syntax">Syntax</a></h2>
 The syntax is line&#x2010;based, just as in any other assembler, meaning that
   you do one instruction or pseudo&#x2010;op per line:
-<div class="Pp"></div>
-<div class="D1"><code class="Li">[<span class="Op"><var class="Ar" title="Ar">label</var></span>]
-  [<span class="Op"><var class="Ar" title="Ar">instruction</var></span>]
-  [<span class="Op"><var class="Ar" title="Ar">;comment</var></span>]</code></div>
-<div class="Pp"></div>
-Example:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
+<p class="Pp"></p>
+<div class="Bd Bd-indent"><code class="Li">[<var class="Ar">label</var>]
+  [<var class="Ar">instruction</var>]
+  [<var class="Ar">;comment</var>]</code></div>
+<p class="Pp">Example:</p>
+<div class="Bd Pp Bd-indent">
+<pre>
 John: ld a,87 ;Weee
 </pre>
 </div>
-<div class="Pp"></div>
-All pseudo&#x2010;ops, mnemonics and registers (reserved keywords) are
-  case&#x2010;insensitive and all labels are case&#x2010;sensitive.
-<div class="Pp"></div>
-There are two syntaxes for comments. In both cases, a comment ends at the end of
-  the line. The most common one is: anything that follows a semicolon
-  &#x2018;<code class="Li">;</code>&#x2019; (that isn't inside a string) is a
-  comment. There is another format: anything that follows a
-  &#x2018;<code class="Li">*</code>&#x2019; that is placed right at the start of
-  a line is a comment. The assembler removes all comments from the code before
-  doing anything else.
-<div class="Pp"></div>
-Sometimes lines can be too long and it may be necessary to split them. The
-  syntax to do so is the following one:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-    DB 1, 2, 3, 4 \ 
+<p class="Pp">All pseudo&#x2010;ops, mnemonics and registers (reserved keywords)
+    are case&#x2010;insensitive and all labels are case&#x2010;sensitive.</p>
+<p class="Pp">There are two syntaxes for comments. In both cases, a comment ends
+    at the end of the line. The most common one is: anything that follows a
+    semicolon &#x2018;<code class="Li">;</code>&#x2019; (that isn't inside a
+    string) is a comment. There is another format: anything that follows a
+    &#x2018;<code class="Li">*</code>&#x2019; that is placed right at the start
+    of a line is a comment. The assembler removes all comments from the code
+    before doing anything else.</p>
+<p class="Pp">Sometimes lines can be too long and it may be necessary to split
+    them. The syntax to do so is the following one:</p>
+<div class="Bd Pp Bd-indent">
+<pre>
+    DB 1, 2, 3, 4 \
        5, 6, 7, 8
 </pre>
 </div>
-<div class="Pp"></div>
-This works anywhere in the code except inside of strings. To split strings it is
-  needed to use <b class="Fn" title="Fn">STRCAT</b>() like this:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-    DB STRCAT(&quot;Hello &quot;, \ 
+<p class="Pp">This works anywhere in the code except inside of strings. To split
+    strings it is needed to use <code class="Fn">STRCAT</code>() like this:</p>
+<div class="Bd Pp Bd-indent">
+<pre>
+    DB STRCAT(&quot;Hello &quot;, \
               &quot;world!&quot;)
 </pre>
 </div>
-<h2 class="Ss" title="Ss" id="Sections"><a class="selflink" href="#Sections">Sections</a></h2>
-<b class="Ic" title="Ic">SECTION</b> <var class="Ar" title="Ar">name</var>,
-  <var class="Ar" title="Ar">type</var>
-<div class="Pp"></div>
-<b class="Ic" title="Ic">SECTION</b> <var class="Ar" title="Ar">name</var>,
-  <var class="Ar" title="Ar">type</var>,
-  <var class="Ar" title="Ar">options</var>
-<div class="Pp"></div>
-<b class="Ic" title="Ic">SECTION</b> <var class="Ar" title="Ar">name</var>,
-  <var class="Ar" title="Ar">type</var>[<var class="Ar" title="Ar">addr</var>]
-<div class="Pp"></div>
-<b class="Ic" title="Ic">SECTION</b> <var class="Ar" title="Ar">name</var>,
-  <var class="Ar" title="Ar">type</var>[<var class="Ar" title="Ar">addr</var>],
-  <var class="Ar" title="Ar">options</var>
-<div class="Pp"></div>
-Before you can start writing code, you must define a section. This tells the
-  assembler what kind of information follows and, if it is code, where to put
-  it.
-<div class="Pp"></div>
-<var class="Ar" title="Ar">name</var> is a string enclosed in double quotes and
-  can be a new name or the name of an existing section. All sections assembled
-  at the same time that have the same name and type are considered to be the
-  same section, and their code is put together in the object file generated by
-  the assembler. All other sections must have a unique name, even in different
-  source files, or the linker will treat it as an error.
-<div class="Pp"></div>
-Possible section <var class="Ar" title="Ar">type</var>s are as follows:
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Sections"><a class="permalink" href="#Sections">Sections</a></h2>
+<code class="Ic">SECTION</code> <var class="Ar">name</var>,
+  <var class="Ar">type</var>
+<p class="Pp"><code class="Ic">SECTION</code> <var class="Ar">name</var>,
+    <var class="Ar">type</var>, <var class="Ar">options</var></p>
+<p class="Pp"><code class="Ic">SECTION</code> <var class="Ar">name</var>,
+    <var class="Ar">type</var>[<var class="Ar">addr</var>]</p>
+<p class="Pp"><code class="Ic">SECTION</code> <var class="Ar">name</var>,
+    <var class="Ar">type</var>[<var class="Ar">addr</var>],
+    <var class="Ar">options</var></p>
+<p class="Pp">Before you can start writing code, you must define a section. This
+    tells the assembler what kind of information follows and, if it is code,
+    where to put it.</p>
+<p class="Pp"><var class="Ar">name</var> is a string enclosed in double quotes
+    and can be a new name or the name of an existing section. All sections
+    assembled at the same time that have the same name and type are considered
+    to be the same section, and their code is put together in the object file
+    generated by the assembler. All other sections must have a unique name, even
+    in different source files, or the linker will treat it as an error.</p>
+<p class="Pp">Possible section <var class="Ar">type</var>s are as follows:</p>
 <dl class="Bl-tag">
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#ROM0"><b class="Cm" title="Cm" id="ROM0">ROM0</b></a></dt>
-  <dd class="It-tag">A ROM section. <var class="Ar" title="Ar">addr</var> can
-      range from $0000&#x2013;$3FFF (or $0000&#x2013;$7FFF if tiny ROM mode is
-      enabled in <a class="Xr" title="Xr">rgblink(1)</a>).</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#ROMX"><b class="Cm" title="Cm" id="ROMX">ROMX</b></a></dt>
-  <dd class="It-tag">A banked ROM section. <var class="Ar" title="Ar">addr</var>
-      can range from $4000&#x2013;$7FFF. <var class="Ar" title="Ar">bank</var>
-      can range from 1 to 511. Not available if tiny ROM mode is enabled in
-      <a class="Xr" title="Xr">rgblink(1)</a>.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#VRAM"><b class="Cm" title="Cm" id="VRAM">VRAM</b></a></dt>
-  <dd class="It-tag">A banked video RAM section.
-      <var class="Ar" title="Ar">addr</var> can range from $8000&#x2013;$9FFF.
-      <var class="Ar" title="Ar">bank</var> can be 0 or 1 but bank 1 is
-      unavailable if DMG mode is enabled in
-      <a class="Xr" title="Xr">rgblink(1)</a>. Memory in this section can only
-      be allocated with <b class="Sy" title="Sy">DS</b>, not filled with
-    data.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#SRAM"><b class="Cm" title="Cm" id="SRAM">SRAM</b></a></dt>
-  <dd class="It-tag">A banked external (save) RAM section.
-      <var class="Ar" title="Ar">addr</var> can range from $A000&#x2013;$BFFF.
-      <var class="Ar" title="Ar">bank</var> can range from 0 to 15. Memory in
-      this section can only be allocated with <b class="Sy" title="Sy">DS</b>,
-      not filled with data.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#WRAM0"><b class="Cm" title="Cm" id="WRAM0">WRAM0</b></a></dt>
-  <dd class="It-tag">A general-purpose RAM section.
-      <var class="Ar" title="Ar">addr</var> can range from $C000&#x2013;$CFFF,
-      or $C000&#x2013;$DFFF if DMG mode is enabled in
-      <a class="Xr" title="Xr">rgblink(1)</a>. Memory in this section can only
-      be allocated with <b class="Sy" title="Sy">DS</b>, not filled with
-    data.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#WRAMX"><b class="Cm" title="Cm" id="WRAMX">WRAMX</b></a></dt>
-  <dd class="It-tag">A banked general-purpose RAM section.
-      <var class="Ar" title="Ar">addr</var> can range from $D000&#x2013;$DFFF.
-      <var class="Ar" title="Ar">bank</var> can range from 1 to 7. Memory in
-      this section can only be allocated with <b class="Sy" title="Sy">DS</b>,
+  <dt><a class="permalink" href="#ROM0"><code class="Cm" id="ROM0">ROM0</code></a></dt>
+  <dd>A ROM section. <var class="Ar">addr</var> can range from
+      $0000&#x2013;$3FFF (or $0000&#x2013;$7FFF if tiny ROM mode is enabled in
+      <a class="Xr">rgblink(1)</a>).</dd>
+  <dt><a class="permalink" href="#ROMX"><code class="Cm" id="ROMX">ROMX</code></a></dt>
+  <dd>A banked ROM section. <var class="Ar">addr</var> can range from
+      $4000&#x2013;$7FFF. <var class="Ar">bank</var> can range from 1 to 511.
+      Not available if tiny ROM mode is enabled in
+    <a class="Xr">rgblink(1)</a>.</dd>
+  <dt><a class="permalink" href="#VRAM"><code class="Cm" id="VRAM">VRAM</code></a></dt>
+  <dd>A banked video RAM section. <var class="Ar">addr</var> can range from
+      $8000&#x2013;$9FFF. <var class="Ar">bank</var> can be 0 or 1 but bank 1 is
+      unavailable if DMG mode is enabled in <a class="Xr">rgblink(1)</a>. Memory
+      in this section can only be allocated with <b class="Sy">DS</b>, not
+      filled with data.</dd>
+  <dt><a class="permalink" href="#SRAM"><code class="Cm" id="SRAM">SRAM</code></a></dt>
+  <dd>A banked external (save) RAM section. <var class="Ar">addr</var> can range
+      from $A000&#x2013;$BFFF. <var class="Ar">bank</var> can range from 0 to
+      15. Memory in this section can only be allocated with
+      <b class="Sy">DS</b>, not filled with data.</dd>
+  <dt><a class="permalink" href="#WRAM0"><code class="Cm" id="WRAM0">WRAM0</code></a></dt>
+  <dd>A general-purpose RAM section. <var class="Ar">addr</var> can range from
+      $C000&#x2013;$CFFF, or $C000&#x2013;$DFFF if DMG mode is enabled in
+      <a class="Xr">rgblink(1)</a>. Memory in this section can only be allocated
+      with <b class="Sy">DS</b>, not filled with data.</dd>
+  <dt><a class="permalink" href="#WRAMX"><code class="Cm" id="WRAMX">WRAMX</code></a></dt>
+  <dd>A banked general-purpose RAM section. <var class="Ar">addr</var> can range
+      from $D000&#x2013;$DFFF. <var class="Ar">bank</var> can range from 1 to 7.
+      Memory in this section can only be allocated with <b class="Sy">DS</b>,
       not filled with data. Not available if DMG mode is enabled in
-      <a class="Xr" title="Xr">rgblink(1)</a>.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#OAM"><b class="Cm" title="Cm" id="OAM">OAM</b></a></dt>
-  <dd class="It-tag">An object attributes RAM section.
-      <var class="Ar" title="Ar">addr</var> can range from $FE00-$FE9F. Memory
-      in this section can only be allocated with
-      <b class="Sy" title="Sy">DS</b>, not filled with data.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#HRAM"><b class="Cm" title="Cm" id="HRAM">HRAM</b></a></dt>
-  <dd class="It-tag">A high RAM section. <var class="Ar" title="Ar">addr</var>
-      can range from $FF80&#x2013;$FFFE. Memory in this section can only be
-      allocated with <b class="Sy" title="Sy">DS</b>, not filled with data.
-    <div class="Pp"></div>
-    <b class="Sy" title="Sy">Note</b>: If you use this method of allocating HRAM
-      the assembler will <i class="Em" title="Em">not</i> choose the short
-      addressing mode in the LD instructions <b class="Sy" title="Sy">LD
-      [$FF00+n8],A</b> and <b class="Sy" title="Sy">LD A,[$FF00+n8]</b> because
-      the actual address calculation is done by the linker. If you find this
-      undesirable you can use <b class="Ic" title="Ic">RSSET</b>,
-      <b class="Ic" title="Ic">RB</b>, or <b class="Ic" title="Ic">RW</b>
-      instead or use the <b class="Sy" title="Sy">LDH [$FF00+n8],A</b> and
-      <b class="Sy" title="Sy">LDH A,[$FF00+n8]</b> syntax instead. This forces
-      the assembler to emit the correct instruction and the linker to check if
-      the value is in the correct range. This optimization can be disabled by
-      passing the <b class="Fl" title="Fl">-L</b> flag to
-      <a class="Xr" title="Xr">rgbasm(1)</a>.</dd>
+      <a class="Xr">rgblink(1)</a>.</dd>
+  <dt><a class="permalink" href="#OAM"><code class="Cm" id="OAM">OAM</code></a></dt>
+  <dd>An object attributes RAM section. <var class="Ar">addr</var> can range
+      from $FE00-$FE9F. Memory in this section can only be allocated with
+      <b class="Sy">DS</b>, not filled with data.</dd>
+  <dt><a class="permalink" href="#HRAM"><code class="Cm" id="HRAM">HRAM</code></a></dt>
+  <dd>A high RAM section. <var class="Ar">addr</var> can range from
+      $FF80&#x2013;$FFFE. Memory in this section can only be allocated with
+      <b class="Sy">DS</b>, not filled with data.
+    <p class="Pp"><b class="Sy">Note</b>: If you use this method of allocating
+        HRAM the assembler will <i class="Em">not</i> choose the short
+        addressing mode in the LD instructions <b class="Sy">LD [$FF00+n8],A</b>
+        and <b class="Sy">LD A,[$FF00+n8]</b> because the actual address
+        calculation is done by the linker. If you find this undesirable you can
+        use <code class="Ic">RSSET</code>, <code class="Ic">RB</code>, or
+        <code class="Ic">RW</code> instead or use the <b class="Sy">LDH
+        [$FF00+n8],A</b> and <b class="Sy">LDH A,[$FF00+n8]</b> syntax instead.
+        This forces the assembler to emit the correct instruction and the linker
+        to check if the value is in the correct range. This optimization can be
+        disabled by passing the <code class="Fl">-L</code> flag to
+        <a class="Xr">rgbasm(1)</a>.</p>
+  </dd>
 </dl>
-<div class="Pp"></div>
-<var class="Ar" title="Ar">option</var>s are comma separated and may include:
+<p class="Pp"><var class="Ar">option</var>s are comma separated and may
+  include:</p>
 <dl class="Bl-tag">
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#BANK"><b class="Cm" title="Cm" id="BANK">BANK</b></a>[<var class="Ar" title="Ar">bank</var>]</dt>
-  <dd class="It-tag">Specify which <var class="Ar" title="Ar">bank</var> for the
-      linker to place the section.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#ALIGN"><b class="Cm" title="Cm" id="ALIGN">ALIGN</b></a>[<var class="Ar" title="Ar">align</var>]</dt>
-  <dd class="It-tag">Place the section at an address whose
-      <var class="Ar" title="Ar">align</var> least&#x2010;significant bits are
-      zero. It is a syntax error to use this option with
-      <var class="Ar" title="Ar">addr</var>.</dd>
+  <dt><a class="permalink" href="#BANK"><code class="Cm" id="BANK">BANK</code></a>[<var class="Ar">bank</var>]</dt>
+  <dd>Specify which <var class="Ar">bank</var> for the linker to place the
+      section.</dd>
+  <dt><a class="permalink" href="#ALIGN"><code class="Cm" id="ALIGN">ALIGN</code></a>[<var class="Ar">align</var>]</dt>
+  <dd>Place the section at an address whose <var class="Ar">align</var>
+      least&#x2010;significant bits are zero. It is a syntax error to use this
+      option with <var class="Ar">addr</var>.</dd>
 </dl>
-<div class="Pp"></div>
-If [<var class="Ar" title="Ar">addr</var>] is not specified, the section is
-  considered &#x201C;floating&#x201D;; the linker will automatically calculate
-  an appropriate address for the section. Similarly, if
-  <b class="Cm" title="Cm">BANK</b>[<var class="Ar" title="Ar">bank</var>] is
-  not specified, the linker will automatically find a bank with enough space.
-<div class="Pp"></div>
-Sections can also be placed by using a linkerscript file. The format is
-  described in <a class="Xr" title="Xr">rgblink(5)</a>. They allow the user to
-  place floating sections in the desired bank in the order specified in the
-  script. This is useful if the sections can't be placed at an address manually
-  because the size may change, but they have to be together.
-<div class="Pp"></div>
-Section examples:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
+<p class="Pp">If [<var class="Ar">addr</var>] is not specified, the section is
+    considered &#x201C;floating&#x201D;; the linker will automatically calculate
+    an appropriate address for the section. Similarly, if
+    <code class="Cm">BANK</code>[<var class="Ar">bank</var>] is not specified,
+    the linker will automatically find a bank with enough space.</p>
+<p class="Pp">Sections can also be placed by using a linkerscript file. The
+    format is described in <a class="Xr">rgblink(5)</a>. They allow the user to
+    place floating sections in the desired bank in the order specified in the
+    script. This is useful if the sections can't be placed at an address
+    manually because the size may change, but they have to be together.</p>
+<p class="Pp">Section examples:</p>
+<div class="Bd Pp Bd-indent">
+<pre>
     SECTION &quot;CoolStuff&quot;,ROMX
 </pre>
 </div>
-<div class="Pp"></div>
-This switches to the section called &#x201C;CoolStuff&#x201D; (or creates it if
-  it doesn't already exist) and defines it as a code section.
-<div class="Pp"></div>
-The following example defines a section that can be placed anywhere in any ROMX
-  bank:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
+<p class="Pp">This switches to the section called &#x201C;CoolStuff&#x201D; (or
+    creates it if it doesn't already exist) and defines it as a code
+  section.</p>
+<p class="Pp">The following example defines a section that can be placed
+    anywhere in any ROMX bank:</p>
+<div class="Bd Pp Bd-indent">
+<pre>
     SECTION &quot;CoolStuff&quot;,ROMX
 </pre>
 </div>
-<div class="Pp"></div>
-If it is needed, the the base address of the section can be specified:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
+<p class="Pp">If it is needed, the the base address of the section can be
+    specified:</p>
+<div class="Bd Pp Bd-indent">
+<pre>
     SECTION &quot;CoolStuff&quot;,ROMX[$4567]
 </pre>
 </div>
-<div class="Pp"></div>
-An example with a fixed bank:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
+<p class="Pp">An example with a fixed bank:</p>
+<div class="Bd Pp Bd-indent">
+<pre>
     SECTION &quot;CoolStuff&quot;,ROMX[$4567],BANK[3]
 </pre>
 </div>
-<div class="Pp"></div>
-And if you only want to force the section into a certain bank, and not it's
-  position within the bank, that's also possible:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
+<p class="Pp">And if you only want to force the section into a certain bank, and
+    not it's position within the bank, that's also possible:</p>
+<div class="Bd Pp Bd-indent">
+<pre>
     SECTION &quot;CoolStuff&quot;,ROMX,BANK[7]
 </pre>
 </div>
-<div class="Pp"></div>
-Alignment examples: one use could be when using DMA to copy data or when it is
-  needed to align the start of an array to 256 bytes to optimize the code that
-  accesses it.
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-    SECTION &quot;OAM Data&quot;,WRAM0,ALIGN[8] ; align to 256 bytes 
- 
+<p class="Pp">Alignment examples: one use could be when using DMA to copy data
+    or when it is needed to align the start of an array to 256 bytes to optimize
+    the code that accesses it.</p>
+<div class="Bd Pp Bd-indent">
+<pre>
+    SECTION &quot;OAM Data&quot;,WRAM0,ALIGN[8] ; align to 256 bytes
+
     SECTION &quot;VRAM Data&quot;,ROMX,BANK[2],ALIGN[4] ; align to 16 bytes
 </pre>
 </div>
-<div class="Pp"></div>
-<b class="Sy" title="Sy">Hint</b>: If you think this is a lot of typing for
-  doing a simple &#x201C;org&#x201D; type thing you can quite easily write an
-  intelligent macro (called <b class="Ic" title="Ic">ORG</b> for example) that
-  uses <b class="Ic" title="Ic">@</b> for the section name and determines
-  correct section type etc as arguments for
-  <b class="Ic" title="Ic">SECTION</b>.
-<h2 class="Ss" title="Ss" id="Section_Stack"><a class="selflink" href="#Section_Stack">Section
+<p class="Pp"><b class="Sy">Hint</b>: If you think this is a lot of typing for
+    doing a simple &#x201C;org&#x201D; type thing you can quite easily write an
+    intelligent macro (called <code class="Ic">ORG</code> for example) that uses
+    <code class="Ic">@</code> for the section name and determines correct
+    section type etc as arguments for <code class="Ic">SECTION</code>.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Section_Stack"><a class="permalink" href="#Section_Stack">Section
   Stack</a></h2>
-<b class="Ic" title="Ic">POPS</b> and <b class="Ic" title="Ic">PUSHS</b> provide
-  the interface to the section stack.
-<div class="Pp"></div>
-<b class="Ic" title="Ic">PUSHS</b> will push the current section context on the
-  section stack. <b class="Ic" title="Ic">POPS</b> can then later be used to
-  restore it. Useful for defining sections in included files when you don't want
-  to destroy the section context for the program that included your file. The
-  number of entries in the stack is limited only by the amount of memory in your
-  machine.
-<h1 class="Sh" title="Sh" id="SYMBOLS"><a class="selflink" href="#SYMBOLS">SYMBOLS</a></h1>
-<h2 class="Ss" title="Ss" id="Symbols"><a class="selflink" href="#Symbols">Symbols</a></h2>
+<code class="Ic">POPS</code> and <code class="Ic">PUSHS</code> provide the
+  interface to the section stack.
+<p class="Pp"><code class="Ic">PUSHS</code> will push the current section
+    context on the section stack. <code class="Ic">POPS</code> can then later be
+    used to restore it. Useful for defining sections in included files when you
+    don't want to destroy the section context for the program that included your
+    file. The number of entries in the stack is limited only by the amount of
+    memory in your machine.</p>
+</section>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SYMBOLS"><a class="permalink" href="#SYMBOLS">SYMBOLS</a></h1>
+<section class="Ss">
+<h2 class="Ss" id="Symbols"><a class="permalink" href="#Symbols">Symbols</a></h2>
 RGBDS supports several types of symbols:
 <dl class="Bl-hang">
-  <dt class="It-hang"><b class="Sy" title="Sy">Label</b></dt>
-  <dd class="It-hang">Used to assign a memory location with a name</dd>
-  <dt class="It-hang"><b class="Sy" title="Sy">EQUate</b></dt>
-  <dd class="It-hang">Give a constant a name.</dd>
-  <dt class="It-hang"><b class="Sy" title="Sy">SET</b></dt>
-  <dd class="It-hang">Almost the same as EQUate, but you can change the value of
-      a SET during assembling.</dd>
-  <dt class="It-hang"><b class="Sy" title="Sy">Structure</b>
-    (<b class="Sy" title="Sy">the RS group</b>)</dt>
-  <dd class="It-hang">Define a structure easily.</dd>
-  <dt class="It-hang"><b class="Sy" title="Sy">String equate</b>
-    (<b class="Sy" title="Sy">EQUS</b>)</dt>
-  <dd class="It-hang">Give a frequently used string a name. Can also be used as
-      a mini-macro, like <b class="Fd" title="Fd">#define</b> in C.</dd>
-  <dt class="It-hang"><b class="Sy" title="Sy">MACRO</b></dt>
-  <dd class="It-hang">A block of code or pseudo instructions that you invoke
-      like any other mnemonic. You can give them arguments too.</dd>
+  <dt><b class="Sy">Label</b></dt>
+  <dd>Used to assign a memory location with a name</dd>
+  <dt><b class="Sy">EQUate</b></dt>
+  <dd>Give a constant a name.</dd>
+  <dt><b class="Sy">SET</b></dt>
+  <dd>Almost the same as EQUate, but you can change the value of a SET during
+      assembling.</dd>
+  <dt><b class="Sy">Structure</b> (<b class="Sy">the RS group</b>)</dt>
+  <dd>Define a structure easily.</dd>
+  <dt><b class="Sy">String equate</b> (<b class="Sy">EQUS</b>)</dt>
+  <dd>Give a frequently used string a name. Can also be used as a mini-macro,
+      like <code class="Fd">#define</code> in C.</dd>
+  <dt><b class="Sy">MACRO</b></dt>
+  <dd>A block of code or pseudo instructions that you invoke like any other
+      mnemonic. You can give them arguments too.</dd>
 </dl>
-<div class="Pp"></div>
-A symbol cannot have the same name as a reserved keyword.
+<p class="Pp">A symbol cannot have the same name as a reserved keyword.</p>
 <dl class="Bl-hang">
-  <dt class="It-hang"><b class="Sy" title="Sy">Label</b></dt>
-  <dd class="It-hang">
-    <div class="Pp"></div>
-    One of the assembler's main tasks is to keep track of addresses for you so
-      you don't have to remember obscure numbers but can make do with a
-      meaningful name, a label.
-    <div class="Pp"></div>
-    This can be done in a number of ways:
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
-GlobalLabel 
-AnotherGlobal: 
-.locallabel 
-.yet_a_local: 
-AnotherGlobal.with_another_local: 
-ThisWillBeExported:: ;note the two colons 
+  <dt><b class="Sy">Label</b></dt>
+  <dd>
+    <p class="Pp">One of the assembler's main tasks is to keep track of
+        addresses for you so you don't have to remember obscure numbers but can
+        make do with a meaningful name, a label.</p>
+    <p class="Pp">This can be done in a number of ways:</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
+GlobalLabel
+AnotherGlobal:
+.locallabel
+.yet_a_local:
+AnotherGlobal.with_another_local:
+ThisWillBeExported:: ;note the two colons
 ThisWillBeExported.too::
     </pre>
     </div>
-    <div class="Pp"></div>
-    In the line where a label is defined there musn't be any whitespace before
-      it. Local labels are only accessible within the scope they are defined. A
-      scope starts after a global label and ends at the next global label.
-      Declaring a label (global or local) with :: does an EXPORT at the same
-      time. Local labels can be declared as scope.local or simply as as .local.
-      If the former notation is used, the scope must be the actual current
-      scope.
-    <div class="Pp"></div>
-    Labels will normally change their value during the link process and are thus
-      not constant. The exception is the case in which the base address of a
-      section is fixed, so the address of the label is known at assembly time.
-    <div class="Pp"></div>
-    The subtraction of two labels is only constant (known at assembly time) if
-      they are two local labels that belong to the same scope, or they are two
-      global labels that belong to sections with fixed base addresses.</dd>
-  <dt class="It-hang"><b class="Sy" title="Sy">EQU</b></dt>
-  <dd class="It-hang">
-    <div class="Pp"></div>
-    EQUates are constant symbols. They can, for example, be used for things such
-      as bit-definitions of hardware registers.
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
-EXIT_OK      EQU $00 
+    <p class="Pp">In the line where a label is defined there musn't be any
+        whitespace before it. Local labels are only accessible within the scope
+        they are defined. A scope starts after a global label and ends at the
+        next global label. Declaring a label (global or local) with :: does an
+        EXPORT at the same time. Local labels can be declared as scope.local or
+        simply as as .local. If the former notation is used, the scope must be
+        the actual current scope.</p>
+    <p class="Pp">Labels will normally change their value during the link
+        process and are thus not constant. The exception is the case in which
+        the base address of a section is fixed, so the address of the label is
+        known at assembly time.</p>
+    <p class="Pp">The subtraction of two labels is only constant (known at
+        assembly time) if they are two local labels that belong to the same
+        scope, or they are two global labels that belong to sections with fixed
+        base addresses.</p>
+  </dd>
+  <dt><b class="Sy">EQU</b></dt>
+  <dd>
+    <p class="Pp">EQUates are constant symbols. They can, for example, be used
+        for things such as bit-definitions of hardware registers.</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
+EXIT_OK      EQU $00
 EXIT_FAILURE EQU $01
     </pre>
     </div>
-    <div class="Pp"></div>
-    Note that a colon (:) following the label-name is not allowed. EQUates
-      cannot be exported and imported. They don't change their value during the
-      link process.</dd>
-  <dt class="It-hang"><b class="Sy" title="Sy">SET</b></dt>
-  <dd class="It-hang">
-    <div class="Pp"></div>
-    SETs are similar to EQUates. They are also constant symbols in the sense
-      that their values are defined during the assembly process. These symbols
-      are normally used in macros.
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
-ARRAY_SIZE EQU 4 
-COUNT      SET 2 
+    <p class="Pp">Note that a colon (:) following the label-name is not allowed.
+        EQUates cannot be exported and imported. They don't change their value
+        during the link process.</p>
+  </dd>
+  <dt><b class="Sy">SET</b></dt>
+  <dd>
+    <p class="Pp">SETs are similar to EQUates. They are also constant symbols in
+        the sense that their values are defined during the assembly process.
+        These symbols are normally used in macros.</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
+ARRAY_SIZE EQU 4
+COUNT      SET 2
 COUNT      SET ARRAY_SIZE+COUNT
     </pre>
     </div>
-    <div class="Pp"></div>
-    Note that a colon (:) following the label-name is not allowed. SETs cannot
-      be exported and imported. Alternatively you can use = as a synonym for
-      SET.
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
+    <p class="Pp">Note that a colon (:) following the label-name is not allowed.
+        SETs cannot be exported and imported. Alternatively you can use = as a
+        synonym for SET.</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
 COUNT = 2
     </pre>
     </div>
   </dd>
-  <dt class="It-hang"><b class="Sy" title="Sy">RSSET</b>,
-    <b class="Sy" title="Sy">RSRESET</b>, <b class="Sy" title="Sy">RB</b>,
-    <b class="Sy" title="Sy">RW</b></dt>
-  <dd class="It-hang">
-    <div class="Pp"></div>
-    The RS group of commands is a handy way of defining structures:
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
-              RSRESET 
-str_pStuff    RW   1 
-str_tData     RB   256 
-str_bCount    RB   1 
+  <dt><b class="Sy">RSSET</b>, <b class="Sy">RSRESET</b>, <b class="Sy">RB</b>,
+    <b class="Sy">RW</b></dt>
+  <dd>
+    <p class="Pp">The RS group of commands is a handy way of defining
+        structures:</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
+              RSRESET
+str_pStuff    RW   1
+str_tData     RB   256
+str_bCount    RB   1
 str_SIZEOF    RB   0
     </pre>
     </div>
-    <div class="Pp"></div>
-    The example defines four equated symbols:
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
-str_pStuff = 0 
-str_tData  = 2 
-str_bCount = 258 
+    <p class="Pp">The example defines four equated symbols:</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
+str_pStuff = 0
+str_tData  = 2
+str_bCount = 258
 str_SIZEOF = 259
     </pre>
     </div>
-    <div class="Pp"></div>
-    There are four commands in the RS group of commands:
+    <p class="Pp">There are four commands in the RS group of commands:</p>
     <table class="Bl-column">
-      <colgroup>
-        <col style="min-width: 15.00ex;"/>
-      </colgroup>
-      <tr class="It-column">
-        <td class="It-column"><b class="Sy" title="Sy">Command</b></td>
-        <td class="It-column"><b class="Sy" title="Sy">Meaning</b></td>
+      <tr>
+        <td><b class="Sy">Command</b></td>
+        <td><b class="Sy">Meaning</b></td>
       </tr>
-      <tr class="It-column">
-        <td class="It-column"><a class="selflink" href="#RSRESET"><b class="Ic" title="Ic" id="RSRESET">RSRESET</b></a></td>
-        <td class="It-column">Resets the _RS counter to zero.</td>
+      <tr>
+        <td><a class="permalink" href="#RSRESET"><code class="Ic" id="RSRESET">RSRESET</code></a></td>
+        <td>Resets the _RS counter to zero.</td>
       </tr>
-      <tr class="It-column">
-        <td class="It-column"><a class="selflink" href="#RSSET"><b class="Ic" title="Ic" id="RSSET">RSSET</b></a>
-          <var class="Ar" title="Ar">constexpr</var></td>
-        <td class="It-column">Sets the <b class="Ic" title="Ic">_RS</b>
-          <span class="No">counter to</span>
-          <var class="Ar" title="Ar">constexpr</var>.</td>
+      <tr>
+        <td><a class="permalink" href="#RSSET"><code class="Ic" id="RSSET">RSSET</code></a>
+          <var class="Ar">constexpr</var></td>
+        <td>Sets the <code class="Ic">_RS</code> <span class="No">counter
+          to</span> <var class="Ar">constexpr</var>.</td>
       </tr>
-      <tr class="It-column">
-        <td class="It-column"><a class="selflink" href="#RB"><b class="Ic" title="Ic" id="RB">RB</b></a>
-          <var class="Ar" title="Ar">constexpr</var></td>
-        <td class="It-column">Sets the preceding symbol to
-          <b class="Ic" title="Ic">_RS</b> <span class="No">and adds</span>
-          <var class="Ar" title="Ar">constexpr</var> <span class="No">to</span>
-          <b class="Ic" title="Ic">_RS</b>.</td>
+      <tr>
+        <td><a class="permalink" href="#RB"><code class="Ic" id="RB">RB</code></a>
+          <var class="Ar">constexpr</var></td>
+        <td>Sets the preceding symbol to <code class="Ic">_RS</code>
+          <span class="No">and adds</span> <var class="Ar">constexpr</var>
+          <span class="No">to</span> <code class="Ic">_RS</code>.</td>
       </tr>
-      <tr class="It-column">
-        <td class="It-column"><a class="selflink" href="#RW"><b class="Ic" title="Ic" id="RW">RW</b></a>
-          <var class="Ar" title="Ar">constexpr</var></td>
-        <td class="It-column">Sets the preceding symbol to
-          <b class="Ic" title="Ic">_RS</b> <span class="No">and adds</span>
-          <var class="Ar" title="Ar">constexpr</var> <span class="No">* 2
-          to</span> <b class="Ic" title="Ic">_RS.</b></td>
+      <tr>
+        <td><a class="permalink" href="#RW"><code class="Ic" id="RW">RW</code></a>
+          <var class="Ar">constexpr</var></td>
+        <td>Sets the preceding symbol to <code class="Ic">_RS</code>
+          <span class="No">and adds</span> <var class="Ar">constexpr</var>
+          <span class="No">* 2 to</span> <code class="Ic">_RS.</code></td>
       </tr>
-      <tr class="It-column">
-        <td class="It-column"><a class="selflink" href="#RL"><b class="Ic" title="Ic" id="RL">RL</b></a>
-          <var class="Ar" title="Ar">constexpr</var></td>
-        <td class="It-column">Sets the preceding symbol to
-          <b class="Ic" title="Ic">_RS</b> <span class="No">and adds</span>
-          <var class="Ar" title="Ar">constexpr</var> <span class="No">* 4
-          to</span> <b class="Ic" title="Ic">_RS.</b></td>
+      <tr>
+        <td><a class="permalink" href="#RL"><code class="Ic" id="RL">RL</code></a>
+          <var class="Ar">constexpr</var></td>
+        <td>Sets the preceding symbol to <code class="Ic">_RS</code>
+          <span class="No">and adds</span> <var class="Ar">constexpr</var>
+          <span class="No">* 4 to</span> <code class="Ic">_RS.</code></td>
       </tr>
     </table>
-    <div class="Pp"></div>
-    Note that a colon (:) following the symbol-name is not allowed.
-      <b class="Sy" title="Sy">RS</b> symbols cannot be exported and imported.
-      They don't change their value during the link process.</dd>
-  <dt class="It-hang"><b class="Sy" title="Sy">EQUS</b></dt>
-  <dd class="It-hang">
-    <div class="Pp"></div>
-    EQUS is used to define string-symbols. Wherever the assembler meets a string
-      symbol its name is replaced with its value. If you are familiar with C you
-      can think of it as the same as <b class="Fd" title="Fd">#define .</b>
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
-COUNTREG EQUS &quot;[hl+]&quot; 
-    ld a,COUNTREG 
- 
-PLAYER_NAME EQUS &quot;\&quot;John\&quot;&quot; 
+    <p class="Pp">Note that a colon (:) following the symbol-name is not
+        allowed. <b class="Sy">RS</b> symbols cannot be exported and imported.
+        They don't change their value during the link process.</p>
+  </dd>
+  <dt><b class="Sy">EQUS</b></dt>
+  <dd>
+    <p class="Pp">EQUS is used to define string-symbols. Wherever the assembler
+        meets a string symbol its name is replaced with its value. If you are
+        familiar with C you can think of it as the same as
+        <code class="Fd">#define .</code></p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
+COUNTREG EQUS &quot;[hl+]&quot;
+    ld a,COUNTREG
+
+PLAYER_NAME EQUS &quot;\&quot;John\&quot;&quot;
     db PLAYER_NAME
     </pre>
     </div>
-    <div class="Pp"></div>
-    Note that : following the label-name is not allowed, and that strings must
-      be quoted to be useful.
-    <div class="Pp"></div>
-    This will be interpreted as:
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
-    ld a,[hl+] 
+    <p class="Pp">Note that : following the label-name is not allowed, and that
+        strings must be quoted to be useful.</p>
+    <p class="Pp">This will be interpreted as:</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
+    ld a,[hl+]
     db &quot;John&quot;
     </pre>
     </div>
-    <div class="Pp"></div>
-    String-symbols can also be used to define small one-line macros:
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
+    <p class="Pp">String-symbols can also be used to define small one-line
+        macros:</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
 PUSHA EQUS &quot;push af\npush bc\npush de\npush hl\n&quot;
     </pre>
     </div>
-    <div class="Pp"></div>
-    Note that a colon (:) following the label-name is not allowed. String
-      equates can't be exported or imported.
-    <div class="Pp"></div>
-    <b class="Sy" title="Sy">Important note</b>: An EQUS can be expanded to a
-      string that contains another EQUS and it will be expanded as well. This
-      means that, if you aren't careful, you may trap the assembler into an
-      infinite loop if there's a circular dependency in the expansions. Also, a
-      MACRO can have inside an EQUS which references the same MACRO, which has
-      the same problem.</dd>
-  <dt class="It-hang"><b class="Sy" title="Sy">MACRO</b></dt>
-  <dd class="It-hang">
-    <div class="Pp"></div>
-    One of the best features of an assembler is the ability to write macros for
-      it. Macros also provide a method of passing arguments to them and they can
-      then react to the input using IF-constructs.
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
-MyMacro: MACRO 
-         ld   a,80 
-         call MyFunc 
+    <p class="Pp">Note that a colon (:) following the label-name is not allowed.
+        String equates can't be exported or imported.</p>
+    <p class="Pp"><b class="Sy">Important note</b>: An EQUS can be expanded to a
+        string that contains another EQUS and it will be expanded as well. This
+        means that, if you aren't careful, you may trap the assembler into an
+        infinite loop if there's a circular dependency in the expansions. Also,
+        a MACRO can have inside an EQUS which references the same MACRO, which
+        has the same problem.</p>
+  </dd>
+  <dt><b class="Sy">MACRO</b></dt>
+  <dd>
+    <p class="Pp">One of the best features of an assembler is the ability to
+        write macros for it. Macros also provide a method of passing arguments
+        to them and they can then react to the input using IF-constructs.</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
+MyMacro: MACRO
+         ld   a,80
+         call MyFunc
          ENDM
     </pre>
     </div>
-    <div class="Pp"></div>
-    Note that a colon (:) following the macro-name is required. Macros can't be
-      exported or imported. It's valid to call a macro from a macro (yes, even
-      the same one).
-    <div class="Pp"></div>
-    The above example is a very simple macro. You execute the macro by typing
-      its name.
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
-         add  a,b 
-         ld   sp,hl 
-         MyMacro ;This will be expanded 
+    <p class="Pp">Note that a colon (:) following the macro-name is required.
+        Macros can't be exported or imported. It's valid to call a macro from a
+        macro (yes, even the same one).</p>
+    <p class="Pp">The above example is a very simple macro. You execute the
+        macro by typing its name.</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
+         add  a,b
+         ld   sp,hl
+         MyMacro ;This will be expanded
          sub  a,87
     </pre>
     </div>
-    <div class="Pp"></div>
-    When the assembler meets MyMacro it will insert the macrodefinition (the
-      text enclosed in <b class="Ic" title="Ic">MACRO</b> /
-      <b class="Ic" title="Ic">ENDM</b>).
-    <div class="Pp"></div>
-    Suppose your macro contains a loop.
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
-LoopyMacro: MACRO 
-            xor  a,a 
-.loop       ld   [hl+],a 
-            dec  c 
-            jr   nz,.loop 
+    <p class="Pp">When the assembler meets MyMacro it will insert the
+        macrodefinition (the text enclosed in <code class="Ic">MACRO</code> /
+        <code class="Ic">ENDM</code>).</p>
+    <p class="Pp">Suppose your macro contains a loop.</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
+LoopyMacro: MACRO
+            xor  a,a
+.loop       ld   [hl+],a
+            dec  c
+            jr   nz,.loop
             ENDM
     </pre>
     </div>
-    <div class="Pp"></div>
-    This is fine. That is, if you only use the macro once per scope. To get
-      around this problem there is a special label string equate called
-      <b class="Ic" title="Ic">\@</b> that you can append to your labels and it
-      will then expand to a unique string.
-    <div class="Pp"></div>
-    <b class="Ic" title="Ic">\@</b> also works in REPT-blocks should you have
-      any loops there.
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
-LoopyMacro: MACRO 
-            xor  a,a 
-.loop\@     ld   [hl+],a 
-            dec  c 
-            jr   nz,.loop\@ 
+    <p class="Pp">This is fine. That is, if you only use the macro once per
+        scope. To get around this problem there is a special label string equate
+        called <code class="Ic">\@</code> that you can append to your labels and
+        it will then expand to a unique string.</p>
+    <p class="Pp"><code class="Ic">\@</code> also works in REPT-blocks should
+        you have any loops there.</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
+LoopyMacro: MACRO
+            xor  a,a
+.loop\@     ld   [hl+],a
+            dec  c
+            jr   nz,.loop\@
             ENDM
     </pre>
     </div>
-    <div class="Pp"></div>
-    <b class="Sy" title="Sy">Important note</b>: Since a MACRO can call itself
-      (or a different MACRO that calls the first one) there can be problems of
-      circular dependency. They trap the assembler in an infinite loop, so you
-      have to be careful when using recursion with MACROs. Also, a MACRO can
-      have inside an EQUS which references the same MACRO, which has the same
-      problem.
-    <div class="Pp"></div>
-    <b class="Sy" title="Sy">Macro Arguments</b>
-    <div class="Pp"></div>
-    I'd like LoopyMacro a lot better if I didn't have to pre-load the registers
-      with values and then call it. What I'd like is the ability to pass it
-      arguments and it then loaded the registers itself.
-    <div class="Pp"></div>
-    And I can do that. In macros you can get the arguments by using the special
-      macro string equates <b class="Ic" title="Ic">\1</b> through
-      <b class="Ic" title="Ic">\9</b>, <b class="Ic" title="Ic">\1</b> being the
-      first argument specified on the calling of the macro.
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
-LoopyMacro: MACRO 
-            ld   hl,\1 
-            ld   c,\2 
-            xor  a,a 
-.loop\@     ld   [hl+],a 
-            dec  c 
-            jr   nz,.loop\@ 
+    <p class="Pp"><b class="Sy">Important note</b>: Since a MACRO can call
+        itself (or a different MACRO that calls the first one) there can be
+        problems of circular dependency. They trap the assembler in an infinite
+        loop, so you have to be careful when using recursion with MACROs. Also,
+        a MACRO can have inside an EQUS which references the same MACRO, which
+        has the same problem.</p>
+    <p class="Pp"><b class="Sy">Macro Arguments</b></p>
+    <p class="Pp">I'd like LoopyMacro a lot better if I didn't have to pre-load
+        the registers with values and then call it. What I'd like is the ability
+        to pass it arguments and it then loaded the registers itself.</p>
+    <p class="Pp">And I can do that. In macros you can get the arguments by
+        using the special macro string equates <code class="Ic">\1</code>
+        through <code class="Ic">\9</code>, <code class="Ic">\1</code> being the
+        first argument specified on the calling of the macro.</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
+LoopyMacro: MACRO
+            ld   hl,\1
+            ld   c,\2
+            xor  a,a
+.loop\@     ld   [hl+],a
+            dec  c
+            jr   nz,.loop\@
             ENDM
     </pre>
     </div>
-    <div class="Pp"></div>
-    Now I can call the macro specifying two arguments. The first being the
-      address and the second being a bytecount. The macro will then reset all
-      bytes in this range.
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
+    <p class="Pp">Now I can call the macro specifying two arguments. The first
+        being the address and the second being a bytecount. The macro will then
+        reset all bytes in this range.</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
 LoopyMacro MyVars,54
     </pre>
     </div>
-    <div class="Pp"></div>
-    Arguments are passed as string equates. There's no need to enclose them in
-      quotes. An expression will not be evaluated first but passed directly.
-      This means that it's probably a very good idea to use brackets around
-      <b class="Ic" title="Ic">\1</b> to <b class="Ic" title="Ic">\9</b> if you
-      perform further calculations on them. For instance, if you pass 1 + 2 as
-      the first argument and then do <b class="Ic" title="Ic">PRINTV</b>
-      <b class="Ic" title="Ic">\1</b> * 2 you will get the value 5 on screen and
-      not 6 as you might have expected.
-    <div class="Pp"></div>
-    In reality, up to 256 arguments can be passed to a macro, but you can only
-      use the first 9 like this. If you want to use the rest, you need to use
-      the keyword <b class="Ic" title="Ic">SHIFT</b>.
-    <div class="Pp"></div>
-    Line continuations work as usual inside macros or lists of arguments of
-      macros. Strings, however, are a bit trickier. The following example shows
-      how to use strings as arguments for a macro:
-    <div class="Pp"></div>
-    <div class="Bd" style="margin-left: 5.00ex;">
-    <pre class="Li">
-PrintMacro : MACRO 
-    PRINTT \1 
-ENDM 
- 
-    PrintMacro STRCAT(\&quot;Hello\&quot;\,  \ 
+    <p class="Pp">Arguments are passed as string equates. There's no need to
+        enclose them in quotes. An expression will not be evaluated first but
+        passed directly. This means that it's probably a very good idea to use
+        brackets around <code class="Ic">\1</code> to <code class="Ic">\9</code>
+        if you perform further calculations on them. For instance, if you pass 1
+        + 2 as the first argument and then do <code class="Ic">PRINTV</code>
+        <code class="Ic">\1</code> * 2 you will get the value 5 on screen and
+        not 6 as you might have expected.</p>
+    <p class="Pp">In reality, up to 256 arguments can be passed to a macro, but
+        you can only use the first 9 like this. If you want to use the rest, you
+        need to use the keyword <code class="Ic">SHIFT</code>.</p>
+    <p class="Pp">Line continuations work as usual inside macros or lists of
+        arguments of macros. Strings, however, are a bit trickier. The following
+        example shows how to use strings as arguments for a macro:</p>
+    <div class="Bd Pp Bd-indent">
+    <pre>
+PrintMacro : MACRO
+    PRINTT \1
+ENDM
+
+    PrintMacro STRCAT(\&quot;Hello\&quot;\,  \
                       \&quot; world\\n\&quot;)
     </pre>
     </div>
-    <div class="Pp"></div>
-    <b class="Ic" title="Ic">SHIFT</b> is a special command only available in
-      macros. Very useful in REPT-blocks. It will shift the arguments by one to
-      the left. <b class="Ic" title="Ic">\1</b> will get the value of
-      <b class="Ic" title="Ic">\2</b>, <b class="Ic" title="Ic">\2</b> will get
-      the value in <b class="Ic" title="Ic">\3</b> and so forth.
-    <div class="Pp"></div>
-    This is the only way of accessing the value of arguments from 10 to
-    256.</dd>
+    <p class="Pp"><code class="Ic">SHIFT</code> is a special command only
+        available in macros. Very useful in REPT-blocks. It will shift the
+        arguments by one to the left. <code class="Ic">\1</code> will get the
+        value of <code class="Ic">\2</code>, <code class="Ic">\2</code> will get
+        the value in <code class="Ic">\3</code> and so forth.</p>
+    <p class="Pp">This is the only way of accessing the value of arguments from
+        10 to 256.</p>
+  </dd>
 </dl>
-<h2 class="Ss" title="Ss" id="Exporting_and_importing_symbols"><a class="selflink" href="#Exporting_and_importing_symbols">Exporting
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Exporting_and_importing_symbols"><a class="permalink" href="#Exporting_and_importing_symbols">Exporting
   and importing symbols</a></h2>
 Importing and exporting of symbols is a feature that is very useful when your
   project spans many source-files and, for example, you need to jump to a
   routine defined in another file.
-<div class="Pp"></div>
-Exporting of symbols has to be done manually, importing is done automatically if
-  the assembler doesn't know where a symbol is defined.
-<div class="Pp"></div>
-<b class="Ic" title="Ic">EXPORT</b> <var class="Ar" title="Ar">label</var> [,
-  <var class="Ar" title="Ar">label</var> , <span class="No">...</span>]
-<div class="Pp"></div>
-The assembler will make label accessible to other files during the link process.
-<div class="Pp"></div>
-<b class="Ic" title="Ic">GLOBAL</b> <var class="Ar" title="Ar">label</var> [,
-  <var class="Ar" title="Ar">label</var> , <span class="No">...</span>]
-<div class="Pp"></div>
-If label is defined during the assembly it will be exported, if not, it will be
-  imported. Handy (very!) for include-files. Note that, since importing is done
-  automatically, this keyword has the same effect as
-  <b class="Ic" title="Ic">EXPORT</b>.
-<h2 class="Ss" title="Ss" id="Purging_symbols"><a class="selflink" href="#Purging_symbols">Purging
+<p class="Pp">Exporting of symbols has to be done manually, importing is done
+    automatically if the assembler doesn't know where a symbol is defined.</p>
+<p class="Pp"><code class="Ic">EXPORT</code> <var class="Ar">label</var> [,
+    <var class="Ar">label</var> , <span class="No">...</span>]</p>
+<p class="Pp">The assembler will make label accessible to other files during the
+    link process.</p>
+<p class="Pp"><code class="Ic">GLOBAL</code> <var class="Ar">label</var> [,
+    <var class="Ar">label</var> , <span class="No">...</span>]</p>
+<p class="Pp">If label is defined during the assembly it will be exported, if
+    not, it will be imported. Handy (very!) for include-files. Note that, since
+    importing is done automatically, this keyword has the same effect as
+    <code class="Ic">EXPORT</code>.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Purging_symbols"><a class="permalink" href="#Purging_symbols">Purging
   symbols</a></h2>
-<b class="Ic" title="Ic">PURGE</b> allows you to completely remove a symbol from
-  the symbol table as if it had never existed. USE WITH EXTREME CAUTION!!! I
-  can't stress this enough, you seriously need to know what you are doing. DON'T
-  purge symbol that you use in expressions the linker needs to calculate. In
-  fact, it's probably not even safe to purge anything other than string symbols
-  and macros.
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-Kamikaze EQUS  &quot;I don't want to live anymore&quot; 
-AOLer    EQUS  &quot;Me too&quot; 
+<code class="Ic">PURGE</code> allows you to completely remove a symbol from the
+  symbol table as if it had never existed. USE WITH EXTREME CAUTION!!! I can't
+  stress this enough, you seriously need to know what you are doing. DON'T purge
+  symbol that you use in expressions the linker needs to calculate. In fact,
+  it's probably not even safe to purge anything other than string symbols and
+  macros.
+<div class="Bd Pp Bd-indent">
+<pre>
+Kamikaze EQUS  &quot;I don't want to live anymore&quot;
+AOLer    EQUS  &quot;Me too&quot;
          PURGE Kamikaze, AOLer
 </pre>
 </div>
-<div class="Pp"></div>
-Note that string symbols that are part of a <b class="Ic" title="Ic">PURGE</b>
-  command WILL NOT BE EXPANDED as the ONLY exception to this rule.
-<h2 class="Ss" title="Ss" id="Predeclared_Symbols"><a class="selflink" href="#Predeclared_Symbols">Predeclared
+<p class="Pp">Note that string symbols that are part of a
+    <code class="Ic">PURGE</code> command WILL NOT BE EXPANDED as the ONLY
+    exception to this rule.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Predeclared_Symbols"><a class="permalink" href="#Predeclared_Symbols">Predeclared
   Symbols</a></h2>
 The following symbols are defined by the assembler:
-<table class="Bl-column" style="margin-left: 6.00ex;">
-  <colgroup>
-    <col style="width: 7.80ex;"/>
-    <col style="min-width: 18.00ex;"/>
-  </colgroup>
-  <tr class="It-column">
-    <td class="It-column"><b class="Sy" title="Sy">Type</b></td>
-    <td class="It-column"><b class="Sy" title="Sy">Name</b></td>
-    <td class="It-column"><b class="Sy" title="Sy">Contents</b></td>
+<table class="Bl-column Bd-indent">
+  <tr>
+    <td><b class="Sy">Type</b></td>
+    <td><b class="Sy">Name</b></td>
+    <td><b class="Sy">Contents</b></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQU"><b class="Ic" title="Ic" id="EQU">EQU</b></a></td>
-    <td class="It-column"><a class="selflink" href="#@"><b class="Ic" title="Ic" id="@">@</b></a></td>
-    <td class="It-column">PC value</td>
+  <tr>
+    <td><a class="permalink" href="#EQU"><code class="Ic" id="EQU">EQU</code></a></td>
+    <td><a class="permalink" href="#@"><code class="Ic" id="@">@</code></a></td>
+    <td>PC value</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQU"><b class="Ic" title="Ic" id="EQU">EQU</b></a></td>
-    <td class="It-column"><a class="selflink" href="#_PI"><b class="Ic" title="Ic" id="_PI">_PI</b></a></td>
-    <td class="It-column">Fixed point &#x03C0;</td>
+  <tr>
+    <td><a class="permalink" href="#EQU_2"><code class="Ic" id="EQU_2">EQU</code></a></td>
+    <td><a class="permalink" href="#_PI"><code class="Ic" id="_PI">_PI</code></a></td>
+    <td>Fixed point &#x03C0;</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#SET"><b class="Ic" title="Ic" id="SET">SET</b></a></td>
-    <td class="It-column"><a class="selflink" href="#_RS"><b class="Ic" title="Ic" id="_RS">_RS</b></a></td>
-    <td class="It-column">_RS Counter</td>
+  <tr>
+    <td><a class="permalink" href="#SET"><code class="Ic" id="SET">SET</code></a></td>
+    <td><a class="permalink" href="#_RS"><code class="Ic" id="_RS">_RS</code></a></td>
+    <td>_RS Counter</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQU"><b class="Ic" title="Ic" id="EQU">EQU</b></a></td>
-    <td class="It-column"><a class="selflink" href="#_NARG"><b class="Ic" title="Ic" id="_NARG">_NARG</b></a></td>
-    <td class="It-column">Number of arguments passed to macro</td>
+  <tr>
+    <td><a class="permalink" href="#EQU_3"><code class="Ic" id="EQU_3">EQU</code></a></td>
+    <td><a class="permalink" href="#_NARG"><code class="Ic" id="_NARG">_NARG</code></a></td>
+    <td>Number of arguments passed to macro</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQU"><b class="Ic" title="Ic" id="EQU">EQU</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__LINE__"><b class="Ic" title="Ic" id="__LINE__">__LINE__</b></a></td>
-    <td class="It-column">The current line number</td>
+  <tr>
+    <td><a class="permalink" href="#EQU_4"><code class="Ic" id="EQU_4">EQU</code></a></td>
+    <td><a class="permalink" href="#__LINE__"><code class="Ic" id="__LINE__">__LINE__</code></a></td>
+    <td>The current line number</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQUS"><b class="Ic" title="Ic" id="EQUS">EQUS</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__FILE__"><b class="Ic" title="Ic" id="__FILE__">__FILE__</b></a></td>
-    <td class="It-column">The current filename</td>
+  <tr>
+    <td><a class="permalink" href="#EQUS"><code class="Ic" id="EQUS">EQUS</code></a></td>
+    <td><a class="permalink" href="#__FILE__"><code class="Ic" id="__FILE__">__FILE__</code></a></td>
+    <td>The current filename</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQUS"><b class="Ic" title="Ic" id="EQUS">EQUS</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__DATE__"><b class="Ic" title="Ic" id="__DATE__">__DATE__</b></a></td>
-    <td class="It-column">Today's date</td>
+  <tr>
+    <td><a class="permalink" href="#EQUS_2"><code class="Ic" id="EQUS_2">EQUS</code></a></td>
+    <td><a class="permalink" href="#__DATE__"><code class="Ic" id="__DATE__">__DATE__</code></a></td>
+    <td>Today's date</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQUS"><b class="Ic" title="Ic" id="EQUS">EQUS</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__TIME__"><b class="Ic" title="Ic" id="__TIME__">__TIME__</b></a></td>
-    <td class="It-column">The current time</td>
+  <tr>
+    <td><a class="permalink" href="#EQUS_3"><code class="Ic" id="EQUS_3">EQUS</code></a></td>
+    <td><a class="permalink" href="#__TIME__"><code class="Ic" id="__TIME__">__TIME__</code></a></td>
+    <td>The current time</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQUS"><b class="Ic" title="Ic" id="EQUS">EQUS</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__ISO_8601_LOCAL__"><b class="Ic" title="Ic" id="__ISO_8601_LOCAL__">__ISO_8601_LOCAL__</b></a></td>
-    <td class="It-column">ISO 8601 timestamp (local)</td>
+  <tr>
+    <td><a class="permalink" href="#EQUS_4"><code class="Ic" id="EQUS_4">EQUS</code></a></td>
+    <td><a class="permalink" href="#__ISO_8601_LOCAL__"><code class="Ic" id="__ISO_8601_LOCAL__">__ISO_8601_LOCAL__</code></a></td>
+    <td>ISO 8601 timestamp (local)</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQUS"><b class="Ic" title="Ic" id="EQUS">EQUS</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__ISO_8601_UTC__"><b class="Ic" title="Ic" id="__ISO_8601_UTC__">__ISO_8601_UTC__</b></a></td>
-    <td class="It-column">ISO 8601 timestamp (UTC)</td>
+  <tr>
+    <td><a class="permalink" href="#EQUS_5"><code class="Ic" id="EQUS_5">EQUS</code></a></td>
+    <td><a class="permalink" href="#__ISO_8601_UTC__"><code class="Ic" id="__ISO_8601_UTC__">__ISO_8601_UTC__</code></a></td>
+    <td>ISO 8601 timestamp (UTC)</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQU"><b class="Ic" title="Ic" id="EQU">EQU</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__UTC_YEAR__"><b class="Ic" title="Ic" id="__UTC_YEAR__">__UTC_YEAR__</b></a></td>
-    <td class="It-column">Today's year</td>
+  <tr>
+    <td><a class="permalink" href="#EQU_5"><code class="Ic" id="EQU_5">EQU</code></a></td>
+    <td><a class="permalink" href="#__UTC_YEAR__"><code class="Ic" id="__UTC_YEAR__">__UTC_YEAR__</code></a></td>
+    <td>Today's year</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQU"><b class="Ic" title="Ic" id="EQU">EQU</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__UTC_MONTH__"><b class="Ic" title="Ic" id="__UTC_MONTH__">__UTC_MONTH__</b></a></td>
-    <td class="It-column">Today's month number, 1-12</td>
+  <tr>
+    <td><a class="permalink" href="#EQU_6"><code class="Ic" id="EQU_6">EQU</code></a></td>
+    <td><a class="permalink" href="#__UTC_MONTH__"><code class="Ic" id="__UTC_MONTH__">__UTC_MONTH__</code></a></td>
+    <td>Today's month number, 1-12</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQU"><b class="Ic" title="Ic" id="EQU">EQU</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__UTC_DAY__"><b class="Ic" title="Ic" id="__UTC_DAY__">__UTC_DAY__</b></a></td>
-    <td class="It-column">Today's day of the month, 1-31</td>
+  <tr>
+    <td><a class="permalink" href="#EQU_7"><code class="Ic" id="EQU_7">EQU</code></a></td>
+    <td><a class="permalink" href="#__UTC_DAY__"><code class="Ic" id="__UTC_DAY__">__UTC_DAY__</code></a></td>
+    <td>Today's day of the month, 1-31</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQU"><b class="Ic" title="Ic" id="EQU">EQU</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__UTC_HOUR__"><b class="Ic" title="Ic" id="__UTC_HOUR__">__UTC_HOUR__</b></a></td>
-    <td class="It-column">Current hour, 0-23</td>
+  <tr>
+    <td><a class="permalink" href="#EQU_8"><code class="Ic" id="EQU_8">EQU</code></a></td>
+    <td><a class="permalink" href="#__UTC_HOUR__"><code class="Ic" id="__UTC_HOUR__">__UTC_HOUR__</code></a></td>
+    <td>Current hour, 0-23</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQU"><b class="Ic" title="Ic" id="EQU">EQU</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__UTC_MINUTE__"><b class="Ic" title="Ic" id="__UTC_MINUTE__">__UTC_MINUTE__</b></a></td>
-    <td class="It-column">Current minute, 0-59</td>
+  <tr>
+    <td><a class="permalink" href="#EQU_9"><code class="Ic" id="EQU_9">EQU</code></a></td>
+    <td><a class="permalink" href="#__UTC_MINUTE__"><code class="Ic" id="__UTC_MINUTE__">__UTC_MINUTE__</code></a></td>
+    <td>Current minute, 0-59</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQU"><b class="Ic" title="Ic" id="EQU">EQU</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__UTC_SECOND__"><b class="Ic" title="Ic" id="__UTC_SECOND__">__UTC_SECOND__</b></a></td>
-    <td class="It-column">Current second, 0-59</td>
+  <tr>
+    <td><a class="permalink" href="#EQU_10"><code class="Ic" id="EQU_10">EQU</code></a></td>
+    <td><a class="permalink" href="#__UTC_SECOND__"><code class="Ic" id="__UTC_SECOND__">__UTC_SECOND__</code></a></td>
+    <td>Current second, 0-59</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQU"><b class="Ic" title="Ic" id="EQU">EQU</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__RGBDS_MAJOR__"><b class="Ic" title="Ic" id="__RGBDS_MAJOR__">__RGBDS_MAJOR__</b></a></td>
-    <td class="It-column">Major version number of RGBDS.</td>
+  <tr>
+    <td><a class="permalink" href="#EQU_11"><code class="Ic" id="EQU_11">EQU</code></a></td>
+    <td><a class="permalink" href="#__RGBDS_MAJOR__"><code class="Ic" id="__RGBDS_MAJOR__">__RGBDS_MAJOR__</code></a></td>
+    <td>Major version number of RGBDS.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQU"><b class="Ic" title="Ic" id="EQU">EQU</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__RGBDS_MINOR__"><b class="Ic" title="Ic" id="__RGBDS_MINOR__">__RGBDS_MINOR__</b></a></td>
-    <td class="It-column">Minor version number of RGBDS.</td>
+  <tr>
+    <td><a class="permalink" href="#EQU_12"><code class="Ic" id="EQU_12">EQU</code></a></td>
+    <td><a class="permalink" href="#__RGBDS_MINOR__"><code class="Ic" id="__RGBDS_MINOR__">__RGBDS_MINOR__</code></a></td>
+    <td>Minor version number of RGBDS.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#EQU"><b class="Ic" title="Ic" id="EQU">EQU</b></a></td>
-    <td class="It-column"><a class="selflink" href="#__RGBDS_PATCH__"><b class="Ic" title="Ic" id="__RGBDS_PATCH__">__RGBDS_PATCH__</b></a></td>
-    <td class="It-column">Patch version number of RGBDS.</td>
+  <tr>
+    <td><a class="permalink" href="#EQU_13"><code class="Ic" id="EQU_13">EQU</code></a></td>
+    <td><a class="permalink" href="#__RGBDS_PATCH__"><code class="Ic" id="__RGBDS_PATCH__">__RGBDS_PATCH__</code></a></td>
+    <td>Patch version number of RGBDS.</td>
   </tr>
 </table>
-<h1 class="Sh" title="Sh" id="DEFINING_DATA"><a class="selflink" href="#DEFINING_DATA">DEFINING
+</section>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="DEFINING_DATA"><a class="permalink" href="#DEFINING_DATA">DEFINING
   DATA</a></h1>
-<h2 class="Ss" title="Ss" id="Defining_constant_data"><a class="selflink" href="#Defining_constant_data">Defining
+<section class="Ss">
+<h2 class="Ss" id="Defining_constant_data"><a class="permalink" href="#Defining_constant_data">Defining
   constant data</a></h2>
-<b class="Ic" title="Ic">DB</b> defines a list of bytes that will be stored in
-  the final image. Ideal for tables and text (which is not zero-terminated).
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
+<code class="Ic">DB</code> defines a list of bytes that will be stored in the
+  final image. Ideal for tables and text (which is not zero-terminated).
+<div class="Bd Pp Bd-indent">
+<pre>
 DB 1,2,3,4,&quot;This is a string&quot;
 </pre>
 </div>
-<div class="Pp"></div>
-Alternatively, you can use <b class="Ic" title="Ic">DW</b> to store a list of
-  words (16-bits) or <b class="Ic" title="Ic">DL</b> to store a list of
-  doublewords/longs (32-bits). Strings are not allowed as arguments to
-  <b class="Ic" title="Ic">DW</b> and <b class="Ic" title="Ic">DL</b>.
-<div class="Pp"></div>
-You can also use <b class="Ic" title="Ic">DB</b>,
-  <b class="Ic" title="Ic">DW</b> and <b class="Ic" title="Ic">DL</b> without
-  arguments, or leaving empty elements at any point in the list. This works
-  exactly like <b class="Sy" title="Sy">DS 1</b>, <b class="Sy" title="Sy">DS
-  2</b> and <b class="Sy" title="Sy">DS 4</b> respectively. Consequently,
-  <b class="Ic" title="Ic">DB</b>, <b class="Ic" title="Ic">DW</b> and
-  <b class="Ic" title="Ic">DL</b> can be used in a
-  <b class="Sy" title="Sy">WRAM0</b> <span class="No">/</span>
-  <b class="Sy" title="Sy">WRAMX</b> <span class="No">/</span>
-  <b class="Sy" title="Sy">HRAM</b> <span class="No">/</span>
-  <b class="Sy" title="Sy">VRAM</b> <span class="No">/</span>
-  <b class="Sy" title="Sy">SRAM</b> section.
-<h2 class="Ss" title="Ss" id="Declaring_variables_in_a_RAM_section"><a class="selflink" href="#Declaring_variables_in_a_RAM_section">Declaring
+<p class="Pp">Alternatively, you can use <code class="Ic">DW</code> to store a
+    list of words (16-bits) or <code class="Ic">DL</code> to store a list of
+    doublewords/longs (32-bits). Strings are not allowed as arguments to
+    <code class="Ic">DW</code> and <code class="Ic">DL</code>.</p>
+<p class="Pp">You can also use <code class="Ic">DB</code>,
+    <code class="Ic">DW</code> and <code class="Ic">DL</code> without arguments,
+    or leaving empty elements at any point in the list. This works exactly like
+    <b class="Sy">DS 1</b>, <b class="Sy">DS 2</b> and <b class="Sy">DS 4</b>
+    respectively. Consequently, <code class="Ic">DB</code>,
+    <code class="Ic">DW</code> and <code class="Ic">DL</code> can be used in a
+    <b class="Sy">WRAM0</b> <span class="No">/</span> <b class="Sy">WRAMX</b>
+    <span class="No">/</span> <b class="Sy">HRAM</b> <span class="No">/</span>
+    <b class="Sy">VRAM</b> <span class="No">/</span> <b class="Sy">SRAM</b>
+    section.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Declaring_variables_in_a_RAM_section"><a class="permalink" href="#Declaring_variables_in_a_RAM_section">Declaring
   variables in a RAM section</a></h2>
-<b class="Ic" title="Ic">DS</b> allocates a number of bytes. The content is
+<code class="Ic">DS</code> allocates a number of bytes. The content is
   undefined. This is the preferred method of allocationg space in a RAM section.
-  You can, however, use <b class="Ic" title="Ic">DB</b>,
-  <b class="Ic" title="Ic">DW</b> and <b class="Ic" title="Ic">DL</b> without
-  any arguments instead.
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
+  You can, however, use <code class="Ic">DB</code>, <code class="Ic">DW</code>
+  and <code class="Ic">DL</code> without any arguments instead.
+<div class="Bd Pp Bd-indent">
+<pre>
 DS str_SIZEOF ;allocate str_SIZEOF bytes
 </pre>
 </div>
-<h2 class="Ss" title="Ss" id="Including_binary_files"><a class="selflink" href="#Including_binary_files">Including
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Including_binary_files"><a class="permalink" href="#Including_binary_files">Including
   binary files</a></h2>
 You probably have some graphics you'd like to include. Use
-  <b class="Ic" title="Ic">INCBIN</b> to include a raw binary file as it is. If
-  the file isn't found in the current directory, the include-path list passed to
-  the linker on the command line will be searched.
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-INCBIN &quot;titlepic.bin&quot; 
-INCBIN &quot;sprites/hero.bin&quot;&#x00A0;; UNIX 
+  <code class="Ic">INCBIN</code> to include a raw binary file as it is. If the
+  file isn't found in the current directory, the include-path list passed to the
+  linker on the command line will be searched.
+<div class="Bd Pp Bd-indent">
+<pre>
+INCBIN &quot;titlepic.bin&quot;
+INCBIN &quot;sprites/hero.bin&quot;&#x00A0;; UNIX
 INCBIN &quot;sprites\\hero.bin&quot;&#x00A0;; Windows
 </pre>
 </div>
-<div class="Pp"></div>
-You can also include only part of a file with
-  <b class="Ic" title="Ic">INCBIN</b>. The example below includes 256 bytes from
-  data.bin starting from byte 78.
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
+<p class="Pp">You can also include only part of a file with
+    <code class="Ic">INCBIN</code>. The example below includes 256 bytes from
+    data.bin starting from byte 78.</p>
+<div class="Bd Pp Bd-indent">
+<pre>
 INCBIN &quot;data.bin&quot;,78,256
 </pre>
 </div>
-<h2 class="Ss" title="Ss" id="Unions"><a class="selflink" href="#Unions">Unions</a></h2>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Unions"><a class="permalink" href="#Unions">Unions</a></h2>
 Unions allow multiple memory allocations to share the same space in memory, like
   unions in C. This allows you to easily reuse memory for different purposes,
   depending on the game's state.
-<div class="Pp"></div>
-You create unions using the <b class="Ic" title="Ic">UNION</b>,
-  <b class="Ic" title="Ic">NEXTU</b> and <b class="Ic" title="Ic">ENDU</b>
-  keywords. <b class="Ic" title="Ic">NEXTU</b> lets you create a new block of
-  allocations, and you may use it as many times within a union as necessary.
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-UNION 
-Name: ds 8 
-Nickname: ds 8 
-NEXTU 
-Health: dw 
-Something: ds 3 
-Lives: db 
-NEXTU 
-Temporary: ds 19 
+<p class="Pp">You create unions using the <code class="Ic">UNION</code>,
+    <code class="Ic">NEXTU</code> and <code class="Ic">ENDU</code> keywords.
+    <code class="Ic">NEXTU</code> lets you create a new block of allocations,
+    and you may use it as many times within a union as necessary.</p>
+<div class="Bd Pp Bd-indent">
+<pre>
+UNION
+Name: ds 8
+Nickname: ds 8
+NEXTU
+Health: dw
+Something: ds 3
+Lives: db
+NEXTU
+Temporary: ds 19
 ENDU
 </pre>
 </div>
-<div class="Pp"></div>
-This union will use up 19 bytes, as this is the size of the largest block (the
-  last one, containing 'Temporary'). Of course, as 'Name', 'Health', and
-  'Temporary' all point to the same memory locations, writes to any one of these
-  will affect values read from the others.
-<div class="Pp"></div>
-Unions may be used in any section, but code and data may not be included.
-<h1 class="Sh" title="Sh" id="THE_MACRO_LANGUAGE"><a class="selflink" href="#THE_MACRO_LANGUAGE">THE
+<p class="Pp">This union will use up 19 bytes, as this is the size of the
+    largest block (the last one, containing 'Temporary'). Of course, as 'Name',
+    'Health', and 'Temporary' all point to the same memory locations, writes to
+    any one of these will affect values read from the others.</p>
+<p class="Pp">Unions may be used in any section, but code and data may not be
+    included.</p>
+</section>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="THE_MACRO_LANGUAGE"><a class="permalink" href="#THE_MACRO_LANGUAGE">THE
   MACRO LANGUAGE</a></h1>
-<h2 class="Ss" title="Ss" id="Printing_things_during_assembly"><a class="selflink" href="#Printing_things_during_assembly">Printing
+<section class="Ss">
+<h2 class="Ss" id="Printing_things_during_assembly"><a class="permalink" href="#Printing_things_during_assembly">Printing
   things during assembly</a></h2>
 These three instructions type text and values to stdout. Useful for debugging
   macros or wherever you may feel the need to tell yourself some important
   information.
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-PRINTT &quot;I'm the greatest programmer in the whole wide world\n&quot; 
-PRINTI (2 + 3) / 5 
-PRINTV $FF00 + $F0 
+<div class="Bd Pp Bd-indent">
+<pre>
+PRINTT &quot;I'm the greatest programmer in the whole wide world\n&quot;
+PRINTI (2 + 3) / 5
+PRINTV $FF00 + $F0
 PRINTF MUL(3.14, 3987.0)
 </pre>
 </div>
 <dl class="Bl-inset">
-  <dt class="It-inset"><a class="selflink" href="#PRINTT"><b class="Ic" title="Ic" id="PRINTT">PRINTT</b></a></dt>
-  <dd class="It-inset">prints out a string.</dd>
-  <dt class="It-inset"><a class="selflink" href="#PRINTV"><b class="Ic" title="Ic" id="PRINTV">PRINTV</b></a></dt>
-  <dd class="It-inset">prints out an integer value in hexadecimal or, as in the
-      example, the result of a calculation. Unsurprisingly, you can also print
-      out a constant symbols value.</dd>
-  <dt class="It-inset"><a class="selflink" href="#PRINTI"><b class="Ic" title="Ic" id="PRINTI">PRINTI</b></a></dt>
-  <dd class="It-inset">prints out a signed integer value.</dd>
-  <dt class="It-inset"><a class="selflink" href="#PRINTF"><b class="Ic" title="Ic" id="PRINTF">PRINTF</b></a></dt>
-  <dd class="It-inset">prints out a fixed point value.</dd>
+  <dt><a class="permalink" href="#PRINTT"><code class="Ic" id="PRINTT">PRINTT</code></a></dt>
+  <dd>prints out a string.</dd>
+  <dt><a class="permalink" href="#PRINTV"><code class="Ic" id="PRINTV">PRINTV</code></a></dt>
+  <dd>prints out an integer value in hexadecimal or, as in the example, the
+      result of a calculation. Unsurprisingly, you can also print out a constant
+      symbols value.</dd>
+  <dt><a class="permalink" href="#PRINTI"><code class="Ic" id="PRINTI">PRINTI</code></a></dt>
+  <dd>prints out a signed integer value.</dd>
+  <dt><a class="permalink" href="#PRINTF"><code class="Ic" id="PRINTF">PRINTF</code></a></dt>
+  <dd>prints out a fixed point value.</dd>
 </dl>
-<h2 class="Ss" title="Ss" id="Automatically_repeating_blocks_of_code"><a class="selflink" href="#Automatically_repeating_blocks_of_code">Automatically
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Automatically_repeating_blocks_of_code"><a class="permalink" href="#Automatically_repeating_blocks_of_code">Automatically
   repeating blocks of code</a></h2>
 Suppose you're feeling lazy and you want to unroll a time consuming loop.
-  <b class="Ic" title="Ic">REPT</b> is here for that purpose. Everything between
-  <b class="Ic" title="Ic">REPT</b> and <b class="Ic" title="Ic">ENDR</b> will
-  be repeated a number of times just as if you done a copy/paste operation
-  yourself. The following example will assemble <b class="Sy" title="Sy">add
-  a,c</b> four times:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-REPT 4 
-add  a,c 
+  <code class="Ic">REPT</code> is here for that purpose. Everything between
+  <code class="Ic">REPT</code> and <code class="Ic">ENDR</code> will be repeated
+  a number of times just as if you done a copy/paste operation yourself. The
+  following example will assemble <b class="Sy">add a,c</b> four times:
+<div class="Bd Pp Bd-indent">
+<pre>
+REPT 4
+add  a,c
 ENDR
 </pre>
 </div>
-<div class="Pp"></div>
-You can also use <b class="Ic" title="Ic">REPT</b> to generate tables on the
-  fly:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-; -- 
-; -- Generate a 256 byte sine table with values between 0 and 128 
-; -- 
-ANGLE SET   0.0 
-      REPT  256 
-      DB    (MUL(64.0,SIN(ANGLE))+64.0)&gt;&gt;16 
-ANGLE SET ANGLE+256.0 
+<p class="Pp">You can also use <code class="Ic">REPT</code> to generate tables
+    on the fly:</p>
+<div class="Bd Pp Bd-indent">
+<pre>
+; --
+; -- Generate a 256 byte sine table with values between 0 and 128
+; --
+ANGLE SET   0.0
+      REPT  256
+      DB    (MUL(64.0,SIN(ANGLE))+64.0)&gt;&gt;16
+ANGLE SET ANGLE+256.0
       ENDR
 </pre>
 </div>
-<div class="Pp"></div>
-<b class="Ic" title="Ic">REPT</b> is also very useful in recursive macros and,
-  as in macros, you can also use the special label operator
-  <b class="Ic" title="Ic">\@</b>. REPT-blocks can be nested.
-<h2 class="Ss" title="Ss" id="Aborting_the_assembly_process"><a class="selflink" href="#Aborting_the_assembly_process">Aborting
+<p class="Pp"><code class="Ic">REPT</code> is also very useful in recursive
+    macros and, as in macros, you can also use the special label operator
+    <code class="Ic">\@</code>. REPT-blocks can be nested.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Aborting_the_assembly_process"><a class="permalink" href="#Aborting_the_assembly_process">Aborting
   the assembly process</a></h2>
-<b class="Ic" title="Ic">FAIL</b> and <b class="Ic" title="Ic">WARN</b> can be
-  used to print errors and warnings respectively during the assembly process.
-  This is especially useful for macros that get an invalid argument.
-  <b class="Ic" title="Ic">FAIL</b> and <b class="Ic" title="Ic">WARN</b> take a
-  string as the only argument and they will print this string out as a normal
-  error with a line number.
-<div class="Pp"></div>
-<b class="Ic" title="Ic">FAIL</b> stops assembling immediately while
-  <b class="Ic" title="Ic">WARN</b> shows the message but continues afterwards.
-<h2 class="Ss" title="Ss" id="Including_other_source_files"><a class="selflink" href="#Including_other_source_files">Including
+<code class="Ic">FAIL</code> and <code class="Ic">WARN</code> can be used to
+  print errors and warnings respectively during the assembly process. This is
+  especially useful for macros that get an invalid argument.
+  <code class="Ic">FAIL</code> and <code class="Ic">WARN</code> take a string as
+  the only argument and they will print this string out as a normal error with a
+  line number.
+<p class="Pp"><code class="Ic">FAIL</code> stops assembling immediately while
+    <code class="Ic">WARN</code> shows the message but continues afterwards.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Including_other_source_files"><a class="permalink" href="#Including_other_source_files">Including
   other source files</a></h2>
-Use <b class="Ic" title="Ic">INCLUDE</b> to process another assembler-file and
-  then return to the current file when done. If the file isn't found in the
-  current directory the include-path list will be searched. You may nest
-  <b class="Ic" title="Ic">INCLUDE</b> calls infinitely (or until you run out of
+Use <code class="Ic">INCLUDE</code> to process another assembler-file and then
+  return to the current file when done. If the file isn't found in the current
+  directory the include-path list will be searched. You may nest
+  <code class="Ic">INCLUDE</code> calls infinitely (or until you run out of
   memory, whichever comes first).
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
+<div class="Bd Pp Bd-indent">
+<pre>
     INCLUDE &quot;irq.inc&quot;
 </pre>
 </div>
-<h2 class="Ss" title="Ss" id="Conditional_assembling"><a class="selflink" href="#Conditional_assembling">Conditional
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Conditional_assembling"><a class="permalink" href="#Conditional_assembling">Conditional
   assembling</a></h2>
-The four commands <b class="Ic" title="Ic">IF</b>,
-  <b class="Ic" title="Ic">ELIF</b>, <b class="Ic" title="Ic">ELSE</b>, and
-  <b class="Ic" title="Ic">ENDC</b> are used to conditionally assemble parts of
-  your file. This is a powerful feature commonly used in macros.
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-IF NUM &lt; 0 
-  PRINTT &quot;NUM &lt; 0\n&quot; 
-ELIF NUM == 0 
-  PRINTT &quot;NUM == 0\n&quot; 
-ELSE 
-  PRINTT &quot;NUM &gt; 0\n&quot; 
+The four commands <code class="Ic">IF</code>, <code class="Ic">ELIF</code>,
+  <code class="Ic">ELSE</code>, and <code class="Ic">ENDC</code> are used to
+  conditionally assemble parts of your file. This is a powerful feature commonly
+  used in macros.
+<div class="Bd Pp Bd-indent">
+<pre>
+IF NUM &lt; 0
+  PRINTT &quot;NUM &lt; 0\n&quot;
+ELIF NUM == 0
+  PRINTT &quot;NUM == 0\n&quot;
+ELSE
+  PRINTT &quot;NUM &gt; 0\n&quot;
 ENDC
 </pre>
 </div>
-<div class="Pp"></div>
-The <b class="Ic" title="Ic">ELIF</b> and <b class="Ic" title="Ic">ELSE</b>
-  blocks are optional. <b class="Ic" title="Ic">IF</b> <span class="No">/</span>
-  <b class="Ic" title="Ic">ELIF</b> <span class="No">/</span>
-  <b class="Ic" title="Ic">ELSE</b> <span class="No">/</span>
-  <b class="Ic" title="Ic">ENDC</b> blocks can be nested.
-<div class="Pp"></div>
-Note that if an <b class="Ic" title="Ic">ELSE</b> block is found before an
-  <b class="Ic" title="Ic">ELIF</b> block, the <b class="Ic" title="Ic">ELIF</b>
-  block will be ignored. All <b class="Ic" title="Ic">ELIF</b> blocks must go
-  before the <b class="Ic" title="Ic">ELSE</b> block. Also, if there is more
-  than one <b class="Ic" title="Ic">ELSE</b> block, all of them but the first
-  one are ignored.
-<h2 class="Ss" title="Ss" id="Integer_and_Boolean_expressions"><a class="selflink" href="#Integer_and_Boolean_expressions">Integer
+<p class="Pp">The <code class="Ic">ELIF</code> and <code class="Ic">ELSE</code>
+    blocks are optional. <code class="Ic">IF</code> <span class="No">/</span>
+    <code class="Ic">ELIF</code> <span class="No">/</span>
+    <code class="Ic">ELSE</code> <span class="No">/</span>
+    <code class="Ic">ENDC</code> blocks can be nested.</p>
+<p class="Pp">Note that if an <code class="Ic">ELSE</code> block is found before
+    an <code class="Ic">ELIF</code> block, the <code class="Ic">ELIF</code>
+    block will be ignored. All <code class="Ic">ELIF</code> blocks must go
+    before the <code class="Ic">ELSE</code> block. Also, if there is more than
+    one <code class="Ic">ELSE</code> block, all of them but the first one are
+    ignored.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Integer_and_Boolean_expressions"><a class="permalink" href="#Integer_and_Boolean_expressions">Integer
   and Boolean expressions</a></h2>
 An expression can be composed of many things. Expressions are always evaluated
   using signed 32-bit math.
-<div class="Pp"></div>
-The most basic expression is just a single number.
-<div class="Pp"></div>
-<b class="Sy" title="Sy">Numeric Formats</b>
-<div class="Pp"></div>
-There are a number of numeric formats.
-<div class="Pp"></div>
+<p class="Pp">The most basic expression is just a single number.</p>
+<p class="Pp"><b class="Sy">Numeric Formats</b></p>
+<p class="Pp">There are a number of numeric formats.</p>
+<p class="Pp"></p>
 <ul class="Bl-dash Bl-compact">
-  <li class="It-dash">Hexadecimal: $0123456789ABCDEF. Case-insensitive</li>
-  <li class="It-dash">Decimal: 0123456789</li>
-  <li class="It-dash">Octal: &amp;01234567</li>
-  <li class="It-dash">Binary: %01</li>
-  <li class="It-dash">Fixedpoint (16.16): 01234.56789</li>
-  <li class="It-dash">Character constant: &quot;ABYZ&quot;</li>
-  <li class="It-dash">Gameboy graphics: `0123</li>
+  <li>Hexadecimal: $0123456789ABCDEF. Case-insensitive</li>
+  <li>Decimal: 0123456789</li>
+  <li>Octal: &amp;01234567</li>
+  <li>Binary: %01</li>
+  <li>Fixedpoint (16.16): 01234.56789</li>
+  <li>Character constant: &quot;ABYZ&quot;</li>
+  <li>Gameboy graphics: `0123</li>
 </ul>
-<div class="Pp"></div>
-The last one, Gameboy graphics, is quite interesting and useful. The values are
-  actually pixel values and it converts the &#x201C;chunky&#x201D; data to
-  &#x201C;planar&#x201D; data as used in the Gameboy.
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
+<p class="Pp">The last one, Gameboy graphics, is quite interesting and useful.
+    The values are actually pixel values and it converts the
+    &#x201C;chunky&#x201D; data to &#x201C;planar&#x201D; data as used in the
+    Gameboy.</p>
+<div class="Bd Pp Bd-indent">
+<pre>
     DW `01012323
 </pre>
 </div>
-<div class="Pp"></div>
-Admittedly, an expression with just a single number is quite boring. To spice
-  things up a bit there are a few operators you can use to perform calculations
-  between numbers.
-<div class="Pp"></div>
-<b class="Sy" title="Sy">Operators</b>
-<div class="Pp"></div>
-A great number of operators you can use in expressions are available (listed in
-  order of precedence):
-<table class="Bl-column" style="margin-left: 6.00ex;">
-  <colgroup>
-    <col style="min-width: 8.00ex;"/>
-  </colgroup>
-  <tr class="It-column">
-    <td class="It-column"><b class="Sy" title="Sy">Operator</b></td>
-    <td class="It-column"><b class="Sy" title="Sy">Meaning</b></td>
+<p class="Pp">Admittedly, an expression with just a single number is quite
+    boring. To spice things up a bit there are a few operators you can use to
+    perform calculations between numbers.</p>
+<p class="Pp"><b class="Sy">Operators</b></p>
+<p class="Pp">A great number of operators you can use in expressions are
+    available (listed in order of precedence):</p>
+<table class="Bl-column Bd-indent">
+  <tr>
+    <td><b class="Sy">Operator</b></td>
+    <td><b class="Sy">Meaning</b></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#(_)"><code class="Li" id="(_)">(
+  <tr>
+    <td><a class="permalink" href="#(__&amp;)"><code class="Li" id="(__&amp;)">(
       )</code></a></td>
-    <td class="It-column">Precedence override</td>
+    <td>Precedence override</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#FUNC()"><code class="Li" id="FUNC()">FUNC()</code></a></td>
-    <td class="It-column">Function call</td>
+  <tr>
+    <td><a class="permalink" href="#FUNC()"><code class="Li" id="FUNC()">FUNC()</code></a></td>
+    <td>Function call</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#~_+_-"><code class="Li" id="~_+_-">~
-      + -</code></a></td>
-    <td class="It-column">Unary not/plus/minus</td>
-  </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#*_/_%"><code class="Li" id="*_/_%">*
-      / %</code></a></td>
-    <td class="It-column">Multiply/divide/modulo</td>
-  </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#&lt;&lt;_&gt;&gt;"><code class="Li" id="&lt;&lt;_&gt;&gt;">&lt;&lt;
-      &gt;&gt;</code></a></td>
-    <td class="It-column">Shift left/right</td>
-  </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#&amp;_|_^"><code class="Li" id="&amp;_|_^">&amp;
-      | ^</code></a></td>
-    <td class="It-column">Binary and/or/xor</td>
-  </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#+_-"><code class="Li" id="+_-">+
+  <tr>
+    <td><a class="permalink" href="#~_+_-"><code class="Li" id="~_+_-">~ +
       -</code></a></td>
-    <td class="It-column">Add/subtract</td>
+    <td>Unary not/plus/minus</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#!=_==_&lt;="><code class="Li" id="!=_==_&lt;=">!=
+  <tr>
+    <td><a class="permalink" href="#*_/__"><code class="Li" id="*_/__">* /
+      %</code></a></td>
+    <td>Multiply/divide/modulo</td>
+  </tr>
+  <tr>
+    <td><a class="permalink" href="#_____"><code class="Li" id="_____">&lt;&lt;
+      &gt;&gt;</code></a></td>
+    <td>Shift left/right</td>
+  </tr>
+  <tr>
+    <td><a class="permalink" href="#&amp;__&amp;___"><code class="Li" id="&amp;__&amp;___">&amp;
+      | ^</code></a></td>
+    <td>Binary and/or/xor</td>
+  </tr>
+  <tr>
+    <td><a class="permalink" href="#+_-"><code class="Li" id="+_-">+
+      -</code></a></td>
+    <td>Add/subtract</td>
+  </tr>
+  <tr>
+    <td><a class="permalink" href="#!=_==__="><code class="Li" id="!=_==__=">!=
       == &lt;=</code></a></td>
-    <td class="It-column">Boolean comparison</td>
+    <td>Boolean comparison</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#&gt;=_&lt;_&gt;"><code class="Li" id="&gt;=_&lt;_&gt;">&gt;=
+  <tr>
+    <td><a class="permalink" href="#_=____"><code class="Li" id="_=____">&gt;=
       &lt; &gt;</code></a></td>
-    <td class="It-column">Boolean comparison (Same precedence as the
-      others)</td>
+    <td>Boolean comparison (Same precedence as the others)</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#&amp;&amp;_||"><code class="Li" id="&amp;&amp;_||">&amp;&amp;
+  <tr>
+    <td><a class="permalink" href="#&amp;&amp;___"><code class="Li" id="&amp;&amp;___">&amp;&amp;
       ||</code></a></td>
-    <td class="It-column">Boolean and/or</td>
+    <td>Boolean and/or</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#!"><code class="Li" id="!">!</code></a></td>
-    <td class="It-column">Unary Boolean not</td>
+  <tr>
+    <td><a class="permalink" href="#!"><code class="Li" id="!">!</code></a></td>
+    <td>Unary Boolean not</td>
   </tr>
 </table>
-<div class="Pp"></div>
-The result of the boolean operators is zero if when FALSE and non-zero when
-  TRUE. It is legal to use an integer as the condition for IF blocks. You can
-  use symbols instead of numbers in your expression if you wish.
-<div class="Pp"></div>
-An expression is said to be constant when it doesn't change its value during
-  linking. This basically means that you can't use labels in those expressions.
-  The instructions in the macro-language all require expressions that are
-  constant. The only exception is the subtraction of labels in the same section
-  or labels that belong to sections with a fixed base addresses, all of which
-  must be defined in the same source file (the calculation cannot be passed to
-  the object file generated by the assembler). In this case, the result is a
-  constant that can be calculated at assembly time.
-<h2 class="Ss" title="Ss" id="Fixed&#x2010;point_Expressions"><a class="selflink" href="#Fixed&#x2010;point_Expressions">Fixed&#x2010;point
+<p class="Pp">The result of the boolean operators is zero if when FALSE and
+    non-zero when TRUE. It is legal to use an integer as the condition for IF
+    blocks. You can use symbols instead of numbers in your expression if you
+    wish.</p>
+<p class="Pp">An expression is said to be constant when it doesn't change its
+    value during linking. This basically means that you can't use labels in
+    those expressions. The instructions in the macro-language all require
+    expressions that are constant. The only exception is the subtraction of
+    labels in the same section or labels that belong to sections with a fixed
+    base addresses, all of which must be defined in the same source file (the
+    calculation cannot be passed to the object file generated by the assembler).
+    In this case, the result is a constant that can be calculated at assembly
+    time.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Fixed__u2010_point_Expressions"><a class="permalink" href="#Fixed__u2010_point_Expressions">Fixed&#x2010;point
   Expressions</a></h2>
 Fixed point constants are basically normal 32-bit constants where the upper 16
   bits are used for the integer part and the lower 16 bits are used for the
@@ -1143,87 +1033,83 @@ Fixed point constants are basically normal 32-bit constants where the upper 16
   the operands are integer or fixed-point. You can easily convert a fixed-point
   number to an integer by shifting it right 16 bits. It follows that you can
   convert an integer to a fixed-point number by shifting it left.
-<div class="Pp"></div>
-Some things are different for fixed-point math, though, which is why you have
-  the following functions to use:
-<table class="Bl-column" style="margin-left: 6.00ex;">
-  <colgroup>
-    <col style="min-width: 11.00ex;"/>
-  </colgroup>
-  <tr class="It-column">
-    <td class="It-column"><b class="Sy" title="Sy">Name</b></td>
-    <td class="It-column"><b class="Sy" title="Sy">Operation</b></td>
+<p class="Pp">Some things are different for fixed-point math, though, which is
+    why you have the following functions to use:</p>
+<table class="Bl-column Bd-indent">
+  <tr>
+    <td><b class="Sy">Name</b></td>
+    <td><b class="Sy">Operation</b></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">DIV</b>(<var class="Fa" title="Fa">x</var>,
-      <var class="Fa" title="Fa">y</var>)</td>
-    <td class="It-column">
+  <tr>
+    <td><code class="Fn">DIV</code>(<var class="Fa">x</var>,
+      <var class="Fa">y</var>)</td>
+    <td>
     <math class="eqn">
       <mrow><mi>x</mi><mo>&#x00F7;</mo><mi>y</mi></mrow>
     </math>
     </td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">MUL</b>(<var class="Fa" title="Fa">x</var>,
-      <var class="Fa" title="Fa">y</var>)</td>
-    <td class="It-column">
+  <tr>
+    <td><code class="Fn">MUL</code>(<var class="Fa">x</var>,
+      <var class="Fa">y</var>)</td>
+    <td>
     <math class="eqn">
       <mrow><mi>x</mi><mo>&#x00D7;</mo><mi>y</mi></mrow>
     </math>
     </td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">SIN</b>(<var class="Fa" title="Fa">x</var>)</td>
-    <td class="It-column">
+  <tr>
+    <td><code class="Fn">SIN</code>(<var class="Fa">x</var>)</td>
+    <td>
     <math class="eqn">
       <mrow><mi>sin</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
     </math>
     </td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">COS</b>(<var class="Fa" title="Fa">x</var>)</td>
-    <td class="It-column">
+  <tr>
+    <td><code class="Fn">COS</code>(<var class="Fa">x</var>)</td>
+    <td>
     <math class="eqn">
       <mrow><mi>cos</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
     </math>
     </td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">TAN</b>(<var class="Fa" title="Fa">x</var>)</td>
-    <td class="It-column">
+  <tr>
+    <td><code class="Fn">TAN</code>(<var class="Fa">x</var>)</td>
+    <td>
     <math class="eqn">
       <mrow><mi>tan</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
     </math>
     </td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">ASIN</b>(<var class="Fa" title="Fa">x</var>)</td>
-    <td class="It-column">
+  <tr>
+    <td><code class="Fn">ASIN</code>(<var class="Fa">x</var>)</td>
+    <td>
     <math class="eqn">
       <mrow><mi>asin</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
     </math>
     </td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">ACOS</b>(<var class="Fa" title="Fa">x</var>)</td>
-    <td class="It-column">
+  <tr>
+    <td><code class="Fn">ACOS</code>(<var class="Fa">x</var>)</td>
+    <td>
     <math class="eqn">
       <mrow><mi>acos</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
     </math>
     </td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">ATAN</b>(<var class="Fa" title="Fa">x</var>)</td>
-    <td class="It-column">
+  <tr>
+    <td><code class="Fn">ATAN</code>(<var class="Fa">x</var>)</td>
+    <td>
     <math class="eqn">
       <mrow><mi>atan</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
     </math>
     </td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">ATAN2</b>(<var class="Fa" title="Fa">x</var>,
-      <var class="Fa" title="Fa">y</var>)</td>
-    <td class="It-column">Angle between
+  <tr>
+    <td><code class="Fn">ATAN2</code>(<var class="Fa">x</var>,
+      <var class="Fa">y</var>)</td>
+    <td>Angle between
     <math class="eqn">
       <mrow><mo>(</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo>)</mo></mrow>
     </math>
@@ -1234,244 +1120,235 @@ Some things are different for fixed-point math, though, which is why you have
     </td>
   </tr>
 </table>
-<div class="Pp"></div>
-These functions are extremely useful for automatic generation of various tables.
-  A circle has 65536.0 degrees. Sine values are between [-1.0; 1.0].
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-; -- 
-; -- Generate a 256 byte sine table with values between 0 and 128 
-; -- 
-ANGLE SET   0.0 
-      REPT  256 
-      DB    (MUL(64.0,SIN(ANGLE))+64.0)&gt;&gt;16 
-ANGLE SET ANGLE+256.0 
+<p class="Pp">These functions are extremely useful for automatic generation of
+    various tables. A circle has 65536.0 degrees. Sine values are between [-1.0;
+    1.0].</p>
+<div class="Bd Pp Bd-indent">
+<pre>
+; --
+; -- Generate a 256 byte sine table with values between 0 and 128
+; --
+ANGLE SET   0.0
+      REPT  256
+      DB    (MUL(64.0,SIN(ANGLE))+64.0)&gt;&gt;16
+ANGLE SET ANGLE+256.0
       ENDR
 </pre>
 </div>
-<h2 class="Ss" title="Ss" id="String_Expressions"><a class="selflink" href="#String_Expressions">String
+</section>
+<section class="Ss">
+<h2 class="Ss" id="String_Expressions"><a class="permalink" href="#String_Expressions">String
   Expressions</a></h2>
 The most basic string expression is any number of characters contained in double
   quotes (&quot;for instance&quot;). Like in C, the escape character is \, and
   there are a number of commands you can use within a string:
-<table class="Bl-column" style="margin-left: 6.00ex;">
-  <colgroup>
-    <col style="min-width: 6.00ex;"/>
-  </colgroup>
-  <tr class="It-column">
-    <td class="It-column"><b class="Sy" title="Sy">String</b></td>
-    <td class="It-column"><b class="Sy" title="Sy">Meaning</b></td>
+<table class="Bl-column Bd-indent">
+  <tr>
+    <td><b class="Sy">String</b></td>
+    <td><b class="Sy">Meaning</b></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#\\"><code class="Li" id="\\">\\</code></a></td>
-    <td class="It-column">Backslash</td>
+  <tr>
+    <td><a class="permalink" href="#__rs___rs_"><code class="Li" id="__rs___rs_">\\</code></a></td>
+    <td>Backslash</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#\&quot;"><code class="Li" id="\&quot;">\&quot;</code></a></td>
-    <td class="It-column">Double quote</td>
+  <tr>
+    <td><a class="permalink" href="#__rs__"><code class="Li" id="__rs__">\&quot;</code></a></td>
+    <td>Double quote</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#\,"><code class="Li" id="\,">\,</code></a></td>
-    <td class="It-column">Comma</td>
+  <tr>
+    <td><a class="permalink" href="#__rs_,"><code class="Li" id="__rs_,">\,</code></a></td>
+    <td>Comma</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#\{"><code class="Li" id="\{">\{</code></a></td>
-    <td class="It-column">Curly bracket left</td>
+  <tr>
+    <td><a class="permalink" href="#__rs___2"><code class="Li" id="__rs___2">\{</code></a></td>
+    <td>Curly bracket left</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#\}"><code class="Li" id="\}">\}</code></a></td>
-    <td class="It-column">Curly bracket right</td>
+  <tr>
+    <td><a class="permalink" href="#__rs___3"><code class="Li" id="__rs___3">\}</code></a></td>
+    <td>Curly bracket right</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#\n"><code class="Li" id="\n">\n</code></a></td>
-    <td class="It-column">Newline ($0A)</td>
+  <tr>
+    <td><a class="permalink" href="#__rs_n"><code class="Li" id="__rs_n">\n</code></a></td>
+    <td>Newline ($0A)</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#\t"><code class="Li" id="\t">\t</code></a></td>
-    <td class="It-column">Tab ($09)</td>
+  <tr>
+    <td><a class="permalink" href="#__rs_t"><code class="Li" id="__rs_t">\t</code></a></td>
+    <td>Tab ($09)</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#\1_-_\9"><code class="Li" id="\1_-_\9">\1
+  <tr>
+    <td><a class="permalink" href="#__rs_1_-___rs_9"><code class="Li" id="__rs_1_-___rs_9">\1
       - \9</code></a></td>
-    <td class="It-column">Macro argument (Only the body of a macros)</td>
+    <td>Macro argument (Only the body of a macros)</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#\@"><code class="Li" id="\@">\@</code></a></td>
-    <td class="It-column">Label name suffix (Only in the body of macros and
-      repts)</td>
+  <tr>
+    <td><a class="permalink" href="#__rs_@"><code class="Li" id="__rs_@">\@</code></a></td>
+    <td>Label name suffix (Only in the body of macros and repts)</td>
   </tr>
 </table>
-<div class="Pp"></div>
-A funky feature is <b class="Sy" title="Sy">{symbol}</b> within a string. This
-  will examine the type of the symbol and insert its value accordingly. If
-  symbol is a string symbol, the symbols value is simply copied. If it's a
-  numeric symbol, the value is converted to hexadecimal notation and inserted as
-  a string.
-<div class="Pp"></div>
-HINT: The <b class="Sy" title="Sy">{symbol}</b> construct can also be used
-  outside strings. The symbol's value is again inserted as a string. This is
-  just a short way of doing &#x201C;{symbol}&#x201D;.
-<div class="Pp"></div>
-Whenever the macro-language expects a string you can actually use a string
-  expression. This consists of one or more of these function (yes, you can nest
-  them). Note that some of these functions actually return an integer and can be
-  used as part of an integer expression!
+<p class="Pp">A funky feature is <b class="Sy">{symbol}</b> within a string.
+    This will examine the type of the symbol and insert its value accordingly.
+    If symbol is a string symbol, the symbols value is simply copied. If it's a
+    numeric symbol, the value is converted to hexadecimal notation and inserted
+    as a string.</p>
+<p class="Pp">HINT: The <b class="Sy">{symbol}</b> construct can also be used
+    outside strings. The symbol's value is again inserted as a string. This is
+    just a short way of doing &#x201C;{symbol}&#x201D;.</p>
+<p class="Pp">Whenever the macro-language expects a string you can actually use
+    a string expression. This consists of one or more of these function (yes,
+    you can nest them). Note that some of these functions actually return an
+    integer and can be used as part of an integer expression!</p>
 <table class="Bl-column">
-  <colgroup>
-    <col style="min-width: 20.00ex;"/>
-  </colgroup>
-  <tr class="It-column">
-    <td class="It-column"><b class="Sy" title="Sy">Name</b></td>
-    <td class="It-column"><b class="Sy" title="Sy">Operation</b></td>
+  <tr>
+    <td><b class="Sy">Name</b></td>
+    <td><b class="Sy">Operation</b></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">STRLEN</b>(<var class="Fa" title="Fa">string</var>)</td>
-    <td class="It-column">Returns the number of characters in string</td>
+  <tr>
+    <td><code class="Fn">STRLEN</code>(<var class="Fa">string</var>)</td>
+    <td>Returns the number of characters in string</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">STRCAT</b>(<var class="Fa" title="Fa">str1</var>,
-      <var class="Fa" title="Fa">str2</var>)</td>
-    <td class="It-column">Appends str2 to str1.</td>
+  <tr>
+    <td><code class="Fn">STRCAT</code>(<var class="Fa">str1</var>,
+      <var class="Fa">str2</var>)</td>
+    <td>Appends str2 to str1.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">STRCMP</b>(<var class="Fa" title="Fa">str1</var>,
-      <var class="Fa" title="Fa">str2</var>)</td>
-    <td class="It-column">Returns negative if str1 is alphabetically lower than
-      str2, zero if they match, positive if str1 is greater than str2.</td>
+  <tr>
+    <td><code class="Fn">STRCMP</code>(<var class="Fa">str1</var>,
+      <var class="Fa">str2</var>)</td>
+    <td>Returns negative if str1 is alphabetically lower than str2, zero if they
+      match, positive if str1 is greater than str2.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">STRIN</b>(<var class="Fa" title="Fa">str1</var>,
-      <var class="Fa" title="Fa">str2</var>)</td>
-    <td class="It-column">Returns the position of str2 in str1 or zero if it's
-      not present (first character is position 1).</td>
+  <tr>
+    <td><code class="Fn">STRIN</code>(<var class="Fa">str1</var>,
+      <var class="Fa">str2</var>)</td>
+    <td>Returns the position of str2 in str1 or zero if it's not present (first
+      character is position 1).</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">STRSUB</b>(<var class="Fa" title="Fa">str</var>,
-      <var class="Fa" title="Fa">pos</var>,
-      <var class="Fa" title="Fa">len</var>)</td>
-    <td class="It-column">Returns a substring from str starting at pos (first
-      character is position 1) and with len characters.</td>
+  <tr>
+    <td><code class="Fn">STRSUB</code>(<var class="Fa">str</var>,
+      <var class="Fa">pos</var>, <var class="Fa">len</var>)</td>
+    <td>Returns a substring from str starting at pos (first character is
+      position 1) and with len characters.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">STRUPR</b>(<var class="Fa" title="Fa">str</var>)</td>
-    <td class="It-column">Converts all characters in str to capitals and returns
-      the new string.</td>
+  <tr>
+    <td><code class="Fn">STRUPR</code>(<var class="Fa">str</var>)</td>
+    <td>Converts all characters in str to capitals and returns the new
+      string.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">STRLWR</b>(<var class="Fa" title="Fa">str</var>)</td>
-    <td class="It-column">Converts all characters in str to lower case and
-      returns the new string.</td>
+  <tr>
+    <td><code class="Fn">STRLWR</code>(<var class="Fa">str</var>)</td>
+    <td>Converts all characters in str to lower case and returns the new
+      string.</td>
   </tr>
 </table>
-<h2 class="Ss" title="Ss" id="Character_maps"><a class="selflink" href="#Character_maps">Character
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Character_maps"><a class="permalink" href="#Character_maps">Character
   maps</a></h2>
 When writing text that is meant to be displayed in the Game Boy, the ASCII
   characters used in the source code may not be the same ones used in the
   tileset used in the ROM. For example, the tiles used for uppercase letters may
   be placed starting at tile index 128, which makes it difficult to add text
   strings to the ROM.
-<div class="Pp"></div>
-Character maps allow the code to map strings up to 16 characters long to an
-  abitrary 8-bit value:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-CHARMAP &quot;&lt;LF&gt;&quot;, 10 
-CHARMAP &quot;&amp;iacute&quot;, 20 
+<p class="Pp">Character maps allow the code to map strings up to 16 characters
+    long to an abitrary 8-bit value:</p>
+<div class="Bd Pp Bd-indent">
+<pre>
+CHARMAP &quot;&lt;LF&gt;&quot;, 10
+CHARMAP &quot;&amp;iacute&quot;, 20
 CHARMAP &quot;A&quot;, 128
 </pre>
 </div>
-<div class="Pp"></div>
-<b class="Sy" title="Sy">Note:</b> Character maps affect all strings in the file
-  from the point in which they are defined. This means that any string that the
-  code may want to print as debug information will also be affected by it.
-<div class="Pp"></div>
-<b class="Sy" title="Sy">Note:</b> The output value of a mapping can be 0. If
-  this happens, the assembler will treat this as the end of the string and the
-  rest of it will be trimmed.
-<h2 class="Ss" title="Ss" id="Other_functions"><a class="selflink" href="#Other_functions">Other
+<p class="Pp"><b class="Sy">Note:</b> Character maps affect all strings in the
+    file from the point in which they are defined. This means that any string
+    that the code may want to print as debug information will also be affected
+    by it.</p>
+<p class="Pp"><b class="Sy">Note:</b> The output value of a mapping can be 0. If
+    this happens, the assembler will treat this as the end of the string and the
+    rest of it will be trimmed.</p>
+</section>
+<section class="Ss">
+<h2 class="Ss" id="Other_functions"><a class="permalink" href="#Other_functions">Other
   functions</a></h2>
 There are a few other functions that do various useful things:
 <table class="Bl-column">
-  <colgroup>
-    <col style="min-width: 9.00ex;"/>
-  </colgroup>
-  <tr class="It-column">
-    <td class="It-column"><b class="Sy" title="Sy">Name</b></td>
-    <td class="It-column"><b class="Sy" title="Sy">Operation</b></td>
+  <tr>
+    <td><b class="Sy">Name</b></td>
+    <td><b class="Sy">Operation</b></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">BANK</b>(<var class="Fa" title="Fa">arg</var>)</td>
-    <td class="It-column">Returns a bank number. If
-      <var class="Ar" title="Ar">arg</var> is the symbol
-      <b class="Ic" title="Ic">@</b>, this function returns the bank of the
-      current section. If <var class="Ar" title="Ar">arg</var> is a string, it
-      returns the bank of the section that has that name. If
-      <var class="Ar" title="Ar">arg</var> is a label, it returns the bank
-      number the label is in. For labels, as the linker has to resolve this, it
-      can't be used when the expression has to be constant.</td>
+  <tr>
+    <td><code class="Fn">BANK</code>(<var class="Fa">arg</var>)</td>
+    <td>Returns a bank number. If <var class="Ar">arg</var> is the symbol
+      <code class="Ic">@</code>, this function returns the bank of the current
+      section. If <var class="Ar">arg</var> is a string, it returns the bank of
+      the section that has that name. If <var class="Ar">arg</var> is a label,
+      it returns the bank number the label is in. For labels, as the linker has
+      to resolve this, it can't be used when the expression has to be
+      constant.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">DEF</b>(<var class="Fa" title="Fa">label</var>)</td>
-    <td class="It-column">Returns TRUE if <var class="Ar" title="Ar">label</var>
-      has been defined.</td>
+  <tr>
+    <td><code class="Fn">DEF</code>(<var class="Fa">label</var>)</td>
+    <td>Returns TRUE if <var class="Ar">label</var> has been defined.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">HIGH</b>(<var class="Fa" title="Fa">arg</var>)</td>
-    <td class="It-column">Returns the top 8 bits of the operand if
-      <var class="Ar" title="Ar">arg</var> is a label or constant, or the top
-      8-bit register if it is a 16-bit register.</td>
+  <tr>
+    <td><code class="Fn">HIGH</code>(<var class="Fa">arg</var>)</td>
+    <td>Returns the top 8 bits of the operand if <var class="Ar">arg</var> is a
+      label or constant, or the top 8-bit register if it is a 16-bit
+      register.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><b class="Fn" title="Fn">LOW</b>(<var class="Fa" title="Fa">arg</var>)</td>
-    <td class="It-column">Returns the bottom 8 bits of the operand if
-      <var class="Ar" title="Ar">arg</var> is a label or constant, or the bottom
-      8-bit register if it is a 16-bit register (AF isn't a valid register for
-      this function).</td>
+  <tr>
+    <td><code class="Fn">LOW</code>(<var class="Fa">arg</var>)</td>
+    <td>Returns the bottom 8 bits of the operand if <var class="Ar">arg</var> is
+      a label or constant, or the bottom 8-bit register if it is a 16-bit
+      register (AF isn't a valid register for this function).</td>
   </tr>
 </table>
-<h1 class="Sh" title="Sh" id="MISCELLANEOUS"><a class="selflink" href="#MISCELLANEOUS">MISCELLANEOUS</a></h1>
-<h2 class="Ss" title="Ss" id="Changing_options_while_assembling"><a class="selflink" href="#Changing_options_while_assembling">Changing
+</section>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="MISCELLANEOUS"><a class="permalink" href="#MISCELLANEOUS">MISCELLANEOUS</a></h1>
+<section class="Ss">
+<h2 class="Ss" id="Changing_options_while_assembling"><a class="permalink" href="#Changing_options_while_assembling">Changing
   options while assembling</a></h2>
-<b class="Ic" title="Ic">OPT</b> can be used to change some of the options
-  during assembling the source instead of defining them on the commandline.
-<div class="Pp"></div>
-<b class="Ic" title="Ic">OPT</b> takes a comma-seperated list of options as its
-  argument:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-PUSHO 
-OPT   g.oOX ;Set the GB graphics constants to use these characters 
-DW    `..ooOOXX 
-POPO 
+<code class="Ic">OPT</code> can be used to change some of the options during
+  assembling the source instead of defining them on the commandline.
+<p class="Pp"><code class="Ic">OPT</code> takes a comma-seperated list of
+    options as its argument:</p>
+<div class="Bd Pp Bd-indent">
+<pre>
+PUSHO
+OPT   g.oOX ;Set the GB graphics constants to use these characters
+DW    `..ooOOXX
+POPO
 DW    `00112233
 </pre>
 </div>
-<div class="Pp"></div>
-The options that OPT can modify are currently: <b class="Sy" title="Sy">b</b>,
-  <b class="Sy" title="Sy">e</b> and <b class="Sy" title="Sy">g</b>.
-<div class="Pp"></div>
-<b class="Ic" title="Ic">POPO</b> and <b class="Ic" title="Ic">PUSHO</b> provide
-  the interface to the option stack. <b class="Ic" title="Ic">PUSHO</b> will
-  push the current set of options on the option stack.
-  <b class="Ic" title="Ic">POPO</b> can then later be used to restore them.
-  Useful if you want to change some options in an include file and you don't
-  want to destroy the options set by the program that included your file. The
-  stacks number of entries is limited only by the amount of memory in your
-  machine.
-<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="selflink" href="#SEE_ALSO">SEE
+<p class="Pp">The options that OPT can modify are currently:
+    <b class="Sy">b</b>, <b class="Sy">e</b> and <b class="Sy">g</b>.</p>
+<p class="Pp"><code class="Ic">POPO</code> and <code class="Ic">PUSHO</code>
+    provide the interface to the option stack. <code class="Ic">PUSHO</code>
+    will push the current set of options on the option stack.
+    <code class="Ic">POPO</code> can then later be used to restore them. Useful
+    if you want to change some options in an include file and you don't want to
+    destroy the options set by the program that included your file. The stacks
+    number of entries is limited only by the amount of memory in your
+  machine.</p>
+</section>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" title="Xr">rgbasm(1)</a>, <a class="Xr" title="Xr">rgblink(1)</a>,
-  <a class="Xr" title="Xr">rgblink(5)</a>,
-  <a class="Xr" title="Xr">rgbds(5)</a>, <a class="Xr" title="Xr">rgbds(7)</a>,
-  <a class="Xr" title="Xr">gbz80(7)</a>
-<h1 class="Sh" title="Sh" id="HISTORY"><a class="selflink" href="#HISTORY">HISTORY</a></h1>
-<b class="Nm" title="Nm">rgbds</b> was originally written by Carsten
-  S&#x00F8;rensen as part of the ASMotor package, and was later packaged in
-  RGBDS by Justin Lloyd. It is now maintained by a number of contributors at
-  <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
+<a class="Xr">rgbasm(1)</a>, <a class="Xr">rgblink(1)</a>,
+  <a class="Xr">rgblink(5)</a>, <a class="Xr">rgbds(5)</a>,
+  <a class="Xr">rgbds(7)</a>, <a class="Xr">gbz80(7)</a>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="HISTORY"><a class="permalink" href="#HISTORY">HISTORY</a></h1>
+<code class="Nm">rgbds</code> was originally written by Carsten S&#x00F8;rensen
+  as part of the ASMotor package, and was later packaged in RGBDS by Justin
+  Lloyd. It is now maintained by a number of contributors at
+  <a class="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.
+</section>
+</div>
 <table class="foot">
   <tr>
     <td class="foot-date">March 13, 2018</td>

--- a/docs/rgbds.5.html
+++ b/docs/rgbds.5.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html>
+<!-- This is an automatically generated file.  Do not edit.
+   This file is part of RGBDS.
+
+   Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
+
+   SPDX-License-Identifier: MIT
+   -->
 <head>
   <meta charset="utf-8"/>
-  <style>
-    table.head, table.foot { width: 100%; }
-    td.head-rtitle, td.foot-os { text-align: right; }
-    td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-  </style>
   <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
   <title>RGBDS(5)</title>
 </head>
@@ -20,124 +21,127 @@
   </tr>
 </table>
 <div class="manual-text">
-<h1 class="Sh" title="Sh" id="NAME"><a class="selflink" href="#NAME">NAME</a></h1>
-<b class="Nm" title="Nm">rgbds</b> &#x2014; <span class="Nd" title="Nd">object
-  file format documentation</span>
-<h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="selflink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-This is the description of the object files used by
-  <a class="Xr" title="Xr">rgbasm(1)</a> and
-  <a class="Xr" title="Xr">rgblink(1)</a>. Please, note that the specifications
-  may change. This toolchain is in development and new features may require
-  adding more information to the current format, or modifying some fields, which
-  would break compatibility with older versions.
-<h1 class="Sh" title="Sh" id="FILE_STRUCTURE"><a class="selflink" href="#FILE_STRUCTURE">FILE
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<code class="Nm">rgbds</code> &#x2014;
+<div class="Nd">object file format documentation</div>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+This is the description of the object files used by <a class="Xr">rgbasm(1)</a>
+  and <a class="Xr">rgblink(1)</a>. Please, note that the specifications may
+  change. This toolchain is in development and new features may require adding
+  more information to the current format, or modifying some fields, which would
+  break compatibility with older versions.
+</section>
+<section class="Sh">
+<h1 class="Sh" id="FILE_STRUCTURE"><a class="permalink" href="#FILE_STRUCTURE">FILE
   STRUCTURE</a></h1>
 The following types are used:
-<div class="Pp"></div>
-<var class="Ar" title="Ar">LONG</var> is a 32&#x2010;bit integer stored in
-  little&#x2010;endian format (Intel). <var class="Ar" title="Ar">BYTE</var> is
-  an 8&#x2010;bit integer. <var class="Ar" title="Ar">STRING</var> is a
-  0&#x2010;terminated string of <var class="Ar" title="Ar">BYTE</var>.
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 0.00ex;">
-<pre class="Li">
-; Header 
- 
-BYTE    ID[4]            ; &quot;RGB6&quot; 
-LONG    NumberOfSymbols  ; The number of symbols used in this file 
-LONG    NumberOfSections ; The number of sections used in this file 
- 
-; Symbols 
- 
-REPT    NumberOfSymbols   ; Number of symbols defined in this object file. 
- 
-    STRING  Name          ; The name of this symbol. Local symbols are stored 
-                          ; as &quot;Scope.Symbol&quot;. 
- 
-    BYTE    Type          ; 0 = LOCAL symbol only used in this file. 
-                          ; 1 = IMPORT this symbol from elsewhere (unused). 
-                          ; 2 = EXPORT this symbol to other objects. 
- 
-    IF      Type != 1     ; If symbol is defined in this object file. 
- 
-        STRING  FileName  ; File where the symbol is defined. 
- 
-        LONG    LineNum   ; Line number in the file where the symbol is defined. 
- 
-        LONG    SectionID ; The section number (of this object file) in which 
-                          ; this symbol is defined. If it doesn't belong to any 
-                          ; specific section (like a constant), this field has 
-                          ; the value -1. 
- 
-        LONG    Value     ; The symbols value. It's the offset into that 
-                          ; symbol's section. 
- 
-    ENDC 
- 
-ENDR 
- 
-; Sections 
- 
-REPT NumberOfSections 
-    STRING  Name  ; Name of the section 
- 
-    LONG    Size  ; Size in bytes of this section 
- 
-    BYTE    Type  ; 0 = WRAM0 
-                  ; 1 = VRAM 
-                  ; 2 = ROMX 
-                  ; 3 = ROM0 
-                  ; 4 = HRAM 
-                  ; 5 = WRAMX 
-                  ; 6 = SRAM 
-                  ; 7 = OAM 
- 
-    LONG    Org   ; Address to fix this section at. -1 if the linker should 
-                  ; decide (floating address). 
- 
-    LONG    Bank  ; Bank to load this section into. -1 if the linker should 
-                  ; decide (floating bank). This field is only valid for ROMX, 
-                  ; VRAM, WRAMX and SRAM sections. 
- 
-    LONG    Align ; Alignment of this section (expressed as number of low bits 
-                  ; to leave as 0). -1 if not defined. 
- 
-    IF      (Type == ROMX) || (Type == ROM0) ; Sections that can contain data. 
- 
-        BYTE    Data[Size]      ; Raw data of the section. 
- 
-        LONG    NumberOfPatches ; Number of patches to apply. 
- 
-        ; These types of sections may have patches 
- 
-        REPT    NumberOfPatches 
- 
-            STRING  SourceFile   ; Name of the source file (for printing error 
-                                 ; messages). 
- 
-            LONG    Line         ; The line of the source file. 
- 
-            LONG    Offset       ; Offset into the section where patch should 
-                                 ; be applied (in bytes). 
- 
-            BYTE    Type         ; 0 = BYTE patch. 
-                                 ; 1 = little endian WORD patch. 
-                                 ; 2 = little endian LONG patch. 
-                                 ; 3 = JR offset value BYTE patch. 
- 
-            LONG    RPNSize      ; Size of the buffer with the RPN. 
-                                 ; expression. 
- 
-            BYTE    RPN[RPNSize] ; RPN expression. Definition below. 
- 
-        ENDR 
- 
-    ENDC 
- 
+<p class="Pp"><var class="Ar">LONG</var> is a 32&#x2010;bit integer stored in
+    little&#x2010;endian format (Intel). <var class="Ar">BYTE</var> is an
+    8&#x2010;bit integer. <var class="Ar">STRING</var> is a 0&#x2010;terminated
+    string of <var class="Ar">BYTE</var>.</p>
+<div class="Bd Pp">
+<pre>
+; Header
+
+BYTE    ID[4]            ; &quot;RGB6&quot;
+LONG    NumberOfSymbols  ; The number of symbols used in this file
+LONG    NumberOfSections ; The number of sections used in this file
+
+; Symbols
+
+REPT    NumberOfSymbols   ; Number of symbols defined in this object file.
+
+    STRING  Name          ; The name of this symbol. Local symbols are stored
+                          ; as &quot;Scope.Symbol&quot;.
+
+    BYTE    Type          ; 0 = LOCAL symbol only used in this file.
+                          ; 1 = IMPORT this symbol from elsewhere
+                          ; 2 = EXPORT this symbol to other objects.
+
+    IF      Type != 1     ; If symbol is defined in this object file.
+
+        STRING  FileName  ; File where the symbol is defined.
+
+        LONG    LineNum   ; Line number in the file where the symbol is defined.
+
+        LONG    SectionID ; The section number (of this object file) in which
+                          ; this symbol is defined. If it doesn't belong to any
+                          ; specific section (like a constant), this field has
+                          ; the value -1.
+
+        LONG    Value     ; The symbols value. It's the offset into that
+                          ; symbol's section.
+
+    ENDC
+
+ENDR
+
+; Sections
+
+REPT NumberOfSections
+    STRING  Name  ; Name of the section
+
+    LONG    Size  ; Size in bytes of this section
+
+    BYTE    Type  ; 0 = WRAM0
+                  ; 1 = VRAM
+                  ; 2 = ROMX
+                  ; 3 = ROM0
+                  ; 4 = HRAM
+                  ; 5 = WRAMX
+                  ; 6 = SRAM
+                  ; 7 = OAM
+
+    LONG    Org   ; Address to fix this section at. -1 if the linker should
+                  ; decide (floating address).
+
+    LONG    Bank  ; Bank to load this section into. -1 if the linker should
+                  ; decide (floating bank). This field is only valid for ROMX,
+                  ; VRAM, WRAMX and SRAM sections.
+
+    LONG    Align ; Alignment of this section (expressed as number of low bits
+                  ; to leave as 0). -1 if not defined.
+
+    IF      (Type == ROMX) || (Type == ROM0) ; Sections that can contain data.
+
+        BYTE    Data[Size]      ; Raw data of the section.
+
+        LONG    NumberOfPatches ; Number of patches to apply.
+
+        ; These types of sections may have patches
+
+        REPT    NumberOfPatches
+
+            STRING  SourceFile   ; Name of the source file (for printing error
+                                 ; messages).
+
+            LONG    Line         ; The line of the source file.
+
+            LONG    Offset       ; Offset into the section where patch should
+                                 ; be applied (in bytes).
+
+            BYTE    Type         ; 0 = BYTE patch.
+                                 ; 1 = little endian WORD patch.
+                                 ; 2 = little endian LONG patch.
+                                 ; 3 = JR offset value BYTE patch.
+
+            LONG    RPNSize      ; Size of the buffer with the RPN.
+                                 ; expression.
+
+            BYTE    RPN[RPNSize] ; RPN expression. Definition below.
+
+        ENDR
+
+    ENDC
+
 ENDR
 </pre>
 </div>
-<h2 class="Ss" title="Ss" id="RPN_DATA"><a class="selflink" href="#RPN_DATA">RPN
+<section class="Ss">
+<h2 class="Ss" id="RPN_DATA"><a class="permalink" href="#RPN_DATA">RPN
   DATA</a></h2>
 Expressions in the object file are stored as RPN. This is an expression of the
   form &#x201C;2 5 +&#x201D;. This will first push the value &#x201C;2&#x201D;
@@ -146,159 +150,160 @@ Expressions in the object file are stored as RPN. This is an expression of the
   effectively replacing the two top arguments with their sum. In the RGB format,
   RPN expressions are stored as BYTEs with some bytes being special prefixes for
   integers and symbols.
-<table class="Bl-column" style="margin-left: 6.00ex;">
-  <colgroup>
-    <col style="width: 15.00ex;"/>
-    <col style="min-width: 10.00ex;"/>
-  </colgroup>
-  <tr class="It-column">
-    <td class="It-column"><b class="Sy" title="Sy">Value</b></td>
-    <td class="It-column"><b class="Sy" title="Sy">Meaning</b></td>
+<table class="Bl-column Bd-indent">
+  <tr>
+    <td><b class="Sy">Value</b></td>
+    <td><b class="Sy">Meaning</b></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$00"><code class="Li" id="$00">$00</code></a></td>
-    <td class="It-column"><a class="selflink" href="#+_operator"><code class="Li" id="+_operator">+
+  <tr>
+    <td><a class="permalink" href="#$00"><code class="Li" id="$00">$00</code></a></td>
+    <td><a class="permalink" href="#+_operator"><code class="Li" id="+_operator">+
       operator</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$01"><code class="Li" id="$01">$01</code></a></td>
-    <td class="It-column"><a class="selflink" href="#-_operator"><code class="Li" id="-_operator">-
+  <tr>
+    <td><a class="permalink" href="#$01"><code class="Li" id="$01">$01</code></a></td>
+    <td><a class="permalink" href="#-_operator"><code class="Li" id="-_operator">-
       operator</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$02"><code class="Li" id="$02">$02</code></a></td>
-    <td class="It-column"><a class="selflink" href="#*_operator"><code class="Li" id="*_operator">*
+  <tr>
+    <td><a class="permalink" href="#$02"><code class="Li" id="$02">$02</code></a></td>
+    <td><a class="permalink" href="#*_operator"><code class="Li" id="*_operator">*
       operator</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$03"><code class="Li" id="$03">$03</code></a></td>
-    <td class="It-column"><a class="selflink" href="#/_operator"><code class="Li" id="/_operator">/
+  <tr>
+    <td><a class="permalink" href="#$03"><code class="Li" id="$03">$03</code></a></td>
+    <td><a class="permalink" href="#/_operator"><code class="Li" id="/_operator">/
       operator</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$04"><code class="Li" id="$04">$04</code></a></td>
-    <td class="It-column"><a class="selflink" href="#%_operator"><code class="Li" id="%_operator">%
+  <tr>
+    <td><a class="permalink" href="#$04"><code class="Li" id="$04">$04</code></a></td>
+    <td><a class="permalink" href="#__operator"><code class="Li" id="__operator">%
       operator</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$05"><code class="Li" id="$05">$05</code></a></td>
-    <td class="It-column"><a class="selflink" href="#unary_-"><code class="Li" id="unary_-">unary
+  <tr>
+    <td><a class="permalink" href="#$05"><code class="Li" id="$05">$05</code></a></td>
+    <td><a class="permalink" href="#unary_-"><code class="Li" id="unary_-">unary
       -</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$10"><code class="Li" id="$10">$10</code></a></td>
-    <td class="It-column">|
-      <a class="selflink" href="#operator"><code class="Li" id="operator">operator</code></a></td>
+  <tr>
+    <td><a class="permalink" href="#$10"><code class="Li" id="$10">$10</code></a></td>
+    <td>|
+      <a class="permalink" href="#operator"><code class="Li" id="operator">operator</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$11"><code class="Li" id="$11">$11</code></a></td>
-    <td class="It-column"><a class="selflink" href="#&amp;_operator"><code class="Li" id="&amp;_operator">&amp;
+  <tr>
+    <td><a class="permalink" href="#$11"><code class="Li" id="$11">$11</code></a></td>
+    <td><a class="permalink" href="#&amp;_operator"><code class="Li" id="&amp;_operator">&amp;
       operator</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$12"><code class="Li" id="$12">$12</code></a></td>
-    <td class="It-column"><a class="selflink" href="#^_operator"><code class="Li" id="^_operator">^
+  <tr>
+    <td><a class="permalink" href="#$12"><code class="Li" id="$12">$12</code></a></td>
+    <td><a class="permalink" href="#__operator_2"><code class="Li" id="__operator_2">^
       operator</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$13"><code class="Li" id="$13">$13</code></a></td>
-    <td class="It-column"><a class="selflink" href="#unary_~"><code class="Li" id="unary_~">unary
+  <tr>
+    <td><a class="permalink" href="#$13"><code class="Li" id="$13">$13</code></a></td>
+    <td><a class="permalink" href="#unary_~"><code class="Li" id="unary_~">unary
       ~</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$21"><code class="Li" id="$21">$21</code></a></td>
-    <td class="It-column"><a class="selflink" href="#&amp;&amp;_comparison"><code class="Li" id="&amp;&amp;_comparison">&amp;&amp;
+  <tr>
+    <td><a class="permalink" href="#$21"><code class="Li" id="$21">$21</code></a></td>
+    <td><a class="permalink" href="#&amp;&amp;_comparison"><code class="Li" id="&amp;&amp;_comparison">&amp;&amp;
       comparison</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$22"><code class="Li" id="$22">$22</code></a></td>
-    <td class="It-column"><a class="selflink" href="#||_comparison"><code class="Li" id="||_comparison">||
+  <tr>
+    <td><a class="permalink" href="#$22"><code class="Li" id="$22">$22</code></a></td>
+    <td><a class="permalink" href="#___comparison"><code class="Li" id="___comparison">||
       comparison</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$23"><code class="Li" id="$23">$23</code></a></td>
-    <td class="It-column"><a class="selflink" href="#unary"><code class="Li" id="unary">unary</code></a>!</td>
+  <tr>
+    <td><a class="permalink" href="#$23"><code class="Li" id="$23">$23</code></a></td>
+    <td><a class="permalink" href="#unary"><code class="Li" id="unary">unary</code></a>!</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$30"><code class="Li" id="$30">$30</code></a></td>
-    <td class="It-column"><a class="selflink" href="#==_comparison"><code class="Li" id="==_comparison">==
+  <tr>
+    <td><a class="permalink" href="#$30"><code class="Li" id="$30">$30</code></a></td>
+    <td><a class="permalink" href="#==_comparison"><code class="Li" id="==_comparison">==
       comparison</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$31"><code class="Li" id="$31">$31</code></a></td>
-    <td class="It-column"><a class="selflink" href="#!=_comparison"><code class="Li" id="!=_comparison">!=
+  <tr>
+    <td><a class="permalink" href="#$31"><code class="Li" id="$31">$31</code></a></td>
+    <td><a class="permalink" href="#!=_comparison"><code class="Li" id="!=_comparison">!=
       comparison</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$32"><code class="Li" id="$32">$32</code></a></td>
-    <td class="It-column"><a class="selflink" href="#&gt;_comparison"><code class="Li" id="&gt;_comparison">&gt;
+  <tr>
+    <td><a class="permalink" href="#$32"><code class="Li" id="$32">$32</code></a></td>
+    <td><a class="permalink" href="#__comparison"><code class="Li" id="__comparison">&gt;
       comparison</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$33"><code class="Li" id="$33">$33</code></a></td>
-    <td class="It-column"><a class="selflink" href="#&lt;_comparison"><code class="Li" id="&lt;_comparison">&lt;
+  <tr>
+    <td><a class="permalink" href="#$33"><code class="Li" id="$33">$33</code></a></td>
+    <td><a class="permalink" href="#__comparison_2"><code class="Li" id="__comparison_2">&lt;
       comparison</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$34"><code class="Li" id="$34">$34</code></a></td>
-    <td class="It-column"><a class="selflink" href="#&gt;=_comparison"><code class="Li" id="&gt;=_comparison">&gt;=
+  <tr>
+    <td><a class="permalink" href="#$34"><code class="Li" id="$34">$34</code></a></td>
+    <td><a class="permalink" href="#_=_comparison"><code class="Li" id="_=_comparison">&gt;=
       comparison</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$35"><code class="Li" id="$35">$35</code></a></td>
-    <td class="It-column"><a class="selflink" href="#&lt;=_comparison"><code class="Li" id="&lt;=_comparison">&lt;=
+  <tr>
+    <td><a class="permalink" href="#$35"><code class="Li" id="$35">$35</code></a></td>
+    <td><a class="permalink" href="#_=_comparison_2"><code class="Li" id="_=_comparison_2">&lt;=
       comparison</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$40"><code class="Li" id="$40">$40</code></a></td>
-    <td class="It-column"><a class="selflink" href="#&lt;&lt;_comparison"><code class="Li" id="&lt;&lt;_comparison">&lt;&lt;
-      comparison</code></a></td>
+  <tr>
+    <td><a class="permalink" href="#$40"><code class="Li" id="$40">$40</code></a></td>
+    <td><a class="permalink" href="#___operator"><code class="Li" id="___operator">&lt;&lt;
+      operator</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$41"><code class="Li" id="$41">$41</code></a></td>
-    <td class="It-column"><a class="selflink" href="#&gt;&gt;_comparison"><code class="Li" id="&gt;&gt;_comparison">&gt;&gt;
-      comparison</code></a></td>
+  <tr>
+    <td><a class="permalink" href="#$41"><code class="Li" id="$41">$41</code></a></td>
+    <td><a class="permalink" href="#___operator_2"><code class="Li" id="___operator_2">&gt;&gt;
+      operator</code></a></td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$50"><code class="Li" id="$50">$50</code></a></td>
-    <td class="It-column"><a class="selflink" href="#BANK(symbol),"><code class="Li" id="BANK(symbol),">BANK(symbol),</code></a>
-      a <var class="Ar" title="Ar">LONG</var> Symbol ID follows.</td>
+  <tr>
+    <td><a class="permalink" href="#$50"><code class="Li" id="$50">$50</code></a></td>
+    <td><a class="permalink" href="#BANK(symbol),"><code class="Li" id="BANK(symbol),">BANK(symbol),</code></a>
+      a <var class="Ar">LONG</var> Symbol ID follows.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$51"><code class="Li" id="$51">$51</code></a></td>
-    <td class="It-column"><a class="selflink" href="#BANK(section_name),"><code class="Li" id="BANK(section_name),">BANK(section_name),</code></a>
+  <tr>
+    <td><a class="permalink" href="#$51"><code class="Li" id="$51">$51</code></a></td>
+    <td><a class="permalink" href="#BANK(section_name),"><code class="Li" id="BANK(section_name),">BANK(section_name),</code></a>
       a null-terminated string follows.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$52"><code class="Li" id="$52">$52</code></a></td>
-    <td class="It-column"><a class="selflink" href="#Current_BANK()"><code class="Li" id="Current_BANK()">Current
+  <tr>
+    <td><a class="permalink" href="#$52"><code class="Li" id="$52">$52</code></a></td>
+    <td><a class="permalink" href="#Current_BANK()"><code class="Li" id="Current_BANK()">Current
       BANK()</code></a>.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$60"><code class="Li" id="$60">$60</code></a></td>
-    <td class="It-column"><a class="selflink" href="#HRAMCheck."><code class="Li" id="HRAMCheck.">HRAMCheck.</code></a>
+  <tr>
+    <td><a class="permalink" href="#$60"><code class="Li" id="$60">$60</code></a></td>
+    <td><a class="permalink" href="#HRAMCheck."><code class="Li" id="HRAMCheck.">HRAMCheck.</code></a>
       Check if the value is in HRAM, AND it with 0xFF.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$80"><code class="Li" id="$80">$80</code></a></td>
-    <td class="It-column"><var class="Ar" title="Ar">LONG</var> integer
-      follows.</td>
+  <tr>
+    <td><a class="permalink" href="#$80"><code class="Li" id="$80">$80</code></a></td>
+    <td><var class="Ar">LONG</var> integer follows.</td>
   </tr>
-  <tr class="It-column">
-    <td class="It-column"><a class="selflink" href="#$81"><code class="Li" id="$81">$81</code></a></td>
-    <td class="It-column"><var class="Ar" title="Ar">LONG</var> Symbol ID
-      follows.</td>
+  <tr>
+    <td><a class="permalink" href="#$81"><code class="Li" id="$81">$81</code></a></td>
+    <td><var class="Ar">LONG</var> Symbol ID follows.</td>
   </tr>
 </table>
-<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="selflink" href="#SEE_ALSO">SEE
+</section>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" title="Xr">rgbasm(1)</a>, <a class="Xr" title="Xr">rgblink(1)</a>,
-  <a class="Xr" title="Xr">rgbds(7)</a>, <a class="Xr" title="Xr">gbz80(7)</a>
-<h1 class="Sh" title="Sh" id="HISTORY"><a class="selflink" href="#HISTORY">HISTORY</a></h1>
-<b class="Nm" title="Nm">rgbds</b> was originally written by Carsten
-  S&#x00F8;rensen as part of the ASMotor package, and was later packaged in
-  RGBDS by Justin Lloyd. It is now maintained by a number of contributors at
-  <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
+<a class="Xr">rgbasm(1)</a>, <a class="Xr">rgblink(1)</a>,
+  <a class="Xr">rgbds(7)</a>, <a class="Xr">gbz80(7)</a>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="HISTORY"><a class="permalink" href="#HISTORY">HISTORY</a></h1>
+<code class="Nm">rgbds</code> was originally written by Carsten S&#x00F8;rensen
+  as part of the ASMotor package, and was later packaged in RGBDS by Justin
+  Lloyd. It is now maintained by a number of contributors at
+  <a class="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.
+</section>
+</div>
 <table class="foot">
   <tr>
     <td class="foot-date">January 26, 2018</td>

--- a/docs/rgbds.7.html
+++ b/docs/rgbds.7.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html>
+<!-- This is an automatically generated file.  Do not edit.
+   This file is part of RGBDS.
+
+   Copyright (c) 2010-2018, Anthony J. Bentley and RGBDS contributors.
+
+   SPDX-License-Identifier: MIT
+   -->
 <head>
   <meta charset="utf-8"/>
-  <style>
-    table.head, table.foot { width: 100%; }
-    td.head-rtitle, td.foot-os { text-align: right; }
-    td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-  </style>
   <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
   <title>RGBDS(7)</title>
 </head>
@@ -20,46 +21,52 @@
   </tr>
 </table>
 <div class="manual-text">
-<h1 class="Sh" title="Sh" id="NAME"><a class="selflink" href="#NAME">NAME</a></h1>
-<b class="Nm" title="Nm">rgbds</b> &#x2014; <span class="Nd" title="Nd">Rednex
-  Game Boy Development System</span>
-<h1 class="Sh" title="Sh" id="EXAMPLES"><a class="selflink" href="#EXAMPLES">EXAMPLES</a></h1>
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<code class="Nm">rgbds</code> &#x2014;
+<div class="Nd">Rednex Game Boy Development System</div>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
 To get a working ROM image from a single assembly source file:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-$ rgbasm -o bar.o foo.asm 
-$ rgblink -o baz.gb bar.o 
+<div class="Bd Pp Bd-indent">
+<pre>
+$ rgbasm -o bar.o foo.asm
+$ rgblink -o baz.gb bar.o
 $ rgbfix -v -p 0 baz.gb
 </pre>
 </div>
-<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="selflink" href="#SEE_ALSO">SEE
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" title="Xr">rgbasm(1)</a>, <a class="Xr" title="Xr">rgbfix(1)</a>,
-  <a class="Xr" title="Xr">rgblink(1)</a>,
-  <a class="Xr" title="Xr">rgbds(5)</a>, <a class="Xr" title="Xr">gbz80(7)</a>
-<h1 class="Sh" title="Sh" id="HISTORY"><a class="selflink" href="#HISTORY">HISTORY</a></h1>
+<a class="Xr">rgbasm(1)</a>, <a class="Xr">rgbfix(1)</a>,
+  <a class="Xr">rgblink(1)</a>, <a class="Xr">rgbds(5)</a>,
+  <a class="Xr">gbz80(7)</a>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="HISTORY"><a class="permalink" href="#HISTORY">HISTORY</a></h1>
 <dl class="Bl-ohang">
-  <dt class="It-ohang"></dt>
-  <dd class="It-ohang">1997, Carsten S&#x00F8;rensen (AKA SurfSmurf) writes
-      ASMotor as a general-purpose assembler/linker system for DOS/Win32.</dd>
-  <dt class="It-ohang"></dt>
-  <dd class="It-ohang">1999, Justin Lloyd (AKA Otaku no Zoku) adapts ASMotor to
-      read and produce GBZ80 assembly/machine code, and releases this version as
-      RGBDS.</dd>
-  <dt class="It-ohang"></dt>
-  <dd class="It-ohang">2009, Vegard Nossum adapts the code to be more UNIX-like
-      and releases this version as rgbds-linux on GitHub.</dd>
-  <dt class="It-ohang"></dt>
-  <dd class="It-ohang">2010, Anthony J. Bentley forks that repository. The fork
-      becomes the reference implementation of rgbds.</dd>
-  <dt class="It-ohang"></dt>
-  <dd class="It-ohang">2017, Bentley's repository is moved to a neutral name. It
-      is now maintained by a number of contributors at
-      <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</dd>
-  <dt class="It-ohang"></dt>
-  <dd class="It-ohang">2018, codebase relicensed under the MIT license.</dd>
+  <dt></dt>
+  <dd>1997, Carsten S&#x00F8;rensen (AKA SurfSmurf) writes ASMotor as a
+      general-purpose assembler/linker system for DOS/Win32.</dd>
+  <dt></dt>
+  <dd>1999, Justin Lloyd (AKA Otaku no Zoku) adapts ASMotor to read and produce
+      GBZ80 assembly/machine code, and releases this version as RGBDS.</dd>
+  <dt></dt>
+  <dd>2009, Vegard Nossum adapts the code to be more UNIX-like and releases this
+      version as rgbds-linux on GitHub.</dd>
+  <dt></dt>
+  <dd>2010, Anthony J. Bentley forks that repository. The fork becomes the
+      reference implementation of rgbds.</dd>
+  <dt></dt>
+  <dd>2017, Bentley's repository is moved to a neutral name. It is now
+      maintained by a number of contributors at
+      <a class="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</dd>
+  <dt></dt>
+  <dd>2018, codebase relicensed under the MIT license.</dd>
 </dl>
+</section>
 </div>
 <table class="foot">
   <tr>

--- a/docs/rgbfix.1.html
+++ b/docs/rgbfix.1.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html>
+<!-- This is an automatically generated file.  Do not edit.
+   This file is part of RGBDS.
+
+   Copyright (c) 2010-2017, Anthony J. Bentley and RGBDS contributors.
+
+   SPDX-License-Identifier: MIT
+   -->
 <head>
   <meta charset="utf-8"/>
-  <style>
-    table.head, table.foot { width: 100%; }
-    td.head-rtitle, td.foot-os { text-align: right; }
-    td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-  </style>
   <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
   <title>RGBFIX(1)</title>
 </head>
@@ -20,189 +21,158 @@
   </tr>
 </table>
 <div class="manual-text">
-<h1 class="Sh" title="Sh" id="NAME"><a class="selflink" href="#NAME">NAME</a></h1>
-<b class="Nm" title="Nm">rgbfix</b> &#x2014; <span class="Nd" title="Nd">Game
-  Boy checksum fixer</span>
-<h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="selflink" href="#SYNOPSIS">SYNOPSIS</a></h1>
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<code class="Nm">rgbfix</code> &#x2014;
+<div class="Nd">Game Boy checksum fixer</div>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <table class="Nm">
   <tr>
-    <td><b class="Nm" title="Nm">rgbfix</b></td>
-    <td>[<span class="Op"><b class="Fl" title="Fl">-CcjsVv</b></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-f</b>
-      <var class="Ar" title="Ar">fix_spec</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-i</b>
-      <var class="Ar" title="Ar">game_id</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-k</b>
-      <var class="Ar" title="Ar">licensee_str</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-l</b>
-      <var class="Ar" title="Ar">licensee_id</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-m</b>
-      <var class="Ar" title="Ar">mbc_type</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-n</b>
-      <var class="Ar" title="Ar">rom_version</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-p</b>
-      <var class="Ar" title="Ar">pad_value</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-r</b>
-      <var class="Ar" title="Ar">ram_size</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-t</b>
-      <var class="Ar" title="Ar">title_str</var></span>]
-      <var class="Ar" title="Ar">file</var></td>
+    <td><code class="Nm">rgbfix</code></td>
+    <td>[<code class="Fl">-CcjsVv</code>] [<code class="Fl">-f</code>
+      <var class="Ar">fix_spec</var>] [<code class="Fl">-i</code>
+      <var class="Ar">game_id</var>] [<code class="Fl">-k</code>
+      <var class="Ar">licensee_str</var>] [<code class="Fl">-l</code>
+      <var class="Ar">licensee_id</var>] [<code class="Fl">-m</code>
+      <var class="Ar">mbc_type</var>] [<code class="Fl">-n</code>
+      <var class="Ar">rom_version</var>] [<code class="Fl">-p</code>
+      <var class="Ar">pad_value</var>] [<code class="Fl">-r</code>
+      <var class="Ar">ram_size</var>] [<code class="Fl">-t</code>
+      <var class="Ar">title_str</var>] <var class="Ar">file</var></td>
   </tr>
 </table>
-<h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="selflink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-The <b class="Nm" title="Nm">rgbfix</b> program changes headers of Game Boy ROM
+</section>
+<section class="Sh">
+<h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+The <code class="Nm">rgbfix</code> program changes headers of Game Boy ROM
   images. It also performs other filetype operations, such as truncation. The
   arguments are as follows:
 <dl class="Bl-tag">
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#C"><b class="Fl" title="Fl" id="C">-C</b></a></dt>
-  <dd class="It-tag">Set the Game Boy Color&#x2013;only flag:
-      <i class="Ad">0x143</i> = 0xC0. If both this and the
-      <b class="Fl" title="Fl">-c</b> flag are set, this takes precedence.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#c"><b class="Fl" title="Fl" id="c">-c</b></a></dt>
-  <dd class="It-tag">Set the Game Boy Color&#x2013;compatible flag:
-      <i class="Ad">0x143</i> = 0x80. If both this and the
-      <b class="Fl" title="Fl">-C</b> flag are set,
-      <b class="Fl" title="Fl">-C</b> takes precedence.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#f"><b class="Fl" title="Fl" id="f">-f</b></a>
-    <var class="Ar" title="Ar">fix_spec</var></dt>
-  <dd class="It-tag">Fix certain header values that the Game Boy checks for
-      correctness. Alternatively, intentionally trash these values by writing
-      their binary inverse instead. <var class="Ar" title="Ar">fix_spec</var> is
-      a string containing any combination of the following characters:
-    <div class="Pp"></div>
-    <dl class="Bl-tag Bl-compact" style="margin-left: 5.40ex;">
-      <dt class="It-tag" style="margin-left: -5.40ex;"><a class="selflink" href="#l"><b class="Cm" title="Cm" id="l">l</b></a></dt>
-      <dd class="It-tag">Fix the Nintendo logo
-          (<i class="Ad">0x104</i>&#x2013;<i class="Ad">0x133</i>).</dd>
-      <dt class="It-tag" style="margin-left: -5.40ex;"><a class="selflink" href="#L"><b class="Cm" title="Cm" id="L">L</b></a></dt>
-      <dd class="It-tag">Trash the Nintendo logo.</dd>
-      <dt class="It-tag" style="margin-left: -5.40ex;"><a class="selflink" href="#h"><b class="Cm" title="Cm" id="h">h</b></a></dt>
-      <dd class="It-tag">Fix the header checksum (<i class="Ad">0x14D</i>).</dd>
-      <dt class="It-tag" style="margin-left: -5.40ex;"><a class="selflink" href="#H"><b class="Cm" title="Cm" id="H">H</b></a></dt>
-      <dd class="It-tag">Trash the header checksum.</dd>
-      <dt class="It-tag" style="margin-left: -5.40ex;"><a class="selflink" href="#g"><b class="Cm" title="Cm" id="g">g</b></a></dt>
-      <dd class="It-tag">Fix the global checksum
-          (<i class="Ad">0x14E</i>&#x2013;<i class="Ad">0x14F</i>).</dd>
-      <dt class="It-tag" style="margin-left: -5.40ex;"><a class="selflink" href="#G"><b class="Cm" title="Cm" id="G">G</b></a></dt>
-      <dd class="It-tag">Trash the global checksum.</dd>
+  <dt><a class="permalink" href="#C"><code class="Fl" id="C">-C</code></a></dt>
+  <dd>Set the Game Boy Color&#x2013;only flag: <span class="Ad">0x143</span> =
+      0xC0. If both this and the <code class="Fl">-c</code> flag are set, this
+      takes precedence.</dd>
+  <dt><a class="permalink" href="#c"><code class="Fl" id="c">-c</code></a></dt>
+  <dd>Set the Game Boy Color&#x2013;compatible flag:
+      <span class="Ad">0x143</span> = 0x80. If both this and the
+      <code class="Fl">-C</code> flag are set, <code class="Fl">-C</code> takes
+      precedence.</dd>
+  <dt><a class="permalink" href="#f"><code class="Fl" id="f">-f</code></a>
+    <var class="Ar">fix_spec</var></dt>
+  <dd>Fix certain header values that the Game Boy checks for correctness.
+      Alternatively, intentionally trash these values by writing their binary
+      inverse instead. <var class="Ar">fix_spec</var> is a string containing any
+      combination of the following characters:
+    <p class="Pp"></p>
+    <dl class="Bl-tag Bl-compact">
+      <dt><a class="permalink" href="#l"><code class="Cm" id="l">l</code></a></dt>
+      <dd>Fix the Nintendo logo
+          (<span class="Ad">0x104</span>&#x2013;<span class="Ad">0x133</span>).</dd>
+      <dt><a class="permalink" href="#L"><code class="Cm" id="L">L</code></a></dt>
+      <dd>Trash the Nintendo logo.</dd>
+      <dt><a class="permalink" href="#h"><code class="Cm" id="h">h</code></a></dt>
+      <dd>Fix the header checksum (<span class="Ad">0x14D</span>).</dd>
+      <dt><a class="permalink" href="#H"><code class="Cm" id="H">H</code></a></dt>
+      <dd>Trash the header checksum.</dd>
+      <dt><a class="permalink" href="#g"><code class="Cm" id="g">g</code></a></dt>
+      <dd>Fix the global checksum
+          (<span class="Ad">0x14E</span>&#x2013;<span class="Ad">0x14F</span>).</dd>
+      <dt><a class="permalink" href="#G"><code class="Cm" id="G">G</code></a></dt>
+      <dd>Trash the global checksum.</dd>
     </dl>
   </dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#i"><b class="Fl" title="Fl" id="i">-i</b></a>
-    <var class="Ar" title="Ar">game_id</var></dt>
-  <dd class="It-tag">Set the game ID string
-      (<i class="Ad">0x13F</i>&#x2013;<i class="Ad">0x142</i>) to a given string
-      of exactly 4 characters. If both this and the title are set, the game ID
-      will overwrite the overlapping portion of the title.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#j"><b class="Fl" title="Fl" id="j">-j</b></a></dt>
-  <dd class="It-tag">Set the non-Japanese region flag: <i class="Ad">0x14A</i> =
-      1.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#k"><b class="Fl" title="Fl" id="k">-k</b></a>
-    <var class="Ar" title="Ar">licensee_str</var></dt>
-  <dd class="It-tag">Set the new licensee string
-      (<i class="Ad">0x144</i>&#x2013;<i class="Ad">0x145</i>) to a given
-      string, truncated to at most two characters.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#l"><b class="Fl" title="Fl" id="l">-l</b></a>
-    <var class="Ar" title="Ar">licensee_id</var></dt>
-  <dd class="It-tag">Set the old licensee code, <i class="Ad">0x14B</i>, to a
-      given value from 0 to 0xFF. This value is deprecated and should be set to
-      0x33 in all new software.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#m"><b class="Fl" title="Fl" id="m">-m</b></a>
-    <var class="Ar" title="Ar">mbc_type</var></dt>
-  <dd class="It-tag">Set the MBC type, <i class="Ad">0x147</i>, to a given value
-      from 0 to 0xFF.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#n"><b class="Fl" title="Fl" id="n">-n</b></a>
-    <var class="Ar" title="Ar">rom_version</var></dt>
-  <dd class="It-tag">Set the ROM version, <i class="Ad">0x14C</i>, to a given
-      value from 0 to 0xFF.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#p"><b class="Fl" title="Fl" id="p">-p</b></a>
-    <var class="Ar" title="Ar">pad_value</var></dt>
-  <dd class="It-tag">Pad the image to a valid size with a given pad value from 0
-      to 0xFF. <b class="Nm" title="Nm">rgbfix</b> will automatically pick a
-      size from 32KiB, 64KiB, 128KiB, ..., 8192KiB and give a warning
-      thereafter. The cartridge size byte (<i class="Ad">0x148</i>) will be
-      changed to reflect this new size.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#r"><b class="Fl" title="Fl" id="r">-r</b></a>
-    <var class="Ar" title="Ar">ram_size</var></dt>
-  <dd class="It-tag">Set the RAM size, <i class="Ad">0x149</i>, to a given value
-      from 0 to 0xFF.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#s"><b class="Fl" title="Fl" id="s">-s</b></a></dt>
-  <dd class="It-tag">Set the SGB flag: <i class="Ad">0x146</i> = 3.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#t"><b class="Fl" title="Fl" id="t">-t</b></a>
-    <var class="Ar" title="Ar">title</var></dt>
-  <dd class="It-tag">Set the title string
-      (<i class="Ad">0x134</i>&#x2013;<i class="Ad">0x143</i>) to a given
-      string, truncated to at most 16 characters. It is recommended to use 15
-      characters instead, to avoid clashing with the CGB flag
-      (<b class="Fl" title="Fl">-c</b> or <b class="Fl" title="Fl">-C</b>). If
-      both this and the game ID are set, the game ID will overwrite the
-      overlapping portion of the title.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#V"><b class="Fl" title="Fl" id="V">-V</b></a></dt>
-  <dd class="It-tag">Print the version of the program and exit.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#v"><b class="Fl" title="Fl" id="v">-v</b></a></dt>
-  <dd class="It-tag">Equivalent to <b class="Fl" title="Fl">-f</b>
-      <b class="Cm" title="Cm">lhg</b>.</dd>
+  <dt><a class="permalink" href="#i"><code class="Fl" id="i">-i</code></a>
+    <var class="Ar">game_id</var></dt>
+  <dd>Set the game ID string
+      (<span class="Ad">0x13F</span>&#x2013;<span class="Ad">0x142</span>) to a
+      given string of exactly 4 characters. If both this and the title are set,
+      the game ID will overwrite the overlapping portion of the title.</dd>
+  <dt><a class="permalink" href="#j"><code class="Fl" id="j">-j</code></a></dt>
+  <dd>Set the non-Japanese region flag: <span class="Ad">0x14A</span> = 1.</dd>
+  <dt><a class="permalink" href="#k"><code class="Fl" id="k">-k</code></a>
+    <var class="Ar">licensee_str</var></dt>
+  <dd>Set the new licensee string
+      (<span class="Ad">0x144</span>&#x2013;<span class="Ad">0x145</span>) to a
+      given string, truncated to at most two characters.</dd>
+  <dt><a class="permalink" href="#l_2"><code class="Fl" id="l_2">-l</code></a>
+    <var class="Ar">licensee_id</var></dt>
+  <dd>Set the old licensee code, <span class="Ad">0x14B</span>, to a given value
+      from 0 to 0xFF. This value is deprecated and should be set to 0x33 in all
+      new software.</dd>
+  <dt><a class="permalink" href="#m"><code class="Fl" id="m">-m</code></a>
+    <var class="Ar">mbc_type</var></dt>
+  <dd>Set the MBC type, <span class="Ad">0x147</span>, to a given value from 0
+      to 0xFF.</dd>
+  <dt><a class="permalink" href="#n"><code class="Fl" id="n">-n</code></a>
+    <var class="Ar">rom_version</var></dt>
+  <dd>Set the ROM version, <span class="Ad">0x14C</span>, to a given value from
+      0 to 0xFF.</dd>
+  <dt><a class="permalink" href="#p"><code class="Fl" id="p">-p</code></a>
+    <var class="Ar">pad_value</var></dt>
+  <dd>Pad the image to a valid size with a given pad value from 0 to 0xFF.
+      <code class="Nm">rgbfix</code> will automatically pick a size from 32KiB,
+      64KiB, 128KiB, ..., 8192KiB and give a warning thereafter. The cartridge
+      size byte (<span class="Ad">0x148</span>) will be changed to reflect this
+      new size.</dd>
+  <dt><a class="permalink" href="#r"><code class="Fl" id="r">-r</code></a>
+    <var class="Ar">ram_size</var></dt>
+  <dd>Set the RAM size, <span class="Ad">0x149</span>, to a given value from 0
+      to 0xFF.</dd>
+  <dt><a class="permalink" href="#s"><code class="Fl" id="s">-s</code></a></dt>
+  <dd>Set the SGB flag: <span class="Ad">0x146</span> = 3.</dd>
+  <dt><a class="permalink" href="#t"><code class="Fl" id="t">-t</code></a>
+    <var class="Ar">title</var></dt>
+  <dd>Set the title string
+      (<span class="Ad">0x134</span>&#x2013;<span class="Ad">0x143</span>) to a
+      given string, truncated to at most 16 characters. It is recommended to use
+      15 characters instead, to avoid clashing with the CGB flag
+      (<code class="Fl">-c</code> or <code class="Fl">-C</code>). If both this
+      and the game ID are set, the game ID will overwrite the overlapping
+      portion of the title.</dd>
+  <dt><a class="permalink" href="#V"><code class="Fl" id="V">-V</code></a></dt>
+  <dd>Print the version of the program and exit.</dd>
+  <dt><a class="permalink" href="#v"><code class="Fl" id="v">-v</code></a></dt>
+  <dd>Equivalent to <code class="Fl">-f</code> <code class="Cm">lhg</code>.</dd>
 </dl>
-<h1 class="Sh" title="Sh" id="EXAMPLES"><a class="selflink" href="#EXAMPLES">EXAMPLES</a></h1>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
 Most values in the ROM header are only cosmetic. The bare minimum requirements
   for a workable image are checksums, the Nintendo logo, and (if needed) the
   CGB/SGB flags. It is a good idea to pad the image to a valid size as well
   (&#x201C;valid&#x201D; meaning a multiple of 32KiB).
-<div class="Pp"></div>
-The following will make a plain, no-color Game Boy game without checking for a
-  valid size:
-<div class="Pp"></div>
-<div class="D1">$ rgbfix -v foo.gb</div>
-<div class="Pp"></div>
-The following will make a SGB-enabled, color-enabled game with a title of
-  &#x201C;foobar&#x201D;, and pad it to a multiple of 32KiB. (The Game Boy
-  itself does not use the title, but some emulators or ROM managers might.)
-<div class="Pp"></div>
-<div class="D1">$ rgbfix -vcs -l 0x33 -p 0 -t foobar baz.gb</div>
-<div class="Pp"></div>
-The following will duplicate the header (sans global checksum) of the game
-  &#x201C;Survival Kids&#x201D;:
-<div class="Pp"></div>
-<div class="D1">$ rgbfix -cjsv -k A4 -l 0x33 -m 0x1B -p 0xFF -r 3 -t
+<p class="Pp">The following will make a plain, no-color Game Boy game without
+    checking for a valid size:</p>
+<p class="Pp"></p>
+<div class="Bd Bd-indent">$ rgbfix -v foo.gb</div>
+<p class="Pp">The following will make a SGB-enabled, color-enabled game with a
+    title of &#x201C;foobar&#x201D;, and pad it to a multiple of 32KiB. (The
+    Game Boy itself does not use the title, but some emulators or ROM managers
+    might.)</p>
+<p class="Pp"></p>
+<div class="Bd Bd-indent">$ rgbfix -vcs -l 0x33 -p 0 -t foobar baz.gb</div>
+<p class="Pp">The following will duplicate the header (sans global checksum) of
+    the game &#x201C;Survival Kids&#x201D;:</p>
+<p class="Pp"></p>
+<div class="Bd Bd-indent">$ rgbfix -cjsv -k A4 -l 0x33 -m 0x1B -p 0xFF -r 3 -t
   SURVIVALKIDAVKE SurvivalKids.gbc</div>
-<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="selflink" href="#SEE_ALSO">SEE
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" title="Xr">rgbasm(1)</a>, <a class="Xr" title="Xr">rgblink(1)</a>,
-  <a class="Xr" title="Xr">rgbds(7)</a>
-<h1 class="Sh" title="Sh" id="HISTORY"><a class="selflink" href="#HISTORY">HISTORY</a></h1>
-<b class="Nm" title="Nm">rgbfix</b> was originally released by Carsten
+<a class="Xr">rgbasm(1)</a>, <a class="Xr">rgblink(1)</a>,
+  <a class="Xr">rgbds(7)</a>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="HISTORY"><a class="permalink" href="#HISTORY">HISTORY</a></h1>
+<code class="Nm">rgbfix</code> was originally released by Carsten
   S&#x00F8;rensen as a standalone program called gbfix, and was later packaged
   in RGBDS by Justin Lloyd. It is now maintained by a number of contributors at
-  <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
+  <a class="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.
+</section>
+</div>
 <table class="foot">
   <tr>
     <td class="foot-date">March 11, 2018</td>

--- a/docs/rgbgfx.1.html
+++ b/docs/rgbgfx.1.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html>
+<!-- This is an automatically generated file.  Do not edit.
+   This file is part of RGBDS.
+
+   Copyright (c) 2013-2018, stag019 and RGBDS contributors.
+
+   SPDX-License-Identifier: MIT
+   -->
 <head>
   <meta charset="utf-8"/>
-  <style>
-    table.head, table.foot { width: 100%; }
-    td.head-rtitle, td.foot-os { text-align: right; }
-    td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-  </style>
   <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
   <title>RGBGFX(1)</title>
 </head>
@@ -20,151 +21,153 @@
   </tr>
 </table>
 <div class="manual-text">
-<h1 class="Sh" title="Sh" id="NAME"><a class="selflink" href="#NAME">NAME</a></h1>
-<b class="Nm" title="Nm">rgbgfx</b> &#x2014; <span class="Nd" title="Nd">Game
-  Boy graphics converter</span>
-<h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="selflink" href="#SYNOPSIS">SYNOPSIS</a></h1>
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<code class="Nm">rgbgfx</code> &#x2014;
+<div class="Nd">Game Boy graphics converter</div>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <table class="Nm">
   <tr>
-    <td><b class="Nm" title="Nm">rgbgfx</b></td>
-    <td>[<span class="Op"><b class="Fl" title="Fl">-DfFhPTVv</b></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-o</b>
-      <var class="Ar" title="Ar">outfile</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-d</b>
-      <var class="Ar" title="Ar">depth</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-p</b>
-      <var class="Ar" title="Ar">palfile</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-t</b>
-      <var class="Ar" title="Ar">mapfile</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-x</b>
-      <var class="Ar" title="Ar">tiles</var></span>]
-      <var class="Ar" title="Ar">file</var></td>
+    <td><code class="Nm">rgbgfx</code></td>
+    <td>[<code class="Fl">-ADfFhmPTuVv</code>] [<code class="Fl">-o</code>
+      <var class="Ar">outfile</var>] [<code class="Fl">-a</code>
+      <var class="Ar">attrmap</var>] [<code class="Fl">-d</code>
+      <var class="Ar">depth</var>] [<code class="Fl">-p</code>
+      <var class="Ar">palfile</var>] [<code class="Fl">-t</code>
+      <var class="Ar">tilemap</var>] [<code class="Fl">-x</code>
+      <var class="Ar">tiles</var>] <var class="Ar">file</var></td>
   </tr>
 </table>
-<h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="selflink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-The <b class="Nm" title="Nm">rgbgfx</b> program converts PNG images into the
-  Nintendo Game Boy's planar tile format.
-<div style="height: 1.00em;">&#x00A0;</div>
-The resulting colors and their palette indices are determined differently
-  depending on the input PNG file:
+</section>
+<section class="Sh">
+<h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+The <code class="Nm">rgbgfx</code> program converts PNG images into the Nintendo
+  Game Boy's planar tile format.
+<p class="Pp">The resulting colors and their palette indices are determined
+    differently depending on the input PNG file:</p>
 <ul class="Bl-dash">
-  <li class="It-dash">If the file has an embedded palette, that palette's color
-      and order are used.</li>
-  <li class="It-dash">If not, and the image only contains shades of gray, rgbgfx
-      maps them to the indices appropriate for each shade. Any undetermined
-      indices are set to respective default shades of gray. For example: if the
-      bit depth is 2 and the image contains light gray and black, they become
-      the second and fourth colors - and the first and third colors get set to
-      default white and dark gray. If the image has multiple shades that map to
-      the same index, the palette is instead determined as if the image had
-      color.</li>
-  <li class="It-dash">If the image has color (or the grayscale method failed),
-      the colors are sorted from lightest to darkest.</li>
+  <li>If the file has an embedded palette, that palette's color and order are
+      used.</li>
+  <li>If not, and the image only contains shades of gray, rgbgfx maps them to
+      the indices appropriate for each shade. Any undetermined indices are set
+      to respective default shades of gray. For example: if the bit depth is 2
+      and the image contains light gray and black, they become the second and
+      fourth colors - and the first and third colors get set to default white
+      and dark gray. If the image has multiple shades that map to the same
+      index, the palette is instead determined as if the image had color.</li>
+  <li>If the image has color (or the grayscale method failed), the colors are
+      sorted from lightest to darkest.</li>
 </ul>
-<div style="height: 1.00em;">&#x00A0;</div>
-The input image may not contain more colors than the selected bit depth allows.
-  Transparent pixels are set to palette index 0.
-<h1 class="Sh" title="Sh" id="ARGUMENTS"><a class="selflink" href="#ARGUMENTS">ARGUMENTS</a></h1>
+<p class="Pp">The input image may not contain more colors than the selected bit
+    depth allows. Transparent pixels are set to palette index 0.</p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="ARGUMENTS"><a class="permalink" href="#ARGUMENTS">ARGUMENTS</a></h1>
 <dl class="Bl-tag">
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#D"><b class="Fl" title="Fl" id="D">-D</b></a></dt>
-  <dd class="It-tag">Debug features are enabled.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#f"><b class="Fl" title="Fl" id="f">-f</b></a></dt>
-  <dd class="It-tag">Fix the input PNG file to be a correctly indexed
-    image.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#F"><b class="Fl" title="Fl" id="F">-F</b></a></dt>
-  <dd class="It-tag">Same as <b class="Fl" title="Fl">-f</b>, but additionally,
-      the supplied command line parameters are saved within the PNG and will be
-      loaded and automatically used next time.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#d"><b class="Fl" title="Fl" id="d">-d</b></a>
-    <var class="Ar" title="Ar">depth</var></dt>
-  <dd class="It-tag">The bit depth of the output image (either 1 or 2). By
-      default, the bit depth is 2 (two bits per pixel).</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#h"><b class="Fl" title="Fl" id="h">-h</b></a></dt>
-  <dd class="It-tag">Lay out tiles horizontally rather than vertically.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#o"><b class="Fl" title="Fl" id="o">-o</b></a>
-    <var class="Ar" title="Ar">outfile</var></dt>
-  <dd class="It-tag">The name of the output file.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#p"><b class="Fl" title="Fl" id="p">-p</b></a>
-    <var class="Ar" title="Ar">palfile</var></dt>
-  <dd class="It-tag">Output the image's palette in standard GBC palette format -
-      bytes (8 bytes for two bits per pixel, 4 bytes for one bit per pixel)
-      containing the RGB15 values in little-endian byte order. If the palette
-      contains too few colors, the remaining entries are set to black.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#P"><b class="Fl" title="Fl" id="P">-P</b></a></dt>
-  <dd class="It-tag">Same as <b class="Fl" title="Fl">-p</b>, but the palette
-      file output name is made by taking the input PNG file's filename, removing
-      the file extension, and appending <i class="Pa" title="Pa">.pal</i>.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#t"><b class="Fl" title="Fl" id="t">-t</b></a>
-    <var class="Ar" title="Ar">mapfile</var></dt>
-  <dd class="It-tag">If any tiles are the same, don't place the repeat tiles in
-      the output file, and make a tilemap file.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#T"><b class="Fl" title="Fl" id="T">-T</b></a></dt>
-  <dd class="It-tag">Same as <b class="Fl" title="Fl">-t</b>, but the tilemap
-      file output name is made by taking the input filename, removing the file
-      extension, and appending <i class="Pa" title="Pa">.tilemap</i>.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#u"><b class="Fl" title="Fl" id="u">-u</b></a></dt>
-  <dd class="It-tag">Truncate repeated tiles. Useful with tilemaps.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#V"><b class="Fl" title="Fl" id="V">-V</b></a></dt>
-  <dd class="It-tag">Print the version of the program and exit.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#v"><b class="Fl" title="Fl" id="v">-v</b></a></dt>
-  <dd class="It-tag">Verbose. Print errors when the command line parameters and
-      the parameters in the PNG file don't match.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#x"><b class="Fl" title="Fl" id="x">-x</b></a>
-    <var class="Ar" title="Ar">tiles</var></dt>
-  <dd class="It-tag">Trim the end of the output file by this many tiles.</dd>
+  <dt><a class="permalink" href="#a"><code class="Fl" id="a">-a</code></a>
+    <var class="Ar">attrmap</var></dt>
+  <dd>Generate a file of tile mirroring attributes for OAM or (CGB-only)
+      background tiles. For each tile in the input file, a byte is written
+      representing the dimensions that the associated tile in the output file
+      should be mirrored. Useful in combination with <code class="Fl">-m</code>
+      to keep track the mirror direction of mirrored duplicate tiles.</dd>
+  <dt><a class="permalink" href="#A"><code class="Fl" id="A">-A</code></a></dt>
+  <dd>Same as <code class="Fl">-a</code>, but the attrmap file output name is
+      made by taking the input filename, removing the file extension, and
+      appending <span class="Pa">.attrmap</span>.</dd>
+  <dt><a class="permalink" href="#D"><code class="Fl" id="D">-D</code></a></dt>
+  <dd>Debug features are enabled.</dd>
+  <dt><a class="permalink" href="#f"><code class="Fl" id="f">-f</code></a></dt>
+  <dd>Fix the input PNG file to be a correctly indexed image.</dd>
+  <dt><a class="permalink" href="#F"><code class="Fl" id="F">-F</code></a></dt>
+  <dd>Same as <code class="Fl">-f</code>, but additionally, the supplied command
+      line parameters are saved within the PNG and will be loaded and
+      automatically used next time.</dd>
+  <dt><a class="permalink" href="#d"><code class="Fl" id="d">-d</code></a>
+    <var class="Ar">depth</var></dt>
+  <dd>The bit depth of the output image (either 1 or 2). By default, the bit
+      depth is 2 (two bits per pixel).</dd>
+  <dt><a class="permalink" href="#h"><code class="Fl" id="h">-h</code></a></dt>
+  <dd>Lay out tiles horizontally rather than vertically.</dd>
+  <dt><a class="permalink" href="#m"><code class="Fl" id="m">-m</code></a></dt>
+  <dd>Truncate tiles by checking for tiles that are mirrored versions of others
+      and omitting these from the output file. Useful with tilemaps and attrmaps
+      together to keep track of the duplicated tiles and the dimension mirrored.
+      Tiles are checked for horizontal, vertical, and horizontal-vertical
+      mirroring. Implies <code class="Fl">-u</code>.</dd>
+  <dt><a class="permalink" href="#o"><code class="Fl" id="o">-o</code></a>
+    <var class="Ar">outfile</var></dt>
+  <dd>The name of the output file.</dd>
+  <dt><a class="permalink" href="#p"><code class="Fl" id="p">-p</code></a>
+    <var class="Ar">palfile</var></dt>
+  <dd>Output the image's palette in standard GBC palette format - bytes (8 bytes
+      for two bits per pixel, 4 bytes for one bit per pixel) containing the
+      RGB15 values in little-endian byte order. If the palette contains too few
+      colors, the remaining entries are set to black.</dd>
+  <dt><a class="permalink" href="#P"><code class="Fl" id="P">-P</code></a></dt>
+  <dd>Same as <code class="Fl">-p</code>, but the palette file output name is
+      made by taking the input PNG file's filename, removing the file extension,
+      and appending <span class="Pa">.pal</span>.</dd>
+  <dt><a class="permalink" href="#t"><code class="Fl" id="t">-t</code></a>
+    <var class="Ar">tilemap</var></dt>
+  <dd>Generate a file of tile indices. For each tile in the input file, a byte
+      is written representing the index of the associated tile in the output
+      file. Useful in combination with <code class="Fl">-u</code> or
+      <code class="Fl">-m</code> to keep track of duplicate tiles.</dd>
+  <dt><a class="permalink" href="#T"><code class="Fl" id="T">-T</code></a></dt>
+  <dd>Same as <code class="Fl">-t</code>, but the tilemap file output name is
+      made by taking the input filename, removing the file extension, and
+      appending <span class="Pa">.tilemap</span>.</dd>
+  <dt><a class="permalink" href="#u"><code class="Fl" id="u">-u</code></a></dt>
+  <dd>Truncate tiles by checking for tiles that are exact duplicates of others
+      and omitting these from the output file. Useful with tilemaps to keep
+      track of the duplicated tiles.</dd>
+  <dt><a class="permalink" href="#V"><code class="Fl" id="V">-V</code></a></dt>
+  <dd>Print the version of the program and exit.</dd>
+  <dt><a class="permalink" href="#v"><code class="Fl" id="v">-v</code></a></dt>
+  <dd>Verbose. Print errors when the command line parameters and the parameters
+      in the PNG file don't match.</dd>
+  <dt><a class="permalink" href="#x"><code class="Fl" id="x">-x</code></a>
+    <var class="Ar">tiles</var></dt>
+  <dd>Trim the end of the output file by this many tiles.</dd>
 </dl>
-<h1 class="Sh" title="Sh" id="EXAMPLES"><a class="selflink" href="#EXAMPLES">EXAMPLES</a></h1>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
 The following will take a PNG file with a bit depth of 1, 2, or 8, and output
   planar 2bpp data:
-<div class="Pp"></div>
-<div class="D1">$ rgbgfx -o out.2bpp in.png</div>
-<div class="Pp"></div>
-The following creates a planar 2bpp file with only unique tiles, and its tilemap
-  <i class="Pa" title="Pa">out.tilemap</i>:
-<div class="Pp"></div>
-<div class="D1">$ rgbgfx -T -u -o out.2bpp in.png</div>
-<div class="Pp"></div>
-The following will do nothing:
-<div class="Pp"></div>
-<div class="D1">$ rgbgfx in.png</div>
-<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="selflink" href="#SEE_ALSO">SEE
+<p class="Pp"></p>
+<div class="Bd Bd-indent">$ rgbgfx -o out.2bpp in.png</div>
+<p class="Pp">The following creates a planar 2bpp file with only unique tiles,
+    and its tilemap <span class="Pa">out.tilemap</span>:</p>
+<p class="Pp"></p>
+<div class="Bd Bd-indent">$ rgbgfx -T -u -o out.2bpp in.png</div>
+<p class="Pp">The following creates a planar 2bpp file with only unique tiles
+    (accounting for tile mirroring) and its associated tilemap
+    <span class="Pa">out.tilemap</span> and attrmap
+    <span class="Pa">out.attrmap</span>:</p>
+<p class="Pp"></p>
+<div class="Bd Bd-indent">$ rgbgfx -A -T -m -o out.2bpp in.png</div>
+<p class="Pp">The following will do nothing:</p>
+<p class="Pp"></p>
+<div class="Bd Bd-indent">$ rgbgfx in.png</div>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" title="Xr">rgbds(7)</a>, <a class="Xr" title="Xr">rgbasm(1)</a>,
-  <a class="Xr" title="Xr">rgblink(1)</a>,
-  <a class="Xr" title="Xr">rgbfix(1)</a>, <a class="Xr" title="Xr">gbz80(7)</a>
-<h1 class="Sh" title="Sh" id="HISTORY"><a class="selflink" href="#HISTORY">HISTORY</a></h1>
-<b class="Nm" title="Nm">rgbgfx</b> was created by
-  <span class="An" title="An">stag019</span> to be included in RGBDS. It is now
-  maintained by a number of contributors at
-  <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
+<a class="Xr">rgbds(7)</a>, <a class="Xr">rgbasm(1)</a>,
+  <a class="Xr">rgblink(1)</a>, <a class="Xr">rgbfix(1)</a>,
+  <a class="Xr">gbz80(7)</a>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="HISTORY"><a class="permalink" href="#HISTORY">HISTORY</a></h1>
+<code class="Nm">rgbgfx</code> was created by <span class="An">stag019</span> to
+  be included in RGBDS. It is now maintained by a number of contributors at
+  <a class="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.
+</section>
+</div>
 <table class="foot">
   <tr>
     <td class="foot-date">January 26, 2018</td>

--- a/docs/rgblink.1.html
+++ b/docs/rgblink.1.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html>
+<!-- This is an automatically generated file.  Do not edit.
+   This file is part of RGBDS.
+
+   Copyright (c) 2010-2018, Anthony J. Bentley and RGBDS contributors.
+
+   SPDX-License-Identifier: MIT
+   -->
 <head>
   <meta charset="utf-8"/>
-  <style>
-    table.head, table.foot { width: 100%; }
-    td.head-rtitle, td.foot-os { text-align: right; }
-    td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-  </style>
   <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
   <title>RGBLINK(1)</title>
 </head>
@@ -20,137 +21,113 @@
   </tr>
 </table>
 <div class="manual-text">
-<h1 class="Sh" title="Sh" id="NAME"><a class="selflink" href="#NAME">NAME</a></h1>
-<b class="Nm" title="Nm">rgblink</b> &#x2014; <span class="Nd" title="Nd">Game
-  Boy linker</span>
-<h1 class="Sh" title="Sh" id="SYNOPSIS"><a class="selflink" href="#SYNOPSIS">SYNOPSIS</a></h1>
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<code class="Nm">rgblink</code> &#x2014;
+<div class="Nd">Game Boy linker</div>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SYNOPSIS"><a class="permalink" href="#SYNOPSIS">SYNOPSIS</a></h1>
 <table class="Nm">
   <tr>
-    <td><b class="Nm" title="Nm">rgblink</b></td>
-    <td>[<span class="Op"><b class="Fl" title="Fl">-dtVw</b></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-m</b>
-      <var class="Ar" title="Ar">mapfile</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-n</b>
-      <var class="Ar" title="Ar">symfile</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-O</b>
-      <var class="Ar" title="Ar">overlayfile</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-o</b>
-      <var class="Ar" title="Ar">outfile</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-p</b>
-      <var class="Ar" title="Ar">pad_value</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-s</b>
-      <var class="Ar" title="Ar">symbol</var></span>]
-      [<span class="Op"><b class="Fl" title="Fl">-l</b>
-      <var class="Ar" title="Ar">linkerscript</var></span>]
-      <var class="Ar" title="Ar">file ...</var></td>
+    <td><code class="Nm">rgblink</code></td>
+    <td>[<code class="Fl">-dtVw</code>] [<code class="Fl">-m</code>
+      <var class="Ar">mapfile</var>] [<code class="Fl">-n</code>
+      <var class="Ar">symfile</var>] [<code class="Fl">-O</code>
+      <var class="Ar">overlayfile</var>] [<code class="Fl">-o</code>
+      <var class="Ar">outfile</var>] [<code class="Fl">-p</code>
+      <var class="Ar">pad_value</var>] [<code class="Fl">-s</code>
+      <var class="Ar">symbol</var>] [<code class="Fl">-l</code>
+      <var class="Ar">linkerscript</var>] <var class="Ar">file ...</var></td>
   </tr>
 </table>
-<h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="selflink" href="#DESCRIPTION">DESCRIPTION</a></h1>
-The <b class="Nm" title="Nm">rgblink</b> program links objects created by
-  <a class="Xr" title="Xr">rgbasm(1)</a> into a single Game Boy ROM file.
-<div class="Pp"></div>
-By default, ROM0 sections created by the assembler are placed in the 16KiB bank
-  0, and ROMX sections are placed in any bank except bank 0. If your ROM will
-  only be 32KiB, you can use the <b class="Fl" title="Fl">-t</b> option to
-  override this.
-<div class="Pp"></div>
-Similarly, WRAM0 sections are placed in the first 4KiB of WRAM bank 0 and WRAMX
-  sections are placed in any bank except bank 0. If your ROM doesn't use banked
-  WRAM you can use option <b class="Fl" title="Fl">-w</b> option to override
-  this.
-<div class="Pp"></div>
-Also, if your ROM is designed for DMG, you can make sure that you don't use any
-  prohibited section by using the option <b class="Fl" title="Fl">-d</b>, which
-  implies <b class="Fl" title="Fl">-w</b> but also prohibits the use of VRAM
-  bank 1.
-<div class="Pp"></div>
-The arguments are as follows:
+</section>
+<section class="Sh">
+<h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+The <code class="Nm">rgblink</code> program links objects created by
+  <a class="Xr">rgbasm(1)</a> into a single Game Boy ROM file.
+<p class="Pp">By default, ROM0 sections created by the assembler are placed in
+    the 16KiB bank 0, and ROMX sections are placed in any bank except bank 0. If
+    your ROM will only be 32KiB, you can use the <code class="Fl">-t</code>
+    option to override this.</p>
+<p class="Pp">Similarly, WRAM0 sections are placed in the first 4KiB of WRAM
+    bank 0 and WRAMX sections are placed in any bank except bank 0. If your ROM
+    doesn't use banked WRAM you can use option <code class="Fl">-w</code> option
+    to override this.</p>
+<p class="Pp">Also, if your ROM is designed for DMG, you can make sure that you
+    don't use any prohibited section by using the option
+    <code class="Fl">-d</code>, which implies <code class="Fl">-w</code> but
+    also prohibits the use of VRAM bank 1.</p>
+<p class="Pp">The arguments are as follows:</p>
 <dl class="Bl-tag">
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#m"><b class="Fl" title="Fl" id="m">-m</b></a>
-    <var class="Ar" title="Ar">mapfile</var></dt>
-  <dd class="It-tag">Write a mapfile to the given filename.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#n"><b class="Fl" title="Fl" id="n">-n</b></a>
-    <var class="Ar" title="Ar">symfile</var></dt>
-  <dd class="It-tag">Write a symbol file to the given filename.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#O"><b class="Fl" title="Fl" id="O">-O</b></a>
-    <var class="Ar" title="Ar">overlayfile</var></dt>
-  <dd class="It-tag">The ROM image to overlay sections over. When an overlay ROM
-      is provided, all sections must be fixed. This may be used to patch an
-      existing binary.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#o"><b class="Fl" title="Fl" id="o">-o</b></a>
-    <var class="Ar" title="Ar">outfile</var></dt>
-  <dd class="It-tag">Write ROM image to the given filename.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#p"><b class="Fl" title="Fl" id="p">-p</b></a>
-    <var class="Ar" title="Ar">pad_value</var></dt>
-  <dd class="It-tag">When padding an image, pad with this value. The default is
-      0x00.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#s"><b class="Fl" title="Fl" id="s">-s</b></a>
-    <var class="Ar" title="Ar">symbol</var></dt>
-  <dd class="It-tag">???</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#w"><b class="Fl" title="Fl" id="w">-w</b></a></dt>
-  <dd class="It-tag">Expand the WRAM0 section size from 4KiB to the full 8KiB
-      assigned to WRAM and prohibit the use of WRAMX sections.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#d"><b class="Fl" title="Fl" id="d">-d</b></a></dt>
-  <dd class="It-tag">Enable DMG mode. Prohibit the use of sections that doesn't
-      exist on a DMG, such as WRAMX and VRAM bank 1. This option automatically
-      enables <b class="Fl" title="Fl">-w</b>.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#t"><b class="Fl" title="Fl" id="t">-t</b></a></dt>
-  <dd class="It-tag">Expand the ROM0 section size from 16KiB to the full 32KiB
-      assigned to ROM and prohibit the use of ROMX sections. Useful for ROMs
-      that fit in 32 KiB.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#l"><b class="Fl" title="Fl" id="l">-l</b></a>
-    <var class="Ar" title="Ar">linkerscript</var></dt>
-  <dd class="It-tag">Specify a linkerscript file that tells the linker how
-      sections must be placed in the ROM. This file has priority over the
-      attributes assigned in the source code, but they have to be consistent.
-      See <a class="Xr" title="Xr">rgblink(5)</a> for more information about its
-      format.</dd>
-  <dt class="It-tag">&#x00A0;</dt>
-  <dd class="It-tag">&#x00A0;</dd>
-  <dt class="It-tag"><a class="selflink" href="#V"><b class="Fl" title="Fl" id="V">-V</b></a></dt>
-  <dd class="It-tag">Print the version of the program and exit.</dd>
+  <dt><a class="permalink" href="#m"><code class="Fl" id="m">-m</code></a>
+    <var class="Ar">mapfile</var></dt>
+  <dd>Write a mapfile to the given filename.</dd>
+  <dt><a class="permalink" href="#n"><code class="Fl" id="n">-n</code></a>
+    <var class="Ar">symfile</var></dt>
+  <dd>Write a symbol file to the given filename.</dd>
+  <dt><a class="permalink" href="#O"><code class="Fl" id="O">-O</code></a>
+    <var class="Ar">overlayfile</var></dt>
+  <dd>The ROM image to overlay sections over. When an overlay ROM is provided,
+      all sections must be fixed. This may be used to patch an existing
+    binary.</dd>
+  <dt><a class="permalink" href="#o"><code class="Fl" id="o">-o</code></a>
+    <var class="Ar">outfile</var></dt>
+  <dd>Write ROM image to the given filename.</dd>
+  <dt><a class="permalink" href="#p"><code class="Fl" id="p">-p</code></a>
+    <var class="Ar">pad_value</var></dt>
+  <dd>When padding an image, pad with this value. The default is 0x00.</dd>
+  <dt><a class="permalink" href="#s"><code class="Fl" id="s">-s</code></a>
+    <var class="Ar">symbol</var></dt>
+  <dd>???</dd>
+  <dt><a class="permalink" href="#w"><code class="Fl" id="w">-w</code></a></dt>
+  <dd>Expand the WRAM0 section size from 4KiB to the full 8KiB assigned to WRAM
+      and prohibit the use of WRAMX sections.</dd>
+  <dt><a class="permalink" href="#d"><code class="Fl" id="d">-d</code></a></dt>
+  <dd>Enable DMG mode. Prohibit the use of sections that doesn't exist on a DMG,
+      such as WRAMX and VRAM bank 1. This option automatically enables
+      <code class="Fl">-w</code>.</dd>
+  <dt><a class="permalink" href="#t"><code class="Fl" id="t">-t</code></a></dt>
+  <dd>Expand the ROM0 section size from 16KiB to the full 32KiB assigned to ROM
+      and prohibit the use of ROMX sections. Useful for ROMs that fit in 32
+    KiB.</dd>
+  <dt><a class="permalink" href="#l"><code class="Fl" id="l">-l</code></a>
+    <var class="Ar">linkerscript</var></dt>
+  <dd>Specify a linkerscript file that tells the linker how sections must be
+      placed in the ROM. This file has priority over the attributes assigned in
+      the source code, but they have to be consistent. See
+      <a class="Xr">rgblink(5)</a> for more information about its format.</dd>
+  <dt><a class="permalink" href="#V"><code class="Fl" id="V">-V</code></a></dt>
+  <dd>Print the version of the program and exit.</dd>
 </dl>
-<h1 class="Sh" title="Sh" id="EXAMPLES"><a class="selflink" href="#EXAMPLES">EXAMPLES</a></h1>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
 All you need for a basic ROM is an object file, which can be made into a ROM
   image like so:
-<div class="Pp"></div>
-<div class="D1">$ rgblink -o bar.gb foo.o</div>
-<div class="Pp"></div>
-The resulting bar.gb will not have correct checksums (unless you put them in the
-  assembly source). You should use <a class="Xr" title="Xr">rgbfix(1)</a> to fix
-  these so that the program will actually run in a Game Boy:
-<div class="Pp"></div>
-<div class="D1">$ rgbfix -v bar.gb</div>
-<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="selflink" href="#SEE_ALSO">SEE
+<p class="Pp"></p>
+<div class="Bd Bd-indent">$ rgblink -o bar.gb foo.o</div>
+<p class="Pp">The resulting bar.gb will not have correct checksums (unless you
+    put them in the assembly source). You should use <a class="Xr">rgbfix(1)</a>
+    to fix these so that the program will actually run in a Game Boy:</p>
+<p class="Pp"></p>
+<div class="Bd Bd-indent">$ rgbfix -v bar.gb</div>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" title="Xr">rgbasm(1)</a>, <a class="Xr" title="Xr">rgblink(5)</a>,
-  <a class="Xr" title="Xr">rgbfix(1)</a>, <a class="Xr" title="Xr">rgbds(5)</a>,
-  <a class="Xr" title="Xr">rgbds(7)</a>
-<h1 class="Sh" title="Sh" id="HISTORY"><a class="selflink" href="#HISTORY">HISTORY</a></h1>
-<b class="Nm" title="Nm">rgblink</b> was originally written by Carsten
+<a class="Xr">rgbasm(1)</a>, <a class="Xr">rgblink(5)</a>,
+  <a class="Xr">rgbfix(1)</a>, <a class="Xr">rgbds(5)</a>,
+  <a class="Xr">rgbds(7)</a>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="HISTORY"><a class="permalink" href="#HISTORY">HISTORY</a></h1>
+<code class="Nm">rgblink</code> was originally written by Carsten
   S&#x00F8;rensen as part of the ASMotor package, and was later packaged in
   RGBDS by Justin Lloyd. It is now maintained by a number of contributors at
-  <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
+  <a class="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.
+</section>
+</div>
 <table class="foot">
   <tr>
     <td class="foot-date">January 26, 2018</td>

--- a/docs/rgblink.5.html
+++ b/docs/rgblink.5.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html>
+<!-- This is an automatically generated file.  Do not edit.
+   This file is part of RGBDS.
+
+   Copyright (c) 2017-2018, Antonio Nino Diaz and RGBDS contributors.
+
+   SPDX-License-Identifier: MIT
+   -->
 <head>
   <meta charset="utf-8"/>
-  <style>
-    table.head, table.foot { width: 100%; }
-    td.head-rtitle, td.foot-os { text-align: right; }
-    td.head-vol { text-align: center; }
-    div.Pp { margin: 1ex 0ex; }
-  </style>
   <link rel="stylesheet" href="mandoc.css" type="text/css" media="all"/>
   <title>RGBLINK(5)</title>
 </head>
@@ -20,81 +21,80 @@
   </tr>
 </table>
 <div class="manual-text">
-<h1 class="Sh" title="Sh" id="NAME"><a class="selflink" href="#NAME">NAME</a></h1>
-<b class="Nm" title="Nm">rgblink</b> &#x2014;
-  <span class="Nd" title="Nd">linkerscript file format</span>
-<h1 class="Sh" title="Sh" id="DESCRIPTION"><a class="selflink" href="#DESCRIPTION">DESCRIPTION</a></h1>
+<section class="Sh">
+<h1 class="Sh" id="NAME"><a class="permalink" href="#NAME">NAME</a></h1>
+<code class="Nm">rgblink</code> &#x2014;
+<div class="Nd">linkerscript file format</div>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="DESCRIPTION"><a class="permalink" href="#DESCRIPTION">DESCRIPTION</a></h1>
 The linkerscript is an external file that allows the user to specify the order
   of sections without the need for doing so before assembling each object file.
-<div class="Pp"></div>
-The placement of sections specified in the linkerscript is done before the
-  sections whose placement is defined in the source code.
-<div class="Pp"></div>
-A linkerscript consists on a series of banks followed by a list of sections and,
-  optionally, commands. They can be lowercase or uppercase, it is ignored. Any
-  line can contain a comment starting with
-  &#x2018;<code class="Li">;</code>&#x2019; that ends at the end of the line:
-<div class="Pp"></div>
-<div class="Bd" style="margin-left: 5.00ex;">
-<pre class="Li">
-ROMX $F ; This is a comment 
-  &quot;Functions to read array&quot; 
-  ALIGN 8 
-  &quot;Array aligned to 256 bytes&quot; 
- 
-WRAMX 2 
+<p class="Pp">The placement of sections specified in the linkerscript is done
+    before the sections whose placement is defined in the source code.</p>
+<p class="Pp">A linkerscript consists on a series of banks followed by a list of
+    sections and, optionally, commands. They can be lowercase or uppercase, it
+    is ignored. Any line can contain a comment starting with
+    &#x2018;<code class="Li">;</code>&#x2019; that ends at the end of the
+  line:</p>
+<div class="Bd Pp Bd-indent">
+<pre>
+ROMX $F ; This is a comment
+  &quot;Functions to read array&quot;
+  ALIGN 8
+  &quot;Array aligned to 256 bytes&quot;
+
+WRAMX 2
   &quot;Some variables&quot;
 </pre>
 </div>
-<div class="Pp"></div>
-Numbers can be in decimal or hexadecimal format (the prefix is
-  &#x2018;<code class="Li">$</code>&#x2019;). It is an error if any section name
-  or command are found before setting a bank.
-<div class="Pp"></div>
-Files can be included by using the <var class="Ar" title="Ar">INCLUDE</var>
-  keyword followed by a string with the path of the file that has to be
-  included.
-<div class="Pp"></div>
-The possible bank types are: <b class="Sy" title="Sy">ROM0</b>,
-  <b class="Sy" title="Sy">ROMX</b>, <b class="Sy" title="Sy">VRAM</b>,
-  <b class="Sy" title="Sy">WRAM0</b>, <b class="Sy" title="Sy">WRAMX</b>,
-  <b class="Sy" title="Sy">OAM</b> and <b class="Sy" title="Sy">HRAM</b>. Types
-  <b class="Sy" title="Sy">ROMX</b>, <b class="Sy" title="Sy">VRAM</b>,
-  <b class="Sy" title="Sy">WRAMX</b> and <b class="Sy" title="Sy">SRAM</b> are
-  banked, which means that it is needed to specify a bank after the type.
-<div class="Pp"></div>
-When a new bank statement is found, sections found after it will be placed right
-  from the beginning of that bank. If the linkerscript switches to a different
-  bank and then it comes back to the previous one it will continue from the last
-  address that was used.
-<div class="Pp"></div>
-The only two commands are <var class="Ar" title="Ar">ORG</var> and
-  <var class="Ar" title="Ar">ALIGN</var>:
+<p class="Pp">Numbers can be in decimal or hexadecimal format (the prefix is
+    &#x2018;<code class="Li">$</code>&#x2019;). It is an error if any section
+    name or command are found before setting a bank.</p>
+<p class="Pp">Files can be included by using the <var class="Ar">INCLUDE</var>
+    keyword followed by a string with the path of the file that has to be
+    included.</p>
+<p class="Pp">The possible bank types are: <b class="Sy">ROM0</b>,
+    <b class="Sy">ROMX</b>, <b class="Sy">VRAM</b>, <b class="Sy">WRAM0</b>,
+    <b class="Sy">WRAMX</b>, <b class="Sy">OAM</b> and <b class="Sy">HRAM</b>.
+    Types <b class="Sy">ROMX</b>, <b class="Sy">VRAM</b>,
+    <b class="Sy">WRAMX</b> and <b class="Sy">SRAM</b> are banked, which means
+    that it is needed to specify a bank after the type.</p>
+<p class="Pp">When a new bank statement is found, sections found after it will
+    be placed right from the beginning of that bank. If the linkerscript
+    switches to a different bank and then it comes back to the previous one it
+    will continue from the last address that was used.</p>
+<p class="Pp">The only two commands are <var class="Ar">ORG</var> and
+    <var class="Ar">ALIGN</var>:</p>
 <ul class="Bl-bullet">
-  <li class="It-bullet"><var class="Ar" title="Ar">ORG</var> sets the address in
-      which new sections will be placed. It can not be lower than the current
-      address.</li>
-  <li class="It-bullet"><var class="Ar" title="Ar">ALIGN</var> will increase the
-      address until it is aligned to the specified boundary (it tries to set to
-      0 the number of bits specified after the command:
-      <b class="Sy" title="Sy">ALIGN 8</b> will align to $100).</li>
+  <li><var class="Ar">ORG</var> sets the address in which new sections will be
+      placed. It can not be lower than the current address.</li>
+  <li><var class="Ar">ALIGN</var> will increase the address until it is aligned
+      to the specified boundary (it tries to set to 0 the number of bits
+      specified after the command: <b class="Sy">ALIGN 8</b> will align to
+      $100).</li>
 </ul>
-<div class="Pp"></div>
-Note: The bank, alignment, address and type of sections can be specified both in
-  the source code and in the linkerscript. For a section to be able to be placed
-  with the linkerscript the bank must be left unassigned in the source code or
-  be the same as the one specified in the linkerscript. The address and
-  alignment musn't be set.
-<h1 class="Sh" title="Sh" id="SEE_ALSO"><a class="selflink" href="#SEE_ALSO">SEE
+<p class="Pp">Note: The bank, alignment, address and type of sections can be
+    specified both in the source code and in the linkerscript. For a section to
+    be able to be placed with the linkerscript the bank must be left unassigned
+    in the source code or be the same as the one specified in the linkerscript.
+    The address and alignment musn't be set.</p>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
-<a class="Xr" title="Xr">rgbasm(1)</a>, <a class="Xr" title="Xr">rgblink(1)</a>,
-  <a class="Xr" title="Xr">rgbfix(1)</a>, <a class="Xr" title="Xr">rgbds(5)</a>,
-  <a class="Xr" title="Xr">rgbds(7)</a>
-<h1 class="Sh" title="Sh" id="HISTORY"><a class="selflink" href="#HISTORY">HISTORY</a></h1>
-<b class="Nm" title="Nm">rgblink</b> was originally written by Carsten
+<a class="Xr">rgbasm(1)</a>, <a class="Xr">rgblink(1)</a>,
+  <a class="Xr">rgbfix(1)</a>, <a class="Xr">rgbds(5)</a>,
+  <a class="Xr">rgbds(7)</a>
+</section>
+<section class="Sh">
+<h1 class="Sh" id="HISTORY"><a class="permalink" href="#HISTORY">HISTORY</a></h1>
+<code class="Nm">rgblink</code> was originally written by Carsten
   S&#x00F8;rensen as part of the ASMotor package, and was later packaged in
   RGBDS by Justin Lloyd. It is now maintained by a number of contributors at
-  <a class="Lk" title="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.</div>
+  <a class="Lk" href="https://github.com/rednex/rgbds">https://github.com/rednex/rgbds</a>.
+</section>
+</div>
 <table class="foot">
   <tr>
     <td class="foot-date">January 27, 2018</td>

--- a/include/gfx/gb.h
+++ b/include/gfx/gb.h
@@ -12,14 +12,24 @@
 #include <stdint.h>
 #include "gfx/main.h"
 
+#define XFLIP 0x40
+#define YFLIP 0x20
+
 void raw_to_gb(const struct RawIndexedImage *raw_image, struct GBImage *gb);
 void output_file(const struct Options *opts, const struct GBImage *gb);
 int get_tile_index(uint8_t *tile, uint8_t **tiles, int num_tiles,
 		   int tile_size);
-void create_tilemap(const struct Options *opts, struct GBImage *gb,
-		    struct Tilemap *tilemap);
+uint8_t reverse_bits(uint8_t b);
+void xflip(uint8_t *tile, uint8_t *tile_xflip, int tile_size);
+void yflip(uint8_t *tile, uint8_t *tile_yflip, int tile_size);
+int get_mirrored_tile_index(uint8_t *tile, uint8_t **tiles, int num_tiles,
+			    int tile_size, int *flags);
+void create_mapfiles(const struct Options *opts, struct GBImage *gb,
+		     struct Mapfile *tilemap, struct Mapfile *attrmap);
 void output_tilemap_file(const struct Options *opts,
-			 const struct Tilemap *tilemap);
+			 const struct Mapfile *tilemap);
+void output_attrmap_file(const struct Options *opts,
+			 const struct Mapfile *attrmap);
 void output_palette_file(const struct Options *opts,
 			 const struct RawIndexedImage *raw_image);
 

--- a/include/gfx/main.h
+++ b/include/gfx/main.h
@@ -21,10 +21,13 @@ struct Options {
 	bool hardfix;
 	bool fix;
 	bool horizontal;
+	bool mirror;
 	bool unique;
 	int trim;
-	char *mapfile;
-	bool mapout;
+	char *tilemapfile;
+	bool tilemapout;
+	char *attrmapfile;
+	bool attrmapout;
 	char *palfile;
 	bool palout;
 	char *outfile;
@@ -40,8 +43,10 @@ struct RGBColor {
 struct ImageOptions {
 	bool horizontal;
 	int trim;
-	char *mapfile;
-	bool mapout;
+	char *tilemapfile;
+	bool tilemapout;
+	char *attrmapfile;
+	bool attrmapout;
 	char *palfile;
 	bool palout;
 };
@@ -71,7 +76,7 @@ struct GBImage {
 	int trim;
 };
 
-struct Tilemap {
+struct Mapfile {
 	uint8_t *data;
 	int size;
 };

--- a/src/gfx/gb.c
+++ b/src/gfx/gb.c
@@ -85,8 +85,87 @@ int get_tile_index(uint8_t *tile, uint8_t **tiles, int num_tiles, int tile_size)
 	return -1;
 }
 
-void create_tilemap(const struct Options *opts, struct GBImage *gb,
-		    struct Tilemap *tilemap)
+uint8_t reverse_bits(uint8_t b)
+{
+	uint8_t rev = 0;
+
+	rev |= (b & 0x80) >> 7;
+	rev |= (b & 0x40) >> 5;
+	rev |= (b & 0x20) >> 3;
+	rev |= (b & 0x10) >> 1;
+	rev |= (b & 0x08) << 1;
+	rev |= (b & 0x04) << 3;
+	rev |= (b & 0x02) << 5;
+	rev |= (b & 0x01) << 7;
+	return rev;
+}
+
+void xflip(uint8_t *tile, uint8_t *tile_xflip, int tile_size)
+{
+	int i;
+
+	for (i = 0; i < tile_size; i++)
+		tile_xflip[i] = reverse_bits(tile[i]);
+}
+
+void yflip(uint8_t *tile, uint8_t *tile_yflip, int tile_size)
+{
+	int i;
+
+	for (i = 0; i < tile_size; i++)
+		tile_yflip[i] = tile[(tile_size - i - 1) ^ (depth - 1)];
+}
+
+/*
+ * get_mirrored_tile_index looks for `tile` in tile array `tiles`, also
+ * checking x-, y-, and xy-mirrored versions of `tile`. If one is found,
+ * `*flags` is set according to the type of mirroring and the index of the
+ * matched tile is returned. If no match is found, -1 is returned.
+ */
+int get_mirrored_tile_index(uint8_t *tile, uint8_t **tiles, int num_tiles,
+			    int tile_size, int *flags)
+{
+	int index;
+	uint8_t *tile_xflip;
+	uint8_t *tile_yflip;
+
+	index = get_tile_index(tile, tiles, num_tiles, tile_size);
+	if (index >= 0) {
+		*flags = 0;
+		return index;
+	}
+
+	tile_yflip = malloc(tile_size);
+	yflip(tile, tile_yflip, tile_size);
+	index = get_tile_index(tile_yflip, tiles, num_tiles, tile_size);
+	if (index >= 0) {
+		*flags = YFLIP;
+		free(tile_yflip);
+		return index;
+	}
+
+	tile_xflip = malloc(tile_size);
+	xflip(tile, tile_xflip, tile_size);
+	index = get_tile_index(tile_xflip, tiles, num_tiles, tile_size);
+	if (index >= 0) {
+		*flags = XFLIP;
+		free(tile_yflip);
+		free(tile_xflip);
+		return index;
+	}
+
+	yflip(tile_xflip, tile_yflip, tile_size);
+	index = get_tile_index(tile_yflip, tiles, num_tiles, tile_size);
+	if (index >= 0)
+		*flags = XFLIP | YFLIP;
+
+	free(tile_yflip);
+	free(tile_xflip);
+	return index;
+}
+
+void create_mapfiles(const struct Options *opts, struct GBImage *gb,
+		     struct Mapfile *tilemap, struct Mapfile *attrmap)
 {
 	int i, j;
 	int gb_i;
@@ -94,6 +173,7 @@ void create_tilemap(const struct Options *opts, struct GBImage *gb,
 	int max_tiles;
 	int num_tiles;
 	int index;
+	int flags;
 	int gb_size;
 	uint8_t *tile;
 	uint8_t **tiles;
@@ -109,19 +189,33 @@ void create_tilemap(const struct Options *opts, struct GBImage *gb,
 	tiles = calloc(max_tiles, sizeof(uint8_t *));
 	num_tiles = 0;
 
-	tilemap->data = calloc(max_tiles, sizeof(uint8_t));
-	tilemap->size = 0;
+	if (*opts->tilemapfile) {
+		tilemap->data = calloc(max_tiles, sizeof(uint8_t));
+		tilemap->size = 0;
+	}
+
+	if (*opts->attrmapfile) {
+		attrmap->data = calloc(max_tiles, sizeof(uint8_t));
+		attrmap->size = 0;
+	}
+
 
 	gb_i = 0;
 	while (gb_i < gb_size) {
+		flags = 0;
 		tile = malloc(tile_size);
 		for (i = 0; i < tile_size; i++) {
 			tile[i] = gb->data[gb_i];
 			gb_i++;
 		}
 		if (opts->unique) {
-			index = get_tile_index(tile, tiles, num_tiles,
-					       tile_size);
+			if (opts->mirror) {
+				index = get_mirrored_tile_index(tile, tiles, num_tiles,
+								tile_size, &flags);
+			} else {
+				index = get_tile_index(tile, tiles, num_tiles,
+						       tile_size);
+			}
 			if (index < 0) {
 				index = num_tiles;
 				tiles[num_tiles] = tile;
@@ -132,8 +226,14 @@ void create_tilemap(const struct Options *opts, struct GBImage *gb,
 			tiles[num_tiles] = tile;
 			num_tiles++;
 		}
-		tilemap->data[tilemap->size] = index;
-		tilemap->size++;
+		if (*opts->tilemapfile) {
+			tilemap->data[tilemap->size] = index;
+			tilemap->size++;
+		}
+		if (*opts->attrmapfile) {
+			attrmap->data[attrmap->size] = flags;
+			attrmap->size++;
+		}
 	}
 
 	if (opts->unique) {
@@ -154,19 +254,35 @@ void create_tilemap(const struct Options *opts, struct GBImage *gb,
 }
 
 void output_tilemap_file(const struct Options *opts,
-			 const struct Tilemap *tilemap)
+			 const struct Mapfile *tilemap)
 {
 	FILE *f;
 
-	f = fopen(opts->mapfile, "wb");
+	f = fopen(opts->tilemapfile, "wb");
 	if (!f)
-		err(1, "Opening tilemap file '%s' failed", opts->mapfile);
+		err(1, "Opening tilemap file '%s' failed", opts->tilemapfile);
 
 	fwrite(tilemap->data, 1, tilemap->size, f);
 	fclose(f);
 
-	if (opts->mapout)
-		free(opts->mapfile);
+	if (opts->tilemapout)
+		free(opts->tilemapfile);
+}
+
+void output_attrmap_file(const struct Options *opts,
+			 const struct Mapfile *attrmap)
+{
+	FILE *f;
+
+	f = fopen(opts->attrmapfile, "wb");
+	if (!f)
+		err(1, "Opening attrmap file '%s' failed", opts->attrmapfile);
+
+	fwrite(attrmap->data, 1, attrmap->size, f);
+	fclose(f);
+
+	if (opts->attrmapout)
+		free(opts->attrmapfile);
 }
 
 void output_palette_file(const struct Options *opts,

--- a/src/gfx/makepng.c
+++ b/src/gfx/makepng.c
@@ -649,10 +649,16 @@ static void get_text(const struct PNGImage *img,
 			png_options->trim = strtoul(text[i].text, NULL, 0);
 			png_free_data(img->png, img->info, PNG_FREE_TEXT, i);
 		} else if (strcmp(text[i].key, "t") == 0) {
-			png_options->mapfile = text[i].text;
+			png_options->tilemapfile = text[i].text;
 			png_free_data(img->png, img->info, PNG_FREE_TEXT, i);
 		} else if (strcmp(text[i].key, "T") == 0 && !*text[i].text) {
-			png_options->mapout = true;
+			png_options->tilemapout = true;
+			png_free_data(img->png, img->info, PNG_FREE_TEXT, i);
+		} else if (strcmp(text[i].key, "a") == 0) {
+			png_options->attrmapfile = text[i].text;
+			png_free_data(img->png, img->info, PNG_FREE_TEXT, i);
+		} else if (strcmp(text[i].key, "A") == 0 && !*text[i].text) {
+			png_options->attrmapout = true;
 			png_free_data(img->png, img->info, PNG_FREE_TEXT, i);
 		} else if (strcmp(text[i].key, "p") == 0) {
 			png_options->palfile = text[i].text;
@@ -699,14 +705,26 @@ static void set_text(const struct PNGImage *img,
 		text[0].compression = PNG_TEXT_COMPRESSION_NONE;
 		png_set_text(img->png, img->info, text, 1);
 	}
-	if (*png_options->mapfile) {
+	if (*png_options->tilemapfile) {
 		text[0].key = "t";
 		text[0].text = "";
 		text[0].compression = PNG_TEXT_COMPRESSION_NONE;
 		png_set_text(img->png, img->info, text, 1);
 	}
-	if (png_options->mapout) {
+	if (png_options->tilemapout) {
 		text[0].key = "T";
+		text[0].text = "";
+		text[0].compression = PNG_TEXT_COMPRESSION_NONE;
+		png_set_text(img->png, img->info, text, 1);
+	}
+	if (*png_options->attrmapfile) {
+		text[0].key = "a";
+		text[0].text = "";
+		text[0].compression = PNG_TEXT_COMPRESSION_NONE;
+		png_set_text(img->png, img->info, text, 1);
+	}
+	if (png_options->attrmapout) {
+		text[0].key = "A";
 		text[0].text = "";
 		text[0].compression = PNG_TEXT_COMPRESSION_NONE;
 		png_set_text(img->png, img->info, text, 1);

--- a/src/gfx/rgbgfx.1
+++ b/src/gfx/rgbgfx.1
@@ -13,11 +13,12 @@
 .Nd Game Boy graphics converter
 .Sh SYNOPSIS
 .Nm rgbgfx
-.Op Fl DfFhPTVv
+.Op Fl ADfFhmPTuVv
 .Op Fl o Ar outfile
+.Op Fl a Ar attrmap
 .Op Fl d Ar depth
 .Op Fl p Ar palfile
-.Op Fl t Ar mapfile
+.Op Fl t Ar tilemap
 .Op Fl x Ar tiles
 .Ar file
 .Sh DESCRIPTION
@@ -47,6 +48,19 @@ The input image may not contain more colors than the selected bit depth
 allows. Transparent pixels are set to palette index 0.
 .Sh ARGUMENTS
 .Bl -tag -width Ds
+.It Fl a Ar attrmap
+Generate a file of tile mirroring attributes for OAM or (CGB-only) background
+tiles. For each tile in the input file, a byte is written representing the
+dimensions that the associated tile in the output file should be mirrored.
+Useful in combination with
+.Fl m
+to keep track the mirror direction of mirrored duplicate tiles.
+.It Fl A
+Same as
+.Fl a ,
+but the attrmap file output name is made by taking the input filename, removing
+the file extension, and appending
+.Pa .attrmap .
 .It Fl D
 Debug features are enabled.
 .It Fl f
@@ -61,6 +75,12 @@ The bit depth of the output image (either 1 or 2).
 By default, the bit depth is 2 (two bits per pixel).
 .It Fl h
 Lay out tiles horizontally rather than vertically.
+.It Fl m
+Truncate tiles by checking for tiles that are mirrored versions of others and
+omitting these from the output file. Useful with tilemaps and attrmaps together
+to keep track of the duplicated tiles and the dimension mirrored. Tiles are
+checked for horizontal, vertical, and horizontal-vertical mirroring. Implies
+.Fl u .
 .It Fl o Ar outfile
 The name of the output file.
 .It Fl p Ar palfile
@@ -74,17 +94,24 @@ Same as
 but the palette file output name is made by taking the input PNG file's
 filename, removing the file extension, and appending
 .Pa .pal .
-.It Fl t Ar mapfile
-If any tiles are the same, don't place the repeat tiles in the output file, and
-make a tilemap file.
+.It Fl t Ar tilemap
+Generate a file of tile indices. For each tile in the input file, a byte is
+written representing the index of the associated tile in the output file.
+Useful in combination with
+.Fl u
+or
+.Fl m
+to keep track of duplicate tiles.
 .It Fl T
 Same as
 .Fl t ,
-but the tilemap file output name is made by taking the input filename,
-removing the file extension, and appending
+but the tilemap file output name is made by taking the input filename, removing
+the file extension, and appending
 .Pa .tilemap .
 .It Fl u
-Truncate repeated tiles. Useful with tilemaps.
+Truncate tiles by checking for tiles that are exact duplicates of others and
+omitting these from the output file. Useful with tilemaps to keep track of the
+duplicated tiles.
 .It Fl V
 Print the version of the program and exit.
 .It Fl v
@@ -104,6 +131,14 @@ The following creates a planar 2bpp file with only unique tiles, and its tilemap
 .Pa out.tilemap :
 .Pp
 .D1 $ rgbgfx -T -u -o out.2bpp in.png
+.Pp
+The following creates a planar 2bpp file with only unique tiles (accounting for
+tile mirroring) and its associated tilemap
+.Pa out.tilemap
+and attrmap
+.Pa out.attrmap :
+.Pp
+.D1 $ rgbgfx -A -T -m -o out.2bpp in.png
 .Pp
 The following will do nothing:
 .Pp


### PR DESCRIPTION
To help users save on VRAM, `rgbgfx` can detect and skip duplicate tiles. The Gameboy also allows for easy X- and Y-mirroring of sprites (DMG and CGB) and background tiles (CGB only), so it would be nice if `rgbgfx` could detect these mirrored-duplicates as well.

This patch adds an `-m` flag to perform this check, an `-a` option to specify an attribute map file to write the X- and Y-mirroring flags, and an `-A` flag to automatically generate the name of the attribute map. Like `-u`, if the tilemap or attrmap is omitted, the duplicate detection is still performed.

Passing `-m` implies `-u` as the mirror-tile check is an additional step on top of the uniqueness check.

- [X] checkpatch is mostly satisfied (a couple lines exceed 80 characters)
- [x] usage and manpage have been updated
- [X] wwwman has been regenerated
- [X] no existing behavior has been altered