### PR TITLE
Improve charmap structure with trie.

### DIFF
--- a/include/asm/charmap.h
+++ b/include/asm/charmap.h
@@ -13,14 +13,25 @@
 
 #define MAXCHARMAPS	512
 #define CHARMAPLENGTH	16
+#define MAXCHARNODES	(MAXCHARMAPS * CHARMAPLENGTH + 1)
+
+/*
+ * A node for trie structure.
+ */
+struct Charnode {
+	uint8_t code; /* the value in a key-value pair. */
+	uint8_t isCode; /* has one if it's a code node, not just a bridge node. */
+	struct Charnode *next[256]; /* each index representing the next possible character from its current state. */
+};
 
 struct Charmap {
-	int32_t count;
-	char input[MAXCHARMAPS][CHARMAPLENGTH + 1];
-	char output[MAXCHARMAPS];
+	int32_t charCount; /* user-side count. */
+	int32_t nodeCount; /* node-side count. */
+	struct Charnode nodes[MAXCHARNODES]; /* first node is reserved for the root node in charmap. */
 };
 
 int32_t readUTF8Char(char *destination, char *source);
+
 int32_t charmap_Add(char *input, uint8_t output);
 int32_t charmap_Convert(char **input);
 


### PR DESCRIPTION
The previous structure of charmap used brute-force string-comparison to convert the strings from its user. It always compares the given string to all of the strings in charmap, which is very costly in a huge project.

For its improvement, I changed its structure into trie, which is being used in many string-processing areas. And thanks to the comments from kind people, I could edit the flaws in it, and committed it again now.

Sorry to bother you! I'm new to this github thing :p