### PR TITLE
Check if parent exists for local label reference

### DIFF
--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -735,6 +735,9 @@ void sym_Ref(char *tzSym)
 		int isLocal = 0;
 
 		if (*tzSym == '.') {
+			if (!pScope)
+				fatalerror("Local label reference '%s' in main scope",
+					   tzSym);
 			fullSymbolName(fullname, sizeof(fullname), tzSym,
 				       pScope);
 			tzSym = fullname;

--- a/test/asm/local-ref-without-parent.asm
+++ b/test/asm/local-ref-without-parent.asm
@@ -1,0 +1,3 @@
+SECTION "sec", ROM0
+
+dw .test

--- a/test/asm/local-ref-without-parent.out
+++ b/test/asm/local-ref-without-parent.out
@@ -1,0 +1,2 @@
+ERROR: local-ref-without-parent.asm(3):
+    Local label reference '.test' in main scope

--- a/test/asm/local-ref-without-parent.out.pipe
+++ b/test/asm/local-ref-without-parent.out.pipe
@@ -1,0 +1,2 @@
+ERROR: -(3):
+    Local label reference '.test' in main scope


### PR DESCRIPTION
If an attempt is made to reference a local label before any non-local label is defined, raise an error instead of segfaulting.