### PR TITLE
Allow 0-byte SECTIONs to be fixed anywhere

### DIFF
--- a/src/link/assign.c
+++ b/src/link/assign.c
@@ -155,6 +155,11 @@ int32_t area_Avail(int32_t bank)
 
 int32_t area_doAlloc(struct sFreeArea *pArea, int32_t org, int32_t size)
 {
+	if (size == 0) {
+		/* 0-byte SECTIONs don't take any room, they can go anywhere */
+		return org;
+	}
+
 	if ((org >= pArea->nOrg)
 	    && ((org + size) <= (pArea->nOrg + pArea->nSize))) {
 


### PR DESCRIPTION
They do not take any room, so they can only be used to define symbols at a given location. I ran into trouble with such a `SECTION` failing to be placed where specified, which doesn't make sense.
This way, it also makes sense to have such a `SECTION` in the middle of another one, but that should be fine, since there's no actual overlap.