### PR TITLE
Have RGBDS' `err` and `warn` output an error message

### DIFF
--- a/src/extern/err.c
+++ b/src/extern/err.c
@@ -14,13 +14,12 @@
 
 void rgbds_vwarn(const char *fmt, va_list ap)
 {
-	fprintf(stderr, "warning");
+	fprintf(stderr, "warning: ");
 	if (fmt) {
-		fputs(": ", stderr);
 		vfprintf(stderr, fmt, ap);
+		fputs(": ", stderr);
 	}
-	putc('\n', stderr);
-	perror(0);
+	perror(NULL);
 }
 
 void rgbds_vwarnx(const char *fmt, va_list ap)
@@ -35,12 +34,12 @@ void rgbds_vwarnx(const char *fmt, va_list ap)
 
 noreturn_ void rgbds_verr(int status, const char *fmt, va_list ap)
 {
-	fprintf(stderr, "error");
+	fprintf(stderr, "error: ");
 	if (fmt) {
-		fputs(": ", stderr);
 		vfprintf(stderr, fmt, ap);
+		fputs(": ", stderr);
 	}
-	putc('\n', stderr);
+	perror(NULL);
 	exit(status);
 }
 

--- a/src/extern/err.c
+++ b/src/extern/err.c
@@ -14,7 +14,7 @@
 
 void rgbds_vwarn(const char *fmt, va_list ap)
 {
-	fprintf(stderr, "warning: ");
+	fputs("warning: ", stderr);
 	if (fmt) {
 		vfprintf(stderr, fmt, ap);
 		fputs(": ", stderr);
@@ -24,7 +24,7 @@ void rgbds_vwarn(const char *fmt, va_list ap)
 
 void rgbds_vwarnx(const char *fmt, va_list ap)
 {
-	fprintf(stderr, "warning");
+	fputs("warning", stderr);
 	if (fmt) {
 		fputs(": ", stderr);
 		vfprintf(stderr, fmt, ap);
@@ -34,7 +34,7 @@ void rgbds_vwarnx(const char *fmt, va_list ap)
 
 noreturn_ void rgbds_verr(int status, const char *fmt, va_list ap)
 {
-	fprintf(stderr, "error: ");
+	fputs("error: ", stderr);
 	if (fmt) {
 		vfprintf(stderr, fmt, ap);
 		fputs(": ", stderr);
@@ -45,7 +45,7 @@ noreturn_ void rgbds_verr(int status, const char *fmt, va_list ap)
 
 noreturn_ void rgbds_verrx(int status, const char *fmt, va_list ap)
 {
-	fprintf(stderr, "error");
+	fputs("error", stderr);
 	if (fmt) {
 		fputs(": ", stderr);
 		vfprintf(stderr, fmt, ap);


### PR DESCRIPTION
The stdlib functions specify that the difference between `err` and `errx` is that the former prints a message obtained with `strerror`.
However, RGBDS' implementation breaks that contract, and `warn`'s puts the added semicolon in the wrong place.