### PR TITLE
Prevent creating labels outside of sections

### DIFF
--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -634,6 +634,10 @@ void sym_AddReloc(char *tzSym)
 
 		nsym->pScope = scope;
 		nsym->pSection = pCurrentSection;
+		/* Labels need to be assigned a section, except PC */
+		if (!pCurrentSection && strcmp(tzSym, "@"))
+			yyerror("Label \"%s\" created outside of a SECTION",
+				tzSym);
 
 		updateSymbolFilename(nsym);
 	}

--- a/test/asm/label-macro-arg.out
+++ b/test/asm/label-macro-arg.out
@@ -1,4 +1,7 @@
 ERROR: label-macro-arg.asm(45) -> label-macro-arg.asm::test_char(31):
+    Label "sizeof_" created outside of a SECTION
+while expanding symbol "VAR_DEF"
+ERROR: label-macro-arg.asm(45) -> label-macro-arg.asm::test_char(31):
     Macro 'something' not defined
 $5
 $6

--- a/test/asm/label-outside-section.asm
+++ b/test/asm/label-outside-section.asm
@@ -1,0 +1,4 @@
+bad:
+SECTION "Test", ROM0
+good:
+    PRINTT "OK!\n"

--- a/test/asm/label-outside-section.out
+++ b/test/asm/label-outside-section.out
@@ -1,0 +1,4 @@
+ERROR: label-outside-section.asm(1):
+    Label "bad" created outside of a SECTION
+error: Assembly aborted (1 errors)!
+OK!

--- a/test/asm/line-continuation-whitespace.out
+++ b/test/asm/line-continuation-whitespace.out
@@ -1,0 +1,3 @@
+ERROR: line-continuation-whitespace.asm(7):
+    Label "foo" created outside of a SECTION
+error: Assembly aborted (1 errors)!

--- a/test/asm/line-continuation.out
+++ b/test/asm/line-continuation.out
@@ -1,0 +1,3 @@
+ERROR: line-continuation.asm(7):
+    Label "foo" created outside of a SECTION
+error: Assembly aborted (1 errors)!

--- a/test/asm/macro-@.out
+++ b/test/asm/macro-@.out
@@ -1,2 +1,4 @@
 ERROR: macro-@.asm(1):
+    Label "foo" created outside of a SECTION
+ERROR: macro-@.asm(1):
     Macro '@' not defined

--- a/test/asm/pops-restore-no-section.out
+++ b/test/asm/pops-restore-no-section.out
@@ -1,2 +1,4 @@
+ERROR: pops-restore-no-section.asm(9):
+    Label "DisallowedContent" created outside of a SECTION
 ERROR: pops-restore-no-section.asm(10):
     Code generation before SECTION directive


### PR DESCRIPTION
This doesn't make sense, and causes RGBLINK to misbehave
Fixes #445.