### PR TITLE
checkpatch.conf: Don't complain when bools are used in struct

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -67,3 +67,6 @@
 
 # Don't complain when files are modified in 'include/asm'
 --ignore MODIFIED_INCLUDE_ASM
+
+# Don't complain when bools are used in structs
+--ignore BOOL_MEMBER


### PR DESCRIPTION
In RGBDS's codebase, boolean struct members aren't a problem. See
include/asm/main.h, include/gfx/main.h for examples.

This check has been triggered by #381, and it seems that it's not intended.