### PR TITLE
Make `BANK(@)` and `BANK("section")` known to RGBASM

### DIFF
--- a/include/asm/constexpr.h
+++ b/include/asm/constexpr.h
@@ -20,6 +20,8 @@ struct ConstExpression {
 };
 
 void constexpr_Symbol(struct ConstExpression *expr, char *tzSym);
+void constexpr_BanksSymbol(struct ConstExpression *expr, char *tzSym);
+void constexpr_BankSection(struct ConstExpression *expr, char *tzSym);
 void constexpr_Number(struct ConstExpression *expr, int32_t i);
 void constexpr_UnaryOp(struct ConstExpression *expr,
 		       int32_t op,

--- a/include/asm/output.h
+++ b/include/asm/output.h
@@ -29,6 +29,7 @@ extern char *tzObjectname;
 
 void out_PrepPass2(void);
 void out_SetFileName(char *s);
+struct Section *out_FindSectionByName(const char *pzName);
 void out_NewSection(char *pzName, uint32_t secttype);
 void out_NewAbsSection(char *pzName, uint32_t secttype, int32_t org,
 		       int32_t bank);

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1394,6 +1394,14 @@ const		: T_ID					{ constexpr_Symbol(&$$, $1); }
 		| T_NUMBER				{ constexpr_Number(&$$, $1); }
 		| T_OP_HIGH '(' const ')'		{ constexpr_UnaryOp(&$$, $1, &$3); }
 		| T_OP_LOW '(' const ')'		{ constexpr_UnaryOp(&$$, $1, &$3); }
+		| T_OP_BANK '(' T_ID ')'
+		{
+			constexpr_BankSymbol(&$$, $3);
+		}
+		| T_OP_BANK '(' string ')'
+		{
+			constexpr_BankSection(&$$, $3);
+		}
 		| string
 		{
 			char *s = $1;

--- a/src/asm/rpn.c
+++ b/src/asm/rpn.c
@@ -182,17 +182,25 @@ void rpn_BankSymbol(struct Expression *expr, char *tzSym)
 		return;
 	}
 
-	if (!sym_isConstant(tzSym)) {
+	if (sym_isConstant(tzSym)) {
+		yyerror("BANK argument must be a relocatable identifier");
+	} else {
 		rpn_Init(expr);
 		sym_Ref(tzSym);
-		expr->isReloc = 1;
 		pushbyte(expr, RPN_BANK_SYM);
-		while (*tzSym)
-			pushbyte(expr, *tzSym++);
+		for (unsigned int i = 0; tzSym[i]; i++)
+			pushbyte(expr, tzSym[i]);
 		pushbyte(expr, 0);
 		expr->nRPNPatchSize += 5;
-	} else {
-		yyerror("BANK argument must be a relocatable identifier");
+
+		/* If the symbol didn't exist, `sym_Ref` created it */
+		struct sSymbol *pSymbol = sym_FindSymbol(tzSym);
+
+		if (pSymbol->pSection && pSymbol->pSection->nBank != -1)
+			/* Symbol's section is known and bank's fixed */
+			expr->nVal = pSymbol->pSection->nBank;
+		else
+			expr->isReloc = 1;
 	}
 }
 
@@ -200,11 +208,16 @@ void rpn_BankSection(struct Expression *expr, char *tzSectionName)
 {
 	rpn_Init(expr);
 
-	/*
-	 * This symbol is not really relocatable, but this makes the assembler
-	 * write this expression as a RPN patch to the object file.
-	 */
-	expr->isReloc = 1;
+	struct Section *pSection = out_FindSectionByName(tzSectionName);
+
+	if (pSection && pSection->nBank != -1)
+		expr->nVal = pSection->nBank;
+	else
+		/*
+		 * This is not really relocatable, but this makes the assembler
+		 * write this expression as a RPN patch to the object file.
+		 */
+		expr->isReloc = 1;
 
 	pushbyte(expr, RPN_BANK_SECT);
 	expr->nRPNPatchSize++;

--- a/src/asm/rpn.c
+++ b/src/asm/rpn.c
@@ -19,6 +19,7 @@
 #include "asm/main.h"
 #include "asm/rpn.h"
 #include "asm/symbol.h"
+#include "asm/output.h"
 #include "asm/warning.h"
 
 #include "linkdefs.h"
@@ -160,11 +161,14 @@ void rpn_BankSelf(struct Expression *expr)
 {
 	rpn_Init(expr);
 
-	/*
-	 * This symbol is not really relocatable, but this makes the assembler
-	 * write this expression as a RPN patch to the object file.
-	 */
-	expr->isReloc = 1;
+	if (pCurrentSection->nBank == -1)
+		/*
+		 * This is not really relocatable, but this makes the assembler
+		 * write this expression as a RPN patch to the object file.
+		 */
+		expr->isReloc = 1;
+	else
+		expr->nVal = pCurrentSection->nBank;
 
 	pushbyte(expr, RPN_BANK_SELF);
 	expr->nRPNPatchSize++;

--- a/test/asm/pc-bank.asm
+++ b/test/asm/pc-bank.asm
@@ -1,0 +1,7 @@
+SECTION "Fixed bank", ROMX,BANK[42]
+X = BANK(@)
+
+SECTION "Something else", OAM
+Y = BANK("Fixed bank")
+
+    PRINTT "@: {X}\nStr: {Y}\n"

--- a/test/asm/pc-bank.asm
+++ b/test/asm/pc-bank.asm
@@ -1,7 +1,11 @@
 SECTION "Fixed bank", ROMX,BANK[42]
+	ldh a, [BANK(@) * 256] ; This should be complained about at assembly time
+
 X = BANK(@)
 
-SECTION "Something else", OAM
+SECTION "Something else", ROMX
 Y = BANK("Fixed bank")
 
     PRINTT "@: {X}\nStr: {Y}\n"
+
+ERR = BANK(@)

--- a/test/asm/pc-bank.out
+++ b/test/asm/pc-bank.out
@@ -1,0 +1,8 @@
+ERROR: pc-bank.asm(2):
+    Source address $2a00 not in $FF00 to $FFFF
+ERROR: pc-bank.asm(11):
+    @'s bank is not known yet
+ERROR: pc-bank.asm(11):
+    Non-constant expression
+@: $2A
+Str: $2A


### PR DESCRIPTION
When possible, anyways.

This could be extended to labels contained within "fixed-bank" sections, maybe?