### PR TITLE
Prevent `SET` from overriding constant symbols

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -30,6 +30,8 @@ Other contributors
 
 - David Brotz <dbrotz007@gmail.com>
 
+- Eldred Habert <eldredhabert0@gmail.com>
+
 - The Musl C library <http://www.musl-libc.org>
 
 - obskyr <powpowd@gmail.com>

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -553,6 +553,11 @@ void sym_AddSet(char *tzSym, int32_t value)
 					tzSym,
 					nsym->tzFileName,
 					nsym->nFileLine);
+			else if (!(nsym->nType & SYMF_SET))
+				yyerror("'%s' already defined as constant at %s(%u)",
+					tzSym,
+					nsym->tzFileName,
+					nsym->nFileLine);
 		} else if (nsym->nType & SYMF_REF) {
 			yyerror("'%s' already referenced at %s(%u)",
 				tzSym,

--- a/test/asm/symbol-override.asm
+++ b/test/asm/symbol-override.asm
@@ -1,0 +1,14 @@
+V set 0
+V set 1
+    PRINTT "V={V}\n"
+
+W equ 1
+W set 0
+
+rsset 1
+X rb 0
+X set 0
+
+SECTION "Test", ROM0[1]
+Y:
+Y set 0

--- a/test/asm/symbol-override.out
+++ b/test/asm/symbol-override.out
@@ -1,0 +1,8 @@
+ERROR: symbol-override.asm(6):
+    'W' already defined as constant at symbol-override.asm(5)
+ERROR: symbol-override.asm(10):
+    'X' already defined as constant at symbol-override.asm(9)
+ERROR: symbol-override.asm(14):
+    'Y' already defined as non-constant at symbol-override.asm(13)
+error: Assembly aborted (3 errors)!
+V=$1

--- a/test/asm/symbol-override.out.pipe
+++ b/test/asm/symbol-override.out.pipe
@@ -1,0 +1,8 @@
+ERROR: -(6):
+    'W' already defined as constant at -(5)
+ERROR: -(10):
+    'X' already defined as constant at -(9)
+ERROR: -(14):
+    'Y' already defined as non-constant at -(13)
+error: Assembly aborted (3 errors)!
+V=$1


### PR DESCRIPTION
Fixes #341