### PR TITLE
Make RGBDS behave identically whether writing a .o

### DIFF
--- a/include/asm/output.h
+++ b/include/asm/output.h
@@ -40,6 +40,7 @@ void out_AbsByteGroup(char *s, int32_t length);
 void out_RelByte(struct Expression *expr);
 void out_RelWord(struct Expression *expr);
 void out_PCRelByte(struct Expression *expr);
+void out_CheckErrors(void);
 void out_WriteObject(void);
 void out_Skip(int32_t skip);
 void out_BinaryFile(char *s);

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -477,6 +477,10 @@ int main(int argc, char *argv[])
 			printf("(%d lines/minute)\n",
 			       (int)(60 / timespent * nTotalLines));
 	}
-	out_WriteObject();
+
+	out_CheckErrors();
+	/* If no path specified, don't write file */
+	if (tzObjectname != NULL)
+		out_WriteObject();
 	return 0;
 }


### PR DESCRIPTION
Some errors are only tripped in `out_WriteObject`, which was basically a stub when `-o` wasn't specified. Now, instead, the function is ran but all output functions are skipped.

Fixes #404.