### PR TITLE
Get rid of error in line continuation test

### DIFF
--- a/test/asm/line-continuation.asm
+++ b/test/asm/line-continuation.asm
@@ -1,1 +1,7 @@
-foo @bar\
+; Test that \ after a macro invocation at the end of the file doesn't
+; cause a segfault.
+
+bar: MACRO
+ENDM
+
+foo bar baz\

--- a/test/asm/line-continuation.out
+++ b/test/asm/line-continuation.out
@@ -1,2 +1,0 @@
-ERROR: line-continuation.asm(2) -> @(-1):
-    Macro '@' not defined

--- a/test/asm/line-continuation.out.pipe
+++ b/test/asm/line-continuation.out.pipe
@@ -1,2 +1,0 @@
-ERROR: -(2) -> @(-1):
-    Macro '@' not defined


### PR DESCRIPTION
The purpose of the test is to ensure that rgbasm doesn't segfault in this case.
The "Macro '@' not defined" error is unnecessary.

Fixes #393.