### PR TITLE
Fix memory leaks with macro args

### DIFF
--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -63,7 +63,6 @@ void sym_AddNewMacroArg(char *s);
 void sym_SaveCurrentMacroArgs(char *save[]);
 void sym_RestoreCurrentMacroArgs(char *save[]);
 void sym_UseNewMacroArgs(void);
-void sym_FreeCurrentMacroArgs(void);
 void sym_AddEqu(char *tzSym, int32_t value);
 void sym_AddSet(char *tzSym, int32_t value);
 void sym_Init(void);

--- a/src/asm/fstack.c
+++ b/src/asm/fstack.c
@@ -128,13 +128,9 @@ static int32_t popcontext(void)
 	if (nCurrentStatus == STAT_isInclude)
 		fclose(pCurrentFile);
 
-	if (nCurrentStatus == STAT_isMacro) {
-		sym_FreeCurrentMacroArgs();
-		nLineNo += 1;
-	}
-
-	if (nCurrentStatus == STAT_isREPTBlock)
-		nLineNo += 1;
+	if (nCurrentStatus == STAT_isMacro
+	 || nCurrentStatus == STAT_isREPTBlock)
+		nLineNo++;
 
 	CurrentFlexHandle = pLastFile->FlexHandle;
 	strcpy((char *)tzCurrentFileName, (char *)pLastFile->tzFileName);
@@ -385,8 +381,8 @@ void fstk_RunString(char *s)
 void fstk_RunRept(uint32_t count)
 {
 	if (count) {
-		pushcontext();
 		sym_UseCurrentMacroArgs();
+		pushcontext();
 		sym_SetMacroArgID(nMacroCount++);
 		sym_UseNewMacroArgs();
 		nCurrentREPTBlockCount = count;

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -68,7 +68,7 @@ int32_t Callback_NARG(unused_ struct sSymbol *sym)
 	uint32_t i = 0;
 
 	while (currentmacroargs[i] && i < MAXMACROARGS)
-		i += 1;
+		i++;
 
 	return i;
 }
@@ -364,7 +364,7 @@ void sym_ShiftCurrentMacroArgs(void)
 	int32_t i;
 
 	free(currentmacroargs[0]);
-	for (i = 0; i < MAXMACROARGS - 1; i += 1)
+	for (i = 0; i < MAXMACROARGS - 1; i++)
 		currentmacroargs[i] = currentmacroargs[i + 1];
 
 	currentmacroargs[MAXMACROARGS - 1] = NULL;
@@ -387,7 +387,8 @@ void sym_UseNewMacroArgs(void)
 {
 	int32_t i;
 
-	for (i = 0; i <= MAXMACROARGS; i += 1) {
+	for (i = 0; i <= MAXMACROARGS; i++) {
+		free(currentmacroargs[i]);
 		currentmacroargs[i] = newmacroargs[i];
 		newmacroargs[i] = NULL;
 	}
@@ -397,25 +398,19 @@ void sym_SaveCurrentMacroArgs(char *save[])
 {
 	int32_t i;
 
-	for (i = 0; i <= MAXMACROARGS; i += 1)
+	for (i = 0; i <= MAXMACROARGS; i++) {
 		save[i] = currentmacroargs[i];
+		currentmacroargs[i] = NULL;
+	}
 }
 
 void sym_RestoreCurrentMacroArgs(char *save[])
 {
 	int32_t i;
 
-	for (i = 0; i <= MAXMACROARGS; i += 1)
-		currentmacroargs[i] = save[i];
-}
-
-void sym_FreeCurrentMacroArgs(void)
-{
-	int32_t i;
-
-	for (i = 0; i <= MAXMACROARGS; i += 1) {
+	for (i = 0; i <= MAXMACROARGS; i++) {
 		free(currentmacroargs[i]);
-		currentmacroargs[i] = NULL;
+		currentmacroargs[i] = save[i];
 	}
 }
 
@@ -424,7 +419,7 @@ void sym_AddNewMacroArg(char *s)
 	int32_t i = 0;
 
 	while (i < MAXMACROARGS && newmacroargs[i] != NULL)
-		i += 1;
+		i++;
 
 	if (i < MAXMACROARGS) {
 		if (s)
@@ -448,7 +443,7 @@ void sym_UseCurrentMacroArgs(void)
 {
 	int32_t i;
 
-	for (i = 1; i <= MAXMACROARGS; i += 1)
+	for (i = 1; i <= MAXMACROARGS; i++)
 		sym_AddNewMacroArg(sym_FindMacroArg(i));
 }
 
@@ -775,12 +770,12 @@ void sym_Init(void)
 	int32_t i;
 	time_t now;
 
-	for (i = 0; i < MAXMACROARGS; i += 1) {
+	for (i = 0; i < MAXMACROARGS; i++) {
 		currentmacroargs[i] = NULL;
 		newmacroargs[i] = NULL;
 	}
 
-	for (i = 0; i < HASHSIZE; i += 1)
+	for (i = 0; i < HASHSIZE; i++)
 		tHashedSymbols[i] = NULL;
 
 	sym_AddReloc("@");


### PR DESCRIPTION
`REPT` blocks nested in macros (and possibly other cases) leaked memory on every call. Unlike most other memory leaks, which would be freed at the end of program execution if they were done properly, those piled up the more compilation went on.
I believe memory usage could have started being fairly high on large projects following the "one master file `INCLUDE`s all the rest" so this may have actually been worth it.