### PR TITLE
[WIP] Link-time assertions

### DIFF
--- a/include/asm/assertions.h
+++ b/include/asm/assertions.h
@@ -1,0 +1,27 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2018, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef RGBDS_ASM_ASSERTIONS_H
+#define RGBDS_ASM_ASSERTIONS_H
+
+#include <stdint.h>
+#include "asm/lexer.h"
+
+enum AssertSeverity {
+	SEV_WARN = 0,
+	SEV_FAIL = 1,
+};
+
+struct Assert {
+	char tzName[MAXSTRLEN + 1];
+	char tzFilename[_MAX_PATH + 1];
+	uint32_t nLine;
+	enum AssertSeverity severity;
+};
+
+#endif /* RGBDS_ASM_ASSERTIONS_H */

--- a/include/asm/output.h
+++ b/include/asm/output.h
@@ -11,6 +11,7 @@
 
 #include <stdint.h>
 
+#include "asm/assertions.h"
 #include "asm/rpn.h"
 
 struct Section {
@@ -49,5 +50,6 @@ void out_AbsLong(int32_t b);
 void out_RelLong(struct Expression *expr);
 void out_PushSection(void);
 void out_PopSection(void);
+void out_Assert(struct Expression *expr, enum AssertSeverity severity, char * message);
 
 #endif /* RGBDS_ASM_OUTPUT_H */

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -25,6 +25,7 @@
 #include "asm/output.h"
 #include "asm/rpn.h"
 #include "asm/symbol.h"
+#include "asm/assertions.h"
 
 #include "common.h"
 #include "linkdefs.h"
@@ -440,6 +441,7 @@ static void updateUnion(void)
 	struct Expression sVal;
 	int32_t nConstValue;
 	struct ConstExpression sConstExpr;
+	enum AssertSeverity eSeverity;
 }
 
 %type	<sVal>		relocconst
@@ -451,6 +453,8 @@ static void updateUnion(void)
 %type	<nConstValue>	sectiontype
 
 %type	<tzString>	string
+
+%type	<eSeverity>	assert_severity
 
 %token	<nConstValue>	T_NUMBER
 %token	<tzString>	T_STRING
@@ -514,6 +518,7 @@ static void updateUnion(void)
 %token	T_POP_ENDR
 %token	T_POP_FAIL
 %token	T_POP_WARN
+%token	T_POP_ASSERT
 %token	T_POP_PURGE
 %token	T_POP_POPS
 %token	T_POP_PUSHS
@@ -667,6 +672,7 @@ simple_pseudoop : include
 		| shift
 		| fail
 		| warn
+		| assert
 		| purge
 		| pops
 		| pushs
@@ -705,6 +711,20 @@ fail		: T_POP_FAIL string	{ fatalerror("%s", $2); }
 ;
 
 warn		: T_POP_WARN string	{ warning("%s", $2); }
+;
+
+assert		: T_POP_ASSERT relocconst comma assert_severity
+		{
+			out_Assert(&$2, $4, "TODO: stringify expression");
+		}
+		| T_POP_ASSERT relocconst comma assert_severity comma string
+		{
+			out_Assert(&$2, $4, $6);
+		}
+;
+
+assert_severity : T_POP_FAIL		{ $$ = 1; }
+		| T_POP_WARN		{ $$ = 0; }
 ;
 
 shift		: T_POP_SHIFT		{ sym_ShiftCurrentMacroArgs(); }

--- a/src/asm/constexpr.c
+++ b/src/asm/constexpr.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "asm/asm.h"
+#include "asm/assertions.h"
 #include "asm/constexpr.h"
 #include "asm/lexer.h"
 #include "asm/main.h"

--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "asm/asm.h"
+#include "asm/assertions.h"
 #include "asm/constexpr.h"
 #include "asm/lexer.h"
 #include "asm/main.h"
@@ -404,6 +405,7 @@ const struct sLexInitString lexer_strings[] = {
 
 	{"fail", T_POP_FAIL},
 	{"warn", T_POP_WARN},
+	{"assert", T_POP_ASSERT},
 
 	{"macro", T_POP_MACRO},
 	/* Not needed but we have it here just to protect the name */

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -15,6 +15,7 @@
 #include <ctype.h>
 
 #include "asm/asm.h"
+#include "asm/assertions.h"
 #include "asm/constexpr.h"
 #include "asm/fstack.h"
 #include "asm/lexer.h"

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -17,6 +17,7 @@
 #include <string.h>
 
 #include "asm/asm.h"
+#include "asm/assertions.h"
 #include "asm/charmap.h"
 #include "asm/fstack.h"
 #include "asm/main.h"
@@ -154,7 +155,7 @@ static uint32_t countsections(void)
 }
 
 /*
- * Count the number of patches used in this object
+ * Count the number of patches used in this section
  */
 static uint32_t countpatches(struct Section *pSect)
 {
@@ -936,4 +937,19 @@ void out_BinaryFileSlice(char *s, int32_t start_pos, int32_t length)
 	pPCSymbol->nValue += length;
 
 	fclose(f);
+}
+
+void out_Assert(struct Expression *expr, enum AssertSeverity severity, char * message)
+{
+	if (rpn_isReloc(expr)) {
+		fatalerror("Link-time assertions unimplemented");
+	} else {
+		if (!expr->nVal) {
+			if (severity == SEV_WARN) {
+				warning("Assertion failed: %s", message);
+			} else {
+				fatalerror("Assertion failed: %s", message);
+			}
+		}
+	}
 }

--- a/src/rgbds.5
+++ b/src/rgbds.5
@@ -35,9 +35,10 @@ is a 0‐terminated string of
 .Bd -literal
 ; Header
 
-BYTE    ID[4]            ; "RGB6"
-LONG    NumberOfSymbols  ; The number of symbols used in this file
-LONG    NumberOfSections ; The number of sections used in this file
+BYTE    ID[4]                 ; "RGB7"
+LONG    NumberOfSymbols       ; The number of symbols used in this file
+LONG    NumberOfSections      ; The number of sections used in this file
+LONG    NumberOfAssertions    ; The number of assertions used in this file
 
 ; Symbols
 
@@ -126,6 +127,18 @@ REPT NumberOfSections
 
     ENDC
 
+ENDR
+
+; Assertions
+
+REPT NumberOfAssertions
+    STRING  ErrorMessage
+    STRING  SourceFile
+    LONG    Line
+    BYTE    Type ; 0 = assert
+                 ; 1 = warnif
+    LONG    RPNSize
+    BYTE    RPN[RPNSize]
 ENDR
 .Ed
 .Ss RPN DATA


### PR DESCRIPTION
This PR is not supposed to be merged in its current form. However, I would like to seek feedback on this part, as it is unlikely to change otherwise.

Right now, the parser has been modified to add `assert` as a pseudoinstruction, and support for assertions that resolve at assembly-time has been implemented. Moreover, I included the documentation for the modifications I intend to make to the object format.

Finally, I think it would be natural to let the user omit the assertion description string and let RGBDS use the stringified expression instead, but I don't know how to implement it—any hints/pointers are appreciated.