### PR TITLE
Fix comment bug

### DIFF
--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -181,16 +181,10 @@ YY_BUFFER_STATE yy_create_buffer(FILE *f)
 	/* Convert all line endings to LF and spaces */
 
 	char *mem = pBuffer->pBuffer;
-	uint32_t instring = 0;
 
 	while (*mem) {
-		if (*mem == '\"')
-			instring = 1 - instring;
-
 		if ((mem[0] == '\\') && (mem[1] == '\"' || mem[1] == '\\')) {
 			mem += 2;
-		} else if (instring) {
-			mem += 1;
 		} else {
 			/* LF CR and CR LF */
 			if (((mem[0] == 10) && (mem[1] == 13))
@@ -211,7 +205,7 @@ YY_BUFFER_STATE yy_create_buffer(FILE *f)
 	/* Remove comments */
 
 	mem = pBuffer->pBuffer;
-	instring = 0;
+	uint32_t instring = 0;
 
 	while (*mem) {
 		if (*mem == '\"')


### PR DESCRIPTION
I've found a critical bug in processing of comments, and thanks to Ben10do I knew it was related to #326. This bug comes out when you comment something with the character ';', and include the quotation mark without its pair in it. For example,

ld a, 3
push hl
; This is a comment.
; and I will show you an "error!

In the case above, you can confront an unknown compilation error named a syntax error, but actually it's not a syntax error. The latest version of rgbds compiler has a step to parse the given source to convert its line endings to a unified one, and it processes quotation marks even before it processes the comments.
So, I edited a little bit of the source, and it works without any problems now.

Thanks.