### PR TITLE
Add support for multiple charmaps

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -70,3 +70,6 @@
 
 # Don't complain when bools are used in structs
 --ignore BOOL_MEMBER
+
+# Don't complain about initializing statics (this is specific to the kernel)
+--ignore INITIALISED_STATIC

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ rgbasm_obj := \
 	src/asm/output.o \
 	src/asm/rpn.o \
 	src/asm/symbol.o \
+	src/asm/util.o \
 	src/extern/err.o \
 	src/extern/utf8decoder.o \
 	src/version.o

--- a/include/asm/charmap.h
+++ b/include/asm/charmap.h
@@ -25,13 +25,16 @@ struct Charnode {
 };
 
 struct Charmap {
+	char name[MAXSYMLEN + 1];
 	int32_t charCount; /* user-side count. */
 	int32_t nodeCount; /* node-side count. */
 	struct Charnode nodes[MAXCHARNODES]; /* first node is reserved for the root node in charmap. */
+	struct Charmap *next; /* next charmap in hash table bucket */
 };
 
-int32_t readUTF8Char(char *destination, char *source);
-
+void charmap_InitMain(void);
+struct Charmap *charmap_New(const char *name, const char *baseName);
+void charmap_Set(const char *name);
 int32_t charmap_Add(char *input, uint8_t output);
 int32_t charmap_Convert(char **input);
 

--- a/include/asm/charmap.h
+++ b/include/asm/charmap.h
@@ -35,6 +35,8 @@ struct Charmap {
 void charmap_InitMain(void);
 struct Charmap *charmap_New(const char *name, const char *baseName);
 void charmap_Set(const char *name);
+void charmap_Push(void);
+void charmap_Pop(void);
 int32_t charmap_Add(char *input, uint8_t output);
 int32_t charmap_Convert(char **input);
 

--- a/include/asm/main.h
+++ b/include/asm/main.h
@@ -11,6 +11,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #include "helpers.h"
 

--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -51,7 +51,7 @@ struct sSymbol {
 /* Symbol has a constant value, will not be changed during linking */
 #define SYMF_CONST	0x200
 
-uint32_t calchash(char *s);
+uint32_t sym_CalcHash(const char *s);
 void sym_SetExportAll(uint8_t set);
 void sym_AddLocalReloc(char *tzSym);
 void sym_AddReloc(char *tzSym);

--- a/include/asm/util.h
+++ b/include/asm/util.h
@@ -1,0 +1,17 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2019, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef RGBDS_UTIL_H
+#define RGBDS_UTIL_H
+
+#include <stdint.h>
+
+uint32_t calchash(const char *s);
+int32_t readUTF8Char(char *dest, char *src);
+
+#endif /* RGBDS_UTIL_H */

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -621,6 +621,8 @@ static void strsubUTF8(char *dest, const char *src, uint32_t pos, uint32_t len)
 %token	T_POP_CHARMAP
 %token	T_POP_NEWCHARMAP
 %token	T_POP_SETCHARMAP
+%token	T_POP_PUSHC
+%token	T_POP_POPC
 %token	T_POP_SHIFT
 %token	T_POP_ENDR
 %token	T_POP_FAIL
@@ -776,6 +778,8 @@ simple_pseudoop : include
 		| charmap
 		| newcharmap
 		| setcharmap
+		| pushc
+		| popc
 		| rept
 		| shift
 		| fail
@@ -1047,11 +1051,19 @@ newcharmap	: T_POP_NEWCHARMAP T_ID
 		{
 			charmap_New($2, $4);
 		}
+;
 
 setcharmap	: T_POP_SETCHARMAP T_ID
 		{
 			charmap_Set($2);
 		}
+;
+
+pushc		: T_POP_PUSHC	{ charmap_Push(); }
+;
+
+popc		: T_POP_POPC	{ charmap_Pop(); }
+;
 
 printt		: T_POP_PRINTT string
 		{

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -26,6 +26,7 @@
 #include "asm/output.h"
 #include "asm/rpn.h"
 #include "asm/symbol.h"
+#include "asm/util.h"
 
 #include "extern/utf8decoder.h"
 
@@ -618,6 +619,8 @@ static void strsubUTF8(char *dest, const char *src, uint32_t pos, uint32_t len)
 %token	T_POP_UNION T_POP_NEXTU T_POP_ENDU
 %token	T_POP_INCBIN T_POP_REPT
 %token	T_POP_CHARMAP
+%token	T_POP_NEWCHARMAP
+%token	T_POP_SETCHARMAP
 %token	T_POP_SHIFT
 %token	T_POP_ENDR
 %token	T_POP_FAIL
@@ -771,6 +774,8 @@ simple_pseudoop : include
 		| endu
 		| incbin
 		| charmap
+		| newcharmap
+		| setcharmap
 		| rept
 		| shift
 		| fail
@@ -1033,6 +1038,20 @@ charmap		: T_POP_CHARMAP string comma string
 			}
 		}
 ;
+
+newcharmap	: T_POP_NEWCHARMAP T_ID
+		{
+			charmap_New($2, NULL);
+		}
+		| T_POP_NEWCHARMAP T_ID comma T_ID
+		{
+			charmap_New($2, $4);
+		}
+
+setcharmap	: T_POP_SETCHARMAP T_ID
+		{
+			charmap_Set($2);
+		}
 
 printt		: T_POP_PRINTT string
 		{

--- a/src/asm/charmap.c
+++ b/src/asm/charmap.c
@@ -20,10 +20,17 @@
 
 #define CHARMAP_HASH_SIZE (1 << 9)
 
+struct CharmapStackEntry {
+	struct Charmap *charmap;
+	struct CharmapStackEntry *next;
+};
+
 static struct Charmap *tHashedCharmaps[CHARMAP_HASH_SIZE];
 
 static struct Charmap *mainCharmap;
 static struct Charmap *currentCharmap;
+
+struct CharmapStackEntry *charmapStack;
 
 static void warnSectionCharmap(void)
 {
@@ -117,6 +124,32 @@ void charmap_Set(const char *name)
 	}
 
 	currentCharmap = *ppCharmap;
+}
+
+void charmap_Push(void)
+{
+	struct CharmapStackEntry *stackEntry;
+
+	stackEntry = malloc(sizeof(struct CharmapStackEntry));
+	if (stackEntry == NULL)
+		fatalerror("No memory for charmap stack");
+
+	stackEntry->charmap = currentCharmap;
+	stackEntry->next = charmapStack;
+
+	charmapStack = stackEntry;
+}
+
+void charmap_Pop(void)
+{
+	if (charmapStack == NULL)
+		fatalerror("No entries in the charmap stack");
+
+	struct CharmapStackEntry *top = charmapStack;
+
+	currentCharmap = top->charmap;
+	charmapStack = top->next;
+	free(top);
 }
 
 void charmap_InitMain(void)

--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -479,6 +479,8 @@ const struct sLexInitString lexer_strings[] = {
 
 	{"incbin", T_POP_INCBIN},
 	{"charmap", T_POP_CHARMAP},
+	{"newcharmap", T_POP_NEWCHARMAP},
+	{"setcharmap", T_POP_SETCHARMAP},
 
 	{"fail", T_POP_FAIL},
 	{"warn", T_POP_WARN},

--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -481,6 +481,8 @@ const struct sLexInitString lexer_strings[] = {
 	{"charmap", T_POP_CHARMAP},
 	{"newcharmap", T_POP_NEWCHARMAP},
 	{"setcharmap", T_POP_SETCHARMAP},
+	{"pushc", T_POP_PUSHC},
+	{"popc", T_POP_POPC},
 
 	{"fail", T_POP_FAIL},
 	{"warn", T_POP_WARN},

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -21,6 +21,7 @@
 #include "asm/lexer.h"
 #include "asm/output.h"
 #include "asm/main.h"
+#include "asm/charmap.h"
 
 #include "extern/err.h"
 
@@ -437,6 +438,7 @@ int main(int argc, char *argv[])
 	sym_SetExportAll(CurrentOptions.exportall);
 	fstk_Init(tzMainfile);
 	opt_ParseDefines();
+	charmap_InitMain();
 
 	yy_set_state(LEX_STATE_NORMAL);
 	opt_SetCurrentOptions(&DefaultOptions);

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -321,7 +321,7 @@ static uint32_t addsymbol(struct sSymbol *pSym)
 	struct PatchSymbol *pPSym, **ppPSym;
 	uint32_t hash;
 
-	hash = calchash(pSym->tzName);
+	hash = sym_CalcHash(pSym->tzName);
 	ppPSym = &(tHashedPatchSymbols[hash]);
 
 	while ((*ppPSym) != NULL) {

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -1146,7 +1146,8 @@ a different encoding for other purposes, for example. Initially, there is
 one character map called
 .Sy main
 and it is automatically selected as the current character map from the
-beginning.
+beginning. There is also a character map stack that can be used to save and
+restore which character map is currently active.
 .Bl -column "NEWCHARMAP name, basename"
 .It Sy Command Ta Sy Meaning
 .It Ic NEWCHARMAP Ar name Ta Creates a new, empty character map called
@@ -1156,6 +1157,8 @@ beginning.
 copied from character map
 .Ic basename .
 .It Ic SETCHARMAP Ar name Ta Switch to character map Ic name .
+.It Ic PUSHC Ta Push the current character map onto the stack.
+.It Ic POPC Ta Pop a character map off the stack and switch to it.
 .El
 .Pp
 .Sy Note:

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -1140,9 +1140,27 @@ CHARMAP "&iacute", 20
 CHARMAP "A", 128
 .Ed
 .Pp
+It is possible to create multiple character maps and then switch between them
+as desired. This can be used to encode debug information in ASCII and use
+a different encoding for other purposes, for example. Initially, there is
+one character map called
+.Sy main
+and it is automatically selected as the current character map from the
+beginning.
+.Bl -column "NEWCHARMAP name, basename"
+.It Sy Command Ta Sy Meaning
+.It Ic NEWCHARMAP Ar name Ta Creates a new, empty character map called
+.Ic name .
+.It Ic NEWCHARMAP Ar name , basename Ta Creates a new character map called
+. Ic name ,
+copied from character map
+.Ic basename .
+.It Ic SETCHARMAP Ar name Ta Switch to character map Ic name .
+.El
+.Pp
 .Sy Note:
 Character maps affect all strings in the file from the point in which they are
-defined.
+defined, until switching to a different character map.
 This means that any string that the code may want to print as debug information
 will also be affected by it.
 .Pp

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -22,6 +22,7 @@
 #include "asm/main.h"
 #include "asm/mymath.h"
 #include "asm/output.h"
+#include "asm/util.h"
 
 #include "extern/err.h"
 
@@ -90,16 +91,11 @@ static int32_t getvaluefield(struct sSymbol *sym)
 }
 
 /*
- * Calculate the hash value for a string
+ * Calculate the hash value for a symbol name
  */
-uint32_t calchash(char *s)
+uint32_t sym_CalcHash(const char *s)
 {
-	uint32_t hash = 5381;
-
-	while (*s != 0)
-		hash = (hash * 33) ^ (*s++);
-
-	return hash % HASHSIZE;
+	return calchash(s) % HASHSIZE;
 }
 
 /*
@@ -123,7 +119,7 @@ struct sSymbol *createsymbol(char *s)
 	struct sSymbol **ppsym;
 	uint32_t hash;
 
-	hash = calchash(s);
+	hash = sym_CalcHash(s);
 	ppsym = &(tHashedSymbols[hash]);
 
 	while ((*ppsym) != NULL)
@@ -187,7 +183,7 @@ struct sSymbol **findpsymbol(char *s, struct sSymbol *scope)
 				   s);
 	}
 
-	hash = calchash(s);
+	hash = sym_CalcHash(s);
 	ppsym = &(tHashedSymbols[hash]);
 
 	while ((*ppsym) != NULL) {

--- a/src/asm/util.c
+++ b/src/asm/util.c
@@ -1,0 +1,46 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 1997-2019, Carsten Sorensen and RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdint.h>
+
+#include "asm/main.h"
+#include "asm/util.h"
+
+#include "extern/utf8decoder.h"
+
+/*
+ * Calculate the hash value for a string
+ */
+uint32_t calchash(const char *s)
+{
+	uint32_t hash = 5381;
+
+	while (*s != 0)
+		hash = (hash * 33) ^ (*s++);
+
+	return hash;
+}
+
+int32_t readUTF8Char(char *dest, char *src)
+{
+	uint32_t state;
+	uint32_t codep;
+	int32_t i;
+
+	for (i = 0, state = 0;; i++) {
+		if (decode(&state, &codep, (uint8_t)src[i]) == 1)
+			fatalerror("invalid UTF-8 character");
+
+		dest[i] = src[i];
+
+		if (state == 0) {
+			dest[++i] = '\0';
+			return i;
+		}
+	}
+}

--- a/test/asm/equ-charmap.asm
+++ b/test/asm/equ-charmap.asm
@@ -1,4 +1,4 @@
-SECTION "sec", ROM0
 	charmap "A", 1
+SECTION "sec", ROM0
 _A_ EQU "A"
 	db _A_

--- a/test/asm/multiple-charmaps.asm
+++ b/test/asm/multiple-charmaps.asm
@@ -1,0 +1,88 @@
+printt "main charmap\n"
+
+charmap "ab", $0
+
+x = "ab"
+printt "{x}\n"
+
+printt "newcharmap map1\n"
+newcharmap map1
+
+x = "ab"
+printt "{x}\n"
+
+printt "newcharmap map2, main\n"
+newcharmap map2, main
+
+x = "ab"
+printt "{x}\n"
+
+printt "setcharmap map1\n"
+setcharmap map1
+
+x = "ab"
+printt "{x}\n"
+
+printt "newcharmap map3\n"
+newcharmap map3
+
+charmap "ab", $1
+
+x = "ab"
+printt "{x}\n"
+
+printt "newcharmap map4, map3\n"
+newcharmap map4, map3
+
+charmap "ab", $1
+charmap "cd", $2
+
+x = "ab"
+printt "{x}\n"
+
+x = "cd"
+printt "{x}\n"
+
+printt "setcharmap map3\n"
+setcharmap map3
+
+x = "ab"
+printt "{x}\n"
+
+x = "cd"
+printt "{x}\n"
+
+printt "setcharmap main\n"
+setcharmap main
+
+SECTION "sec0", ROM0
+
+x = "ab"
+printt "{x}\n"
+
+printt "override main charmap\n"
+charmap "ef", $3
+
+x = "ab"
+printt "{x}\n"
+
+x = "ef"
+printt "{x}\n"
+
+printt "setcharmap map3\n"
+setcharmap map3
+
+x = "ab"
+printt "{x}\n"
+
+x = "cd"
+printt "{x}\n"
+
+x = "ef"
+printt "{x}\n"
+
+printt "newcharmap map1\n"
+newcharmap map1
+
+printt "setcharmap map5\n"
+setcharmap map5

--- a/test/asm/multiple-charmaps.asm
+++ b/test/asm/multiple-charmaps.asm
@@ -1,88 +1,104 @@
+new_: MACRO
+	IF _NARG > 1
+	printt "newcharmap \1, \2\n"
+	newcharmap \1, \2
+	ELSE
+	printt "newcharmap \1\n"
+	newcharmap \1
+	ENDC
+ENDM
+
+set_: MACRO
+	printt "setcharmap \1\n"
+	setcharmap \1
+ENDM
+
+push_: MACRO
+	printt "pushc\n"
+	pushc
+ENDM
+
+pop_: MACRO
+	printt "popc\n"
+	popc
+ENDM
+
+print: MACRO
+x = \1
+printt "{x}\n"
+ENDM
+
 printt "main charmap\n"
 
 charmap "ab", $0
 
-x = "ab"
-printt "{x}\n"
+	print "ab"
 
-printt "newcharmap map1\n"
-newcharmap map1
+	new_ map1
 
-x = "ab"
-printt "{x}\n"
+	print "ab"
 
-printt "newcharmap map2, main\n"
-newcharmap map2, main
+	new_ map2, main
 
-x = "ab"
-printt "{x}\n"
+	print "ab"
 
-printt "setcharmap map1\n"
-setcharmap map1
+	set_ map1
 
-x = "ab"
-printt "{x}\n"
+	print "ab"
 
-printt "newcharmap map3\n"
-newcharmap map3
+	new_ map3
 
 charmap "ab", $1
 
-x = "ab"
-printt "{x}\n"
+	print "ab"
 
-printt "newcharmap map4, map3\n"
-newcharmap map4, map3
+	new_ map4, map3
 
 charmap "ab", $1
 charmap "cd", $2
 
-x = "ab"
-printt "{x}\n"
+	print "ab"
+	print "cd"
 
-x = "cd"
-printt "{x}\n"
+	set_ map3
 
-printt "setcharmap map3\n"
-setcharmap map3
+	print "ab"
+	print "cd"
 
-x = "ab"
-printt "{x}\n"
-
-x = "cd"
-printt "{x}\n"
-
-printt "setcharmap main\n"
-setcharmap main
+	set_ main
 
 SECTION "sec0", ROM0
 
-x = "ab"
-printt "{x}\n"
+	print "ab"
 
 printt "override main charmap\n"
 charmap "ef", $3
 
-x = "ab"
-printt "{x}\n"
+	print "ab"
+	print "ef"
 
-x = "ef"
-printt "{x}\n"
+	set_ map1
 
-printt "setcharmap map3\n"
-setcharmap map3
+	push_
+	set_ map2
+	push_
 
-x = "ab"
-printt "{x}\n"
+	set_ map3
 
-x = "cd"
-printt "{x}\n"
+	print "ab"
+	print "cd"
+	print "ef"
 
-x = "ef"
-printt "{x}\n"
+	pop_
 
-printt "newcharmap map1\n"
-newcharmap map1
+	print "ab"
 
-printt "setcharmap map5\n"
-setcharmap map5
+	pop_
+
+	print "ab"
+
+	new_ map1
+
+	set_ map5
+
+	pop_

--- a/test/asm/multiple-charmaps.out
+++ b/test/asm/multiple-charmaps.out
@@ -1,0 +1,34 @@
+warning: multiple-charmaps.asm(64):
+    Using 'charmap' within a section when the current charmap is 'main' is deprecated
+ERROR: multiple-charmaps.asm(85):
+    Charmap 'map1' already exists
+ERROR: multiple-charmaps.asm(88):
+    Charmap 'map5' doesn't exist
+error: Assembly aborted (2 errors)!
+main charmap
+$0
+newcharmap map1
+$6162
+newcharmap map2, main
+$0
+setcharmap map1
+$6162
+newcharmap map3
+$1
+newcharmap map4, map3
+$1
+$2
+setcharmap map3
+$1
+$6364
+setcharmap main
+$0
+override main charmap
+$6162
+$3
+setcharmap map3
+$1
+$6364
+$6566
+newcharmap map1
+setcharmap map5

--- a/test/asm/multiple-charmaps.out
+++ b/test/asm/multiple-charmaps.out
@@ -1,10 +1,11 @@
-warning: multiple-charmaps.asm(64):
+warning: multiple-charmaps.asm(75):
     Using 'charmap' within a section when the current charmap is 'main' is deprecated
-ERROR: multiple-charmaps.asm(85):
+ERROR: multiple-charmaps.asm(100) -> new_(5):
     Charmap 'map1' already exists
-ERROR: multiple-charmaps.asm(88):
+ERROR: multiple-charmaps.asm(102) -> set_(2):
     Charmap 'map5' doesn't exist
-error: Assembly aborted (2 errors)!
+ERROR: multiple-charmaps.asm(104) -> pop_(2):
+    No entries in the charmap stack
 main charmap
 $0
 newcharmap map1
@@ -26,9 +27,18 @@ $0
 override main charmap
 $6162
 $3
+setcharmap map1
+pushc
+setcharmap map2
+pushc
 setcharmap map3
 $1
 $6364
 $6566
+popc
+$0
+popc
+$6162
 newcharmap map1
 setcharmap map5
+popc

--- a/test/asm/multiple-charmaps.out.pipe
+++ b/test/asm/multiple-charmaps.out.pipe
@@ -1,10 +1,11 @@
-warning: -(64):
+warning: -(75):
     Using 'charmap' within a section when the current charmap is 'main' is deprecated
-ERROR: -(85):
+ERROR: -(100) -> new_(5):
     Charmap 'map1' already exists
-ERROR: -(88):
+ERROR: -(102) -> set_(2):
     Charmap 'map5' doesn't exist
-error: Assembly aborted (2 errors)!
+ERROR: -(104) -> pop_(2):
+    No entries in the charmap stack
 main charmap
 $0
 newcharmap map1
@@ -26,9 +27,18 @@ $0
 override main charmap
 $6162
 $3
+setcharmap map1
+pushc
+setcharmap map2
+pushc
 setcharmap map3
 $1
 $6364
 $6566
+popc
+$0
+popc
+$6162
 newcharmap map1
 setcharmap map5
+popc

--- a/test/asm/multiple-charmaps.out.pipe
+++ b/test/asm/multiple-charmaps.out.pipe
@@ -1,0 +1,34 @@
+warning: -(64):
+    Using 'charmap' within a section when the current charmap is 'main' is deprecated
+ERROR: -(85):
+    Charmap 'map1' already exists
+ERROR: -(88):
+    Charmap 'map5' doesn't exist
+error: Assembly aborted (2 errors)!
+main charmap
+$0
+newcharmap map1
+$6162
+newcharmap map2, main
+$0
+setcharmap map1
+$6162
+newcharmap map3
+$1
+newcharmap map4, map3
+$1
+$2
+setcharmap map3
+$1
+$6364
+setcharmap main
+$0
+override main charmap
+$6162
+$3
+setcharmap map3
+$1
+$6364
+$6566
+newcharmap map1
+setcharmap map5


### PR DESCRIPTION
This adds two new directives based on the discussion in #256 : `newcharmap` and `setcharmap`
`newcharmap name` creates a new, empty charmap called `name` and switches to it.
`newcharmap name, basename` creates a new charmap called `name` and copies the existing charmap `basename` to it.
`setcharmap name` switches to an existing charmap called `name`.

I noticed that there is an undocumented feature that creates a charmap local to the current section when you use the `charmap` directive within a section. I don't think that this feature is a good idea, especially now that we support multiple charmaps that can be freely selected. I doubt anyone was using this feature except by mistake since it was never documented and its existence is not obvious when using it.

This change preserves backward compatibility by allowing the local section charmap to override the "main" charmap, but not user-created charmaps. However, I think that this feature should be deprecated and removed in a future version, so I added a warning when using `charmap` in a section when the "main" charmap is selected as the current charmap.

Fixes #256.

