### PR TITLE
Fix errors in `make develop`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ wwwman:
 
 develop:
 	$Qenv make -j WARNFLAGS="-Werror -Wall -Wextra -Wpedantic \
-		-Wno-sign-compare -Wformat=2 -Wformat-overflow=2 \
+		-Wno-sign-compare -Wformat -Wformat-security -Wformat-overflow=2 \
 		-Wformat-truncation=1 -Wformat-y2k -Wswitch-enum -Wunused \
 		-Wuninitialized -Wunknown-pragmas -Wstrict-overflow=5 \
 		-Wstringop-overflow=4 -Walloc-zero -Wduplicated-cond \

--- a/include/gfx/main.h
+++ b/include/gfx/main.h
@@ -66,8 +66,8 @@ struct RawIndexedImage {
 	uint8_t **data;
 	struct RGBColor *palette;
 	int num_colors;
-	int width;
-	int height;
+	unsigned int width;
+	unsigned int height;
 };
 
 struct GBImage {

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -116,7 +116,7 @@ size_t symvaluetostring(char *dest, size_t maxLength, char *sym,
 			strncpy(dest, write_ptr, maxLength + 1);
 		} else {
 			fullLength = snprintf(dest, maxLength + 1,
-							  mode ? : "$%X",
+							  mode ? mode : "$%X",
 						      value);
 		}
 
@@ -137,7 +137,7 @@ static uint32_t str2int2(char *s, int32_t length)
 	int32_t i;
 	uint32_t r = 0;
 
-	i = ((length - 4) < 0) ? 0 : length - 4;
+	i = length < 4 ? 0 : length - 4;
 	while (i < length) {
 		r <<= 8;
 		r |= (uint8_t)s[i];

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -371,7 +371,7 @@ char *sym_FindMacroArg(int32_t i)
 	if (i == -1)
 		i = MAXMACROARGS + 1;
 
-	assert(i - 1 >= 0);
+	assert(i >= 1);
 
 	assert((size_t)(i - 1)
 	       < sizeof(currentmacroargs) / sizeof(*currentmacroargs));


### PR DESCRIPTION
This PR allows `make develop` to compile successfully. After this is merged, the Makefile could be changed to compile in "develop" mode by default, and another target would compile without the warnings and with optimizations.

`-Wformat-literal` was removed because it makes [this line](https://github.com/ISSOtm/rgbds/blob/f7c2665e14e03499f8b361e2a02834e45f6b01f9/src/asm/asmy.y#L119) an error.