### PR TITLE
Use POSIX-compatible dd(1) instead of head -c.

### DIFF
--- a/test/asm/test.sh
+++ b/test/asm/test.sh
@@ -18,7 +18,7 @@ for i in *.asm; do
 		bin=${i%.asm}.out.bin
 		if [ -f $bin ]; then
 			../../rgblink -o $gb $o > $after 2>&1
-			head -c $(wc -c < $bin) $gb > $after 2>&1
+			dd if=$gb count=1 bs=$(printf %s $(wc -c < $bin)) > $after 2>/dev/null
 			hexdump -C $after > $before && mv $before $after
 			hexdump -C $bin > $before
 			diff -u $before $after

--- a/test/link/test.sh
+++ b/test/link/test.sh
@@ -12,7 +12,7 @@ $RGBASM -o $otemp bank-numbers.asm
 $RGBLINK -o $gbtemp $otemp > $outtemp 2>&1
 diff bank-numbers.out $outtemp
 rc=$(($? || $rc))
-head -c 20 $gbtemp > $otemp 2>&1
+dd if=$gbtemp count=1 bs=20 > $otemp 2>/dev/null
 diff bank-numbers.out.bin $otemp
 rc=$(($? || $rc))
 

--- a/test/link/update-refs.sh
+++ b/test/link/update-refs.sh
@@ -7,7 +7,7 @@ RGBLINK=../../rgblink
 
 $RGBASM -o $otemp bank-numbers.asm
 $RGBLINK -o $gbtemp $otemp > bank-numbers.out 2>&1
-head -c 20 $gbtemp > bank-numbers.out.bin 2>&1
+dd if=$gbtemp count=1 bs=20 > bank-numbers.out.bin 2>/dev/null
 
 $RGBASM -o $otemp section-attributes.asm
 $RGBLINK -l section-attributes.link \


### PR DESCRIPTION
`head -c` is not part of POSIX, and OpenBSD doesn’t implement it.

    $ uname
    OpenBSD
    $ bash run-tests.sh
    /tmp/rgbds/test/asm /tmp/rgbds/test
    --- /tmp/tmp.69HWHUk5t3 Fri Aug 30 22:46:50 2019
    +++ /tmp/tmp.qJp3MCL2IZ Fri Aug 30 22:46:50 2019
    @@ -1,2 +1,6 @@
    -00000000  01                                                |.|
    -00000001
    +00000000  68 65 61 64 3a 20 75 6e  6b 6e 6f 77 6e 20 6f 70  |head: unknown op|
    +00000010  74 69 6f 6e 20 2d 2d 20  63 0a 75 73 61 67 65 3a  |tion -- c.usage:|
    +00000020  20 68 65 61 64 20 5b 2d  63 6f 75 6e 74 20 7c 20  | head [-count | |
    +00000030  2d 6e 20 63 6f 75 6e 74  5d 20 5b 66 69 6c 65 20  |-n count] [file |
    +00000040  2e 2e 2e 5d 0a                                    |...].|
    +00000045
    …