### PR TITLE
Improve dependency generation

### DIFF
--- a/include/asm/main.h
+++ b/include/asm/main.h
@@ -35,6 +35,7 @@ extern struct sOptions DefaultOptions;
 extern struct sOptions CurrentOptions;
 
 extern FILE *dependfile;
+extern char *tzTargetFileName;
 
 extern bool oGeneratePhonyDeps;
 

--- a/include/asm/main.h
+++ b/include/asm/main.h
@@ -36,7 +36,8 @@ extern struct sOptions CurrentOptions;
 
 extern FILE *dependfile;
 extern char *tzTargetFileName;
-
+extern bool oGeneratedMissingIncludes;
+extern bool oFailedOnMissingInclude;
 extern bool oGeneratePhonyDeps;
 
 void opt_Push(void);

--- a/include/asm/main.h
+++ b/include/asm/main.h
@@ -36,6 +36,8 @@ extern struct sOptions CurrentOptions;
 
 extern FILE *dependfile;
 
+extern bool oGeneratePhonyDeps;
+
 void opt_Push(void);
 void opt_Pop(void);
 void opt_Parse(char *s);

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1004,16 +1004,22 @@ set		: T_LABEL T_POP_SET const
 include		: T_POP_INCLUDE string
 		{
 			fstk_RunInclude($2);
+			if (oFailedOnMissingInclude)
+				YYACCEPT;
 		}
 ;
 
 incbin		: T_POP_INCBIN string
 		{
 			out_BinaryFile($2);
+			if (oFailedOnMissingInclude)
+				YYACCEPT;
 		}
 		| T_POP_INCBIN string comma uconst comma uconst
 		{
 			out_BinaryFileSlice($2, $4, $6);
+			if (oFailedOnMissingInclude)
+				YYACCEPT;
 		}
 ;
 

--- a/src/asm/fstack.c
+++ b/src/asm/fstack.c
@@ -338,7 +338,8 @@ FILE *fstk_FindFile(char *fname, char **incPathUsed)
 
 	if (f != NULL || errno != ENOENT) {
 		if (dependfile) {
-			fprintf(dependfile, "%s: %s\n", tzObjectname, fname);
+			fprintf(dependfile, "%s: %s\n", tzTargetFileName,
+				fname);
 			if (oGeneratePhonyDeps)
 				fprintf(dependfile, "%s:\n", fname);
 		}
@@ -366,8 +367,8 @@ FILE *fstk_FindFile(char *fname, char **incPathUsed)
 
 		if (f != NULL || errno != ENOENT) {
 			if (dependfile) {
-				fprintf(dependfile, "%s: %s\n", tzObjectname,
-					fname);
+				fprintf(dependfile, "%s: %s\n",
+					tzTargetFileName, fname);
 				if (oGeneratePhonyDeps)
 					fprintf(dependfile, "%s:\n", fname);
 			}

--- a/src/asm/fstack.c
+++ b/src/asm/fstack.c
@@ -369,7 +369,7 @@ FILE *fstk_FindFile(char *fname, char **incPathUsed)
 		f = fopen(path, "rb");
 
 		if (f != NULL || errno != ENOENT) {
-			printdep(fname);
+			printdep(path);
 
 			if (incPathUsed)
 				*incPathUsed = IncludePaths[i];

--- a/src/asm/fstack.c
+++ b/src/asm/fstack.c
@@ -337,8 +337,11 @@ FILE *fstk_FindFile(char *fname, char **incPathUsed)
 	f = fopen(fname, "rb");
 
 	if (f != NULL || errno != ENOENT) {
-		if (dependfile)
+		if (dependfile) {
 			fprintf(dependfile, "%s: %s\n", tzObjectname, fname);
+			if (oGeneratePhonyDeps)
+				fprintf(dependfile, "%s:\n", fname);
+		}
 
 		return f;
 	}
@@ -364,8 +367,11 @@ FILE *fstk_FindFile(char *fname, char **incPathUsed)
 		if (f != NULL || errno != ENOENT) {
 			if (dependfile) {
 				fprintf(dependfile, "%s: %s\n", tzObjectname,
-					path);
+					fname);
+				if (oGeneratePhonyDeps)
+					fprintf(dependfile, "%s:\n", fname);
 			}
+
 			if (incPathUsed)
 				*incPathUsed = IncludePaths[i];
 			return f;

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -393,7 +393,10 @@ int main(int argc, char *argv[])
 		case 'M':
 			ep = strchr("GPQT", optarg[0]);
 			if (!ep || !*ep || optarg[1]) {
-				dependfile = fopen(optarg, "w");
+				if (!strcmp("-", optarg))
+					dependfile = stdout;
+				else
+					dependfile = fopen(optarg, "w");
 				if (dependfile == NULL)
 					err(1, "Could not open dependfile %s",
 					    optarg);

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -47,6 +47,8 @@ uint32_t unionStart[128], unionSize[128];
 
 FILE *dependfile;
 
+bool oGeneratePhonyDeps;
+
 /*
  * Option stack
  */
@@ -270,7 +272,7 @@ static void print_usage(void)
 {
 	fputs(
 "Usage: rgbasm [-EhLVvw] [-b chars] [-D name[=value]] [-g chars] [-i path]\n"
-"              [-M depend_file] [-o out_file] [-p pad_value] [-r depth]\n"
+"              [-M depend_file] [-MP] [-o out_file] [-p pad_value] [-r depth]\n"
 "              [-W warning] <file> ...\n"
 "Useful options:\n"
 "    -E, --export-all         export all labels\n"
@@ -306,6 +308,7 @@ int main(int argc, char *argv[])
 	/* yydebug=1; */
 
 	nMaxRecursionDepth = 64;
+	oGeneratePhonyDeps = false;
 
 	DefaultOptions.gbgfx[0] = '0';
 	DefaultOptions.gbgfx[1] = '1';
@@ -361,9 +364,19 @@ int main(int argc, char *argv[])
 			newopt.optimizeloads = false;
 			break;
 		case 'M':
-			dependfile = fopen(optarg, "w");
-			if (dependfile == NULL)
-				err(1, "Could not open dependfile %s", optarg);
+			ep = strchr("P", optarg[0]);
+			if (!ep || !*ep || optarg[1]) {
+				dependfile = fopen(optarg, "w");
+				if (dependfile == NULL)
+					err(1, "Could not open dependfile %s",
+					    optarg);
+			} else {
+				switch (optarg[0]) {
+				case 'P':
+					oGeneratePhonyDeps = true;
+					break;
+				}
+			}
 
 			break;
 		case 'o':

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -332,7 +332,7 @@ int main(int argc, char *argv[])
 
 	nMaxRecursionDepth = 64;
 	oGeneratePhonyDeps = false;
-	oGeneratedMissingIncludes = true;
+	oGeneratedMissingIncludes = false;
 	oFailedOnMissingInclude = false;
 	tzTargetFileName = NULL;
 	size_t nTargetFileNameLen = 0;

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -880,8 +880,13 @@ void out_BinaryFile(char *s)
 	FILE *f;
 
 	f = fstk_FindFile(s, NULL);
-	if (f == NULL)
+	if (f == NULL) {
+		if (oGeneratedMissingIncludes) {
+			oFailedOnMissingInclude = true;
+			return;
+		}
 		err(1, "Unable to open incbin file '%s'", s);
+	}
 
 	int32_t fsize;
 
@@ -915,8 +920,13 @@ void out_BinaryFileSlice(char *s, int32_t start_pos, int32_t length)
 		fatalerror("Number of bytes to read must be greater than zero");
 
 	f = fstk_FindFile(s, NULL);
-	if (f == NULL)
+	if (f == NULL) {
+		if (oGeneratedMissingIncludes) {
+			oFailedOnMissingInclude = true;
+			return;
+		}
 		err(1, "Unable to open included file '%s'", s);
+	}
 
 	int32_t fsize;
 


### PR DESCRIPTION
This PR implements `-MG`, `-MP`, `-MT` and `-MQ` options, mimicking GCC's. See `gcc(1)` or the commit descriptions for what they do.

These options are useful for automatic dependency generation, and I have written a Makefile using them that incrementally generates an ASM file's deps by repeatedly assembling it. This would cause large projects to have a very slow initial build, but this is intended as an option for cases where the overhead is acceptable.

Due to #306's discussion, I have implemented these as short options through special-casing some arguments; they could be implemented more cleanly using `getopt_long_only`, I believe. I decided to use this implementation for the following reasons:
- POSIX-compilant;
- This is not backwards-compatible (if someone had their dep file called `Q` then this will break their workflow), but I don't think this will actually affect anyone;
- It does not consume additional letters for short options.

If this PR gets approved, I will write corresponding entries into the man pages, but I don't want to have to do that and keep it up with changes I would have to make.