### PR TITLE
Allow periods to continue macro args

### DIFF
--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -214,7 +214,8 @@ bool AppendMacroArg(char whichArg, char *dest, size_t *destIndex, char **rest)
 		 || (ch >= '0' && ch <= '9')
 		 || ch == '_'
 		 || ch == '@'
-		 || ch == '#') {
+		 || ch == '#'
+		 || ch == '.') {
 			if (*destIndex >= MAXSYMLEN)
 				fatalerror("Symbol too long");
 

--- a/test/asm/label-macro-arg.asm
+++ b/test/asm/label-macro-arg.asm
@@ -1,3 +1,9 @@
+print: MACRO
+	printv \1
+	printt "\n"
+ENDM
+
+
 m1: MACRO
 x\1
 ENDM
@@ -14,14 +20,26 @@ ENDM
 	m1 x = 7
 	m2 2 = 8
 
-	printv x
-	printt "\n"
+	print x
+	print y
+	print xx
+	print yy
 
-	printv y
-	printt "\n"
 
-	printv xx
-	printt "\n"
+test_char: MACRO
+VAR_DEF equs "sizeof_\1something = 0"
+VAR_DEF
+sizeof_\1something = 1
+	PURGE VAR_DEF
 
-	printv yy
-	printt "\n"
+VAR_PRINT equs "printt \"sizeof_\1something equals {sizeof_\1something}\\n\""
+	VAR_PRINT
+	PURGE VAR_PRINT
+ENDM
+
+	test_char _
+	test_char @
+	test_char #
+	test_char .
+
+	test_char :

--- a/test/asm/label-macro-arg.out
+++ b/test/asm/label-macro-arg.out
@@ -1,4 +1,10 @@
+ERROR: label-macro-arg.asm(45) -> test_char(2):
+    Macro 'something' not defined
 $5
 $6
 $7
 $8
+sizeof__something equals $1
+sizeof_@something equals $1
+sizeof_#something equals $1
+sizeof_.something equals $1

--- a/test/asm/label-macro-arg.out.pipe
+++ b/test/asm/label-macro-arg.out.pipe
@@ -1,4 +1,10 @@
+ERROR: -(45) -> test_char(2):
+    Macro 'something' not defined
 $5
 $6
 $7
 $8
+sizeof__something equals $1
+sizeof_@something equals $1
+sizeof_#something equals $1
+sizeof_.something equals $1


### PR DESCRIPTION
c75a953 broke my (previously-working) project that defined, via macros, `sizeof_.player`.
A test was added to confirm that those are indeed accepted outside of macros.