### PR TITLE
Add support for toggleable warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ rgbasm_obj := \
 	src/asm/rpn.o \
 	src/asm/symbol.o \
 	src/asm/util.o \
+	src/asm/warning.o \
 	src/extern/err.o \
 	src/extern/getopt.o \
 	src/extern/utf8decoder.o \

--- a/include/asm/main.h
+++ b/include/asm/main.h
@@ -40,29 +40,6 @@ void opt_Push(void);
 void opt_Pop(void);
 void opt_Parse(char *s);
 
-/*
- * Used for errors that compromise the whole assembly process by affecting the
- * folliwing code, potencially making the assembler generate errors caused by
- * the first one and unrelated to the code that the assembler complains about.
- * It is also used when the assembler goes into an invalid state (for example,
- * when it fails to allocate memory).
- */
-noreturn_ void fatalerror(const char *fmt, ...);
-
-/*
- * Used for errors that make it impossible to assemble correctly, but don't
- * affect the following code. The code will fail to assemble but the user will
- * get a list of all errors at the end, making it easier to fix all of them at
- * once.
- */
-void yyerror(const char *fmt, ...);
-
-/*
- * Used to warn the user about problems that don't prevent the generation of
- * valid code.
- */
-void warning(const char *fmt, ...);
-
 #define YY_FATAL_ERROR fatalerror
 
 #ifdef YYLMAX

--- a/include/asm/warning.h
+++ b/include/asm/warning.h
@@ -1,0 +1,52 @@
+#ifndef WARNING_H
+#define WARNING_H
+
+extern unsigned int nbErrors;
+
+enum WarningID {
+	WARNING_USER,
+	WARNING_OBSOLETE,
+	WARNING_BUILTIN_ARG,
+	WARNING_LARGE_CONSTANT,
+	WARNING_SHIFT,
+	WARNING_DIV,
+	WARNING_EMPTY_ENTRY,
+	WARNING_LONG_STR,
+
+	NB_WARNINGS,
+
+	/* Warnings past this point are "meta" warnings */
+	WARNING_ALL = NB_WARNINGS,
+	WARNING_EXTRA,
+	WARNING_EVERYTHING,
+
+	NB_WARNINGS_ALL
+#define NB_META_WARNINGS (NB_WARNINGS_ALL - NB_WARNINGS)
+};
+
+void processWarningFlag(char const *flag);
+
+/*
+ * Used to warn the user about problems that don't prevent the generation of
+ * valid code.
+ */
+void warning(enum WarningID id, const char *fmt, ...);
+
+/*
+ * Used for errors that compromise the whole assembly process by affecting the
+ * following code, potencially making the assembler generate errors caused by
+ * the first one and unrelated to the code that the assembler complains about.
+ * It is also used when the assembler goes into an invalid state (for example,
+ * when it fails to allocate memory).
+ */
+noreturn_ void fatalerror(const char *fmt, ...);
+
+/*
+ * Used for errors that make it impossible to assemble correctly, but don't
+ * affect the following code. The code will fail to assemble but the user will
+ * get a list of all errors at the end, making it easier to fix all of them at
+ * once.
+ */
+void yyerror(const char *fmt, ...);
+
+#endif

--- a/src/asm/charmap.c
+++ b/src/asm/charmap.c
@@ -17,6 +17,7 @@
 #include "asm/main.h"
 #include "asm/output.h"
 #include "asm/util.h"
+#include "asm/warning.h"
 
 #define CHARMAP_HASH_SIZE (1 << 9)
 
@@ -39,7 +40,7 @@ static void warnSectionCharmap(void)
 	if (warned)
 		return;
 
-	warning("Using 'charmap' within a section when the current charmap is 'main' is deprecated");
+	warning(WARNING_OBSOLETE, "Using 'charmap' within a section when the current charmap is 'main' is deprecated");
 	warned = true;
 }
 

--- a/src/asm/constexpr.c
+++ b/src/asm/constexpr.c
@@ -17,6 +17,7 @@
 #include "asm/mymath.h"
 #include "asm/rpn.h"
 #include "asm/symbol.h"
+#include "asm/warning.h"
 
 #include "asmy.h"
 
@@ -171,7 +172,7 @@ void constexpr_BinaryOp(struct ConstExpression *expr,
 			break;
 		case T_OP_SHL:
 			if (value1 < 0)
-				warning("Left shift of negative value: %d",
+				warning(WARNING_SHIFT, "Left shift of negative value: %d",
 					value1);
 
 			if (value2 < 0)
@@ -200,7 +201,7 @@ void constexpr_BinaryOp(struct ConstExpression *expr,
 			if (value2 == 0)
 				fatalerror("Division by zero");
 			if (value1 == INT32_MIN && value2 == -1) {
-				warning("Division of min value by -1");
+				warning(WARNING_DIV, "Division of min value by -1");
 				result = INT32_MIN;
 			} else {
 				result = value1 / value2;

--- a/src/asm/fstack.c
+++ b/src/asm/fstack.c
@@ -22,6 +22,7 @@
 #include "asm/main.h"
 #include "asm/output.h"
 #include "asm/symbol.h"
+#include "asm/warning.h"
 
 #include "extern/err.h"
 
@@ -291,7 +292,7 @@ void fstk_DumpToStr(char *buf, size_t buflen)
 		len -= retcode;
 
 	if (!len)
-		warning("File stack dump too long, got truncated");
+		warning(WARNING_LONG_STR, "File stack dump too long, got truncated");
 }
 
 /*

--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -20,6 +20,7 @@
 #include "asm/rpn.h"
 #include "asm/symbol.h"
 #include "asm/symbol.h"
+#include "asm/warning.h"
 
 #include "helpers.h"
 
@@ -126,7 +127,7 @@ static int32_t ascii2bin(char *s)
 		 * the Game Boy tile width, produces a nonsensical result.
 		 */
 		if (size > 8) {
-			warning("Graphics constant '%s' is too long",
+			warning(WARNING_LARGE_CONSTANT, "Graphics constant '%s' is too long",
 				start);
 		}
 	} else {
@@ -143,7 +144,7 @@ static int32_t ascii2bin(char *s)
 		}
 
 		if (overflow)
-			warning("Integer constant '%s' is too large",
+			warning(WARNING_LARGE_CONSTANT, "Integer constant '%s' is too large",
 				start);
 	}
 

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -20,6 +20,7 @@
 #include "asm/lexer.h"
 #include "asm/main.h"
 #include "asm/rpn.h"
+#include "asm/warning.h"
 
 #include "extern/err.h"
 

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -24,6 +24,7 @@
 #include "asm/output.h"
 #include "asm/rpn.h"
 #include "asm/symbol.h"
+#include "asm/warning.h"
 
 #include "extern/err.h"
 

--- a/src/asm/rpn.c
+++ b/src/asm/rpn.c
@@ -19,6 +19,7 @@
 #include "asm/main.h"
 #include "asm/rpn.h"
 #include "asm/symbol.h"
+#include "asm/warning.h"
 
 #include "linkdefs.h"
 
@@ -396,7 +397,8 @@ void rpn_SHL(struct Expression *expr, const struct Expression *src1,
 
 	if (!expr->isReloc) {
 		if (src1->nVal < 0)
-			warning("Left shift of negative value: %d", src1->nVal);
+			warning(WARNING_SHIFT, "Left shift of negative value: %d",
+				src1->nVal);
 
 		if (src2->nVal < 0)
 			fatalerror("Shift by negative value: %d", src2->nVal);
@@ -447,7 +449,7 @@ void rpn_DIV(struct Expression *expr, const struct Expression *src1,
 			fatalerror("Division by zero");
 
 		if (src1->nVal == INT32_MIN && src2->nVal == -1) {
-			warning("Division of min value by -1");
+			warning(WARNING_DIV, "Division of min value by -1");
 			expr->nVal = INT32_MIN;
 		} else {
 			expr->nVal = (src1->nVal / src2->nVal);

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -23,6 +23,7 @@
 #include "asm/mymath.h"
 #include "asm/output.h"
 #include "asm/util.h"
+#include "asm/warning.h"
 
 #include "extern/err.h"
 
@@ -133,7 +134,7 @@ struct sSymbol *createsymbol(char *s)
 	}
 
 	if (snprintf((*ppsym)->tzName, MAXSYMLEN + 1, "%s", s) > MAXSYMLEN)
-		warning("Symbol name is too long: '%s'", s);
+		warning(WARNING_LONG_STR, "Symbol name is too long: '%s'", s);
 
 	(*ppsym)->nValue = 0;
 	(*ppsym)->nType = 0;

--- a/src/asm/util.c
+++ b/src/asm/util.c
@@ -10,6 +10,7 @@
 
 #include "asm/main.h"
 #include "asm/util.h"
+#include "asm/warning.h"
 
 #include "extern/utf8decoder.h"
 

--- a/src/asm/warning.c
+++ b/src/asm/warning.c
@@ -1,0 +1,240 @@
+
+#include <limits.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "asm/fstack.h"
+#include "asm/main.h"
+#include "asm/warning.h"
+
+#include "extern/err.h"
+
+unsigned int nbErrors = 0;
+
+enum WarningState {
+	WARNING_DEFAULT,
+	WARNING_DISABLED,
+	WARNING_ENABLED,
+	WARNING_ERROR
+};
+
+static enum WarningState const defaultWarnings[NB_WARNINGS] = {
+	WARNING_ENABLED,  /* User warnings */
+	WARNING_DISABLED, /* Obsolete things */
+	WARNING_DISABLED, /* Invalid args to builtins */
+	WARNING_DISABLED, /* Constants too large */
+	WARNING_DISABLED, /* Shifting undefined behavior */
+	WARNING_DISABLED, /* Division undefined behavior */
+	WARNING_DISABLED, /* Empty entry in `db`, `dw` or `dl` */
+	WARNING_DISABLED, /* String too long for internal buffers */
+};
+
+static enum WarningState warningStates[NB_WARNINGS];
+
+static bool warningsAreErrors; /* Set if `-Werror` was specified */
+
+static enum WarningState warningState(enum WarningID id)
+{
+	/* Check if warnings are globally disabled */
+	if (!CurrentOptions.warnings)
+		return WARNING_DISABLED;
+
+	/* Get the actual state */
+	enum WarningState state = warningStates[id];
+
+	if (state == WARNING_DEFAULT)
+		/* The state isn't set, grab its default state */
+		state = defaultWarnings[id];
+
+	if (warningsAreErrors && state == WARNING_ENABLED)
+		state = WARNING_ERROR;
+
+	return state;
+}
+
+static char const *warningFlags[NB_WARNINGS_ALL] = {
+	"user",
+	"obsolete",
+	"builtin-args",
+	"large-constant",
+	"shift",
+	"div",
+	"empty-entry",
+	"long-string",
+
+	/* Meta warnings */
+	"all",
+	"extra",
+	"everything" /* Especially useful for testing */
+};
+
+enum MetaWarningCommand {
+	META_WARNING_DONE = NB_WARNINGS
+};
+
+/* Warnings that probably indicate an error */
+static uint8_t const _wallCommands[] = {
+	WARNING_USER,
+	WARNING_BUILTIN_ARG,
+	WARNING_LARGE_CONSTANT,
+	WARNING_EMPTY_ENTRY,
+	WARNING_LONG_STR,
+	META_WARNING_DONE
+};
+
+/* Warnings that are less likely to indicate an error */
+static uint8_t const _wextraCommands[] = {
+	WARNING_OBSOLETE,
+	META_WARNING_DONE
+};
+
+/* Literally everything. Notably useful for testing */
+static uint8_t const _weverythingCommands[] = {
+	WARNING_USER,
+	WARNING_OBSOLETE,
+	WARNING_BUILTIN_ARG,
+	WARNING_LARGE_CONSTANT,
+	WARNING_SHIFT,
+	WARNING_DIV,
+	WARNING_EMPTY_ENTRY,
+	WARNING_LONG_STR,
+	META_WARNING_DONE
+};
+
+static uint8_t const *metaWarningCommands[NB_META_WARNINGS] = {
+	_wallCommands,
+	_wextraCommands,
+	_weverythingCommands
+};
+
+void processWarningFlag(char const *flag)
+{
+	static bool setError = false;
+
+	/* First, try to match against a "meta" warning */
+	for (enum WarningID id = NB_WARNINGS; id < NB_WARNINGS_ALL; id++) {
+		/* TODO: improve the matching performance? */
+		if (!strcmp(flag, warningFlags[id])) {
+			/* We got a match! */
+			uint8_t const *ptr =
+					metaWarningCommands[id - NB_WARNINGS];
+
+			for (;;) {
+				if (*ptr == META_WARNING_DONE)
+					return;
+
+				/* Warning flag, set without override */
+				if (warningStates[*ptr] == WARNING_DEFAULT)
+					warningStates[*ptr] = WARNING_ENABLED;
+				ptr++;
+			}
+		}
+	}
+
+	/* If it's not a meta warning, specially check against `-Werror` */
+	if (!strncmp(flag, "error", strlen("error"))) {
+		char const *errorFlag = flag + strlen("error");
+
+		switch (*errorFlag) {
+		case '\0':
+			/* `-Werror` */
+			warningsAreErrors = true;
+			return;
+
+		case '=':
+			/* `-Werror=XXX */
+			setError = true;
+			processWarningFlag(errorFlag + 1); /* Skip the `=` */
+			setError = false;
+			return;
+
+		/* Otherwise, allow parsing as another flag */
+		}
+	}
+
+	/* Well, it's either a normal warning or a mistake */
+
+	/* Check if this is a negation */
+	bool isNegation = !strncmp(flag, "no-", strlen("no-")) && !setError;
+	char const *rootFlag = isNegation ? flag + strlen("no-") : flag;
+	enum WarningState state = setError ? WARNING_ERROR :
+			isNegation ? WARNING_DISABLED : WARNING_ENABLED;
+
+	/* Try to match the flag against a "normal" flag */
+	for (enum WarningID id = 0; id < NB_WARNINGS; id++) {
+		if (!strcmp(rootFlag, warningFlags[id])) {
+			/* We got a match! */
+			warningStates[id] = state;
+			return;
+		}
+	}
+
+	warnx("Unknown warning `%s`", flag);
+}
+
+void verror(const char *fmt, va_list args, char const *flag)
+{
+	fputs("ERROR: ", stderr);
+	fstk_Dump();
+	fprintf(stderr, flag ? ": [-Werror=%s]\n    " : ":\n    ", flag);
+	vfprintf(stderr, fmt, args);
+	fputc('\n', stderr);
+	fstk_DumpStringExpansions();
+	nbErrors++;
+}
+
+void yyerror(const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	verror(fmt, args, NULL);
+	va_end(args);
+}
+
+noreturn_ void fatalerror(const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	verror(fmt, args, NULL);
+	va_end(args);
+
+	exit(5);
+}
+
+void warning(enum WarningID id, char const *fmt, ...)
+{
+	char const *flag = warningFlags[id];
+	va_list args;
+
+	va_start(args, fmt);
+
+	switch (warningState(id)) {
+	case WARNING_DISABLED:
+		return;
+
+	case WARNING_ERROR:
+		verror(fmt, args, flag);
+		va_end(args);
+		return;
+
+	case WARNING_DEFAULT:
+		abort();
+		/* Not reached */
+
+	case WARNING_ENABLED:
+		break;
+	}
+
+	fputs("warning: ", stderr);
+	fstk_Dump();
+	fprintf(stderr, ": [-W%s]\n    ", flag);
+	vfprintf(stderr, fmt, args);
+	fputc('\n', stderr);
+	fstk_DumpStringExpansions();
+
+	va_end(args);
+}

--- a/test/asm/correct-line-number.out
+++ b/test/asm/correct-line-number.out
@@ -1,4 +1,4 @@
-warning: correct-line-number.asm(5):
+warning: correct-line-number.asm(5): [-Wuser]
     Am I geting ahead of myself?
-warning: correct-line-number.asm(11):
+warning: correct-line-number.asm(11): [-Wuser]
     Hopefully not.

--- a/test/asm/multiple-charmaps.out
+++ b/test/asm/multiple-charmaps.out
@@ -1,4 +1,4 @@
-warning: multiple-charmaps.asm(75):
+warning: multiple-charmaps.asm(75): [-Wobsolete]
     Using 'charmap' within a section when the current charmap is 'main' is deprecated
 ERROR: multiple-charmaps.asm(100) -> multiple-charmaps.asm::new_(7):
     Charmap 'map1' already exists

--- a/test/asm/overflow.out
+++ b/test/asm/overflow.out
@@ -1,14 +1,14 @@
-warning: overflow.asm(24):
+warning: overflow.asm(24): [-Wdiv]
     Division of min value by -1
-warning: overflow.asm(25):
+warning: overflow.asm(25): [-Wdiv]
     Division of min value by -1
-warning: overflow.asm(34):
+warning: overflow.asm(34): [-Wshift]
     Left shift of negative value: -1
-warning: overflow.asm(35):
+warning: overflow.asm(35): [-Wshift]
     Left shift of negative value: -1
-warning: overflow.asm(39):
+warning: overflow.asm(39): [-Wlarge-constant]
     Integer constant '4294967296' is too large
-warning: overflow.asm(42):
+warning: overflow.asm(42): [-Wlarge-constant]
     Graphics constant '`333333333' is too long
 $80000000
 $7FFFFFFF

--- a/test/asm/strsub.out
+++ b/test/asm/strsub.out
@@ -1,18 +1,18 @@
-warning: strsub.asm(13) -> strsub.asm::xstrsub(4):
+warning: strsub.asm(13) -> strsub.asm::xstrsub(4): [-Wbuiltin-args]
     STRSUB: Length too big: 32
-warning: strsub.asm(14) -> strsub.asm::xstrsub(4):
+warning: strsub.asm(14) -> strsub.asm::xstrsub(4): [-Wbuiltin-args]
     STRSUB: Length too big: 300
-warning: strsub.asm(15) -> strsub.asm::xstrsub(4):
+warning: strsub.asm(15) -> strsub.asm::xstrsub(4): [-Wbuiltin-args]
     STRSUB: Position starts at 1
-warning: strsub.asm(15) -> strsub.asm::xstrsub(4):
+warning: strsub.asm(15) -> strsub.asm::xstrsub(4): [-Wbuiltin-args]
     STRSUB: Length too big: 300
-warning: strsub.asm(16) -> strsub.asm::xstrsub(4):
+warning: strsub.asm(16) -> strsub.asm::xstrsub(4): [-Wbuiltin-args]
     STRSUB: Position 4 is past the end of the string
-warning: strsub.asm(17) -> strsub.asm::xstrsub(4):
+warning: strsub.asm(17) -> strsub.asm::xstrsub(4): [-Wbuiltin-args]
     STRSUB: Position 4 is past the end of the string
-warning: strsub.asm(17) -> strsub.asm::xstrsub(4):
+warning: strsub.asm(17) -> strsub.asm::xstrsub(4): [-Wbuiltin-args]
     STRSUB: Length too big: 1
-warning: strsub.asm(20) -> strsub.asm::xstrsub(4):
+warning: strsub.asm(20) -> strsub.asm::xstrsub(4): [-Wbuiltin-args]
     STRSUB: Length too big: 10
 A
 B

--- a/test/asm/test.sh
+++ b/test/asm/test.sh
@@ -10,7 +10,7 @@ rc=0
 for i in *.asm; do
 	for variant in '' '.pipe'; do
 		if [ -z "$variant" ]; then
-			../../rgbasm -o $o $i > $after 2>&1
+			../../rgbasm -Weverything -o $o $i > $after 2>&1
 			desired_output=${i%.asm}.out
 		else
 			# `include-recursion.asm` refers to its own name inside the test code.
@@ -23,7 +23,7 @@ for i in *.asm; do
 			# stdin redirection makes the input an unseekable pipe - a scenario
 			# that's harder to deal with and was broken when the feature was
 			# first implemented.
-			cat $i | ../../rgbasm -o $o - > $after 2>&1
+			cat $i | ../../rgbasm -Weverything -o $o - > $after 2>&1
 
 			# Escape regex metacharacters
 			desired_output=$before


### PR DESCRIPTION
This adds the `-W` flag to allow enabling and disabling warnings, implementing semantics similar to GCC. All relevant code is (should be) in `warning.c`.

Includes:
- `-Werror`and `-Werror=<warning>`
- Two "meta" warnings, `-Wall` and `-Wextra`, plus `-Weverything`
- `-w` is unaffected

Closes #414.