### PR TITLE
Terminate standalone bracketed symbol strings

### DIFF
--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -731,7 +731,9 @@ scanagain:
 			return T_STRING;
 		} else if (*pLexBuffer == '{') {
 			pLexBuffer++;
-			yylex_ReadBracketedSymbol(yylval.tzString, 0);
+			size_t len = yylex_ReadBracketedSymbol(yylval.tzString,
+							       0);
+			yylval.tzString[len] = 0;
 			return T_STRING;
 		}
 


### PR DESCRIPTION
Standalone bracketed symbols like the following weren't being zero-terminated.

`X EQUS {Y}`

This doesn't apply to bracketed symbols that aren't standalone, but are instead found in a string. For example, the following works even without this fix.

`X EQUS "{Y}"`

Fixes #363.