### PR TITLE
Reject input that contains null characters

### DIFF
--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -269,6 +269,7 @@ YY_BUFFER_STATE yy_create_buffer(FILE *f)
 	/* Convert all line endings to LF and spaces */
 
 	char *mem = pBuffer->pBuffer;
+	int32_t lineCount = 0;
 
 	while (*mem) {
 		if ((mem[0] == '\\') && (mem[1] == '\"' || mem[1] == '\\')) {
@@ -279,13 +280,20 @@ YY_BUFFER_STATE yy_create_buffer(FILE *f)
 			 || ((mem[0] == '\r') && (mem[1] == '\n'))) {
 				*mem++ = ' ';
 				*mem++ = '\n';
+				lineCount++;
 			/* LF and CR */
 			} else if ((mem[0] == '\n') || (mem[0] == '\r')) {
 				*mem++ = '\n';
+				lineCount++;
 			} else {
 				mem++;
 			}
 		}
+	}
+
+	if (mem != pBuffer->pBuffer + size) {
+		nLineNo = lineCount + 1;
+		fatalerror("Found null character");
 	}
 
 	/* Remove comments */

--- a/test/asm/null-in-macro.out
+++ b/test/asm/null-in-macro.out
@@ -1,2 +1,2 @@
-ERROR: null-in-macro.asm(1):
-    Unterminated MACRO definition.
+ERROR: null-in-macro.asm(2):
+    Found null character


### PR DESCRIPTION
Null characters in the middle of strings interact badly with the RGBDS codebase, which assumes null-terminated strings. There is no reason to support null characters in input source code, so the simplest way to deal with null characters is to reject them early.

Here are some examples of problems that null characters cause. I represented the null character with `NUL`.

Example 1:
```
m: MACRO
printt "NUL"
ENDM

	m
```

This causes the macro to be truncated in the middle of the string literal due to the use of `strlen()` on the macro's contents in `fstk_RunMacro()`. When the lexer attempts to parse the string literal, it goes outside the bounds of the macro buffer.

https://github.com/rednex/rgbds/blob/17b9838c8fdf8f74edf741ac05a45affe0332089/src/asm/fstack.c#L379-L380

Example 2:
```
X = 0
printt "{NUL:X}"
```

This causes an out-of-bounds array access in `yylex_ReadBracketedSymbol()`.
`strchr(acceptedModes, sym[i - 1])` will return a pointer to the null terminator at the end of the `acceptedModes` string if `sym[i - 1]` is 0. Then, `designatedMode - acceptedModes` will be 4, which is outside the bounds of the `formatSpecifiers` array.

https://github.com/rednex/rgbds/blob/17b9838c8fdf8f74edf741ac05a45affe0332089/src/asm/lexer.c#L657-L674

Catching null characters early and then bailing out prevents these and other similar problems.