### PR TITLE
Add standard exit codes from `sysexits.h`

### DIFF
--- a/include/asm/warning.h
+++ b/include/asm/warning.h
@@ -39,7 +39,7 @@ void warning(enum WarningID id, const char *fmt, ...);
  * It is also used when the assembler goes into an invalid state (for example,
  * when it fails to allocate memory).
  */
-noreturn_ void fatalerror(const char *fmt, ...);
+noreturn_ void fatalerror(int retcode, const char *fmt, ...);
 
 /*
  * Used for errors that make it impossible to assemble correctly, but don't

--- a/src/asm/charmap.c
+++ b/src/asm/charmap.c
@@ -8,9 +8,10 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sysexits.h>
 
 #include "asm/asm.h"
 #include "asm/charmap.h"
@@ -85,7 +86,7 @@ struct Charmap *charmap_New(const char *name, const char *baseName)
 	*ppCharmap = calloc(1, sizeof(struct Charmap));
 
 	if (*ppCharmap == NULL)
-		fatalerror("Not enough memory for charmap");
+		fatalerror(EX_OSERR, "Not enough memory for charmap");
 
 	struct Charmap *pCharmap = *ppCharmap;
 
@@ -122,7 +123,7 @@ void charmap_Push(void)
 
 	stackEntry = malloc(sizeof(struct CharmapStackEntry));
 	if (stackEntry == NULL)
-		fatalerror("No memory for charmap stack");
+		fatalerror(EX_OSERR, "No memory for charmap stack");
 
 	stackEntry->charmap = currentCharmap;
 	stackEntry->next = charmapStack;
@@ -133,7 +134,7 @@ void charmap_Push(void)
 void charmap_Pop(void)
 {
 	if (charmapStack == NULL)
-		fatalerror("No entries in the charmap stack");
+		fatalerror(EX_DATAERR, "No entries in the charmap stack");
 
 	struct CharmapStackEntry *top = charmapStack;
 
@@ -196,7 +197,7 @@ int32_t charmap_Convert(char **input)
 
 	output = malloc(strlen(*input));
 	if (output == NULL)
-		fatalerror("Not enough memory for buffer");
+		fatalerror(EX_OSERR, "Not enough memory for buffer");
 
 	length = 0;
 

--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sysexits.h>
 
 #include "asm/asm.h"
 #include "asm/constexpr.h"
@@ -177,7 +178,7 @@ uint32_t ParseNumber(char *s, uint32_t size)
 	char dest[256];
 
 	if (size > 255)
-		fatalerror("Number token too long");
+		fatalerror(EX_SOFTWARE, "Number token too long");
 
 	strncpy(dest, s, size);
 	dest[size] = 0;
@@ -202,10 +203,12 @@ char *AppendMacroArg(char whichArg, char *dest, size_t *destIndex)
 	else if (whichArg >= '1' && whichArg <= '9')
 		marg = sym_FindMacroArg(whichArg - '0');
 	else
-		fatalerror("Invalid macro argument '\\%c' in symbol", whichArg);
+		fatalerror(EX_DATAERR, "Invalid macro argument '\\%c' in symbol",
+			   whichArg);
 
 	if (!marg)
-		fatalerror("Macro argument '\\%c' not defined", whichArg);
+		fatalerror(EX_DATAERR, "Macro argument '\\%c' not defined",
+			   whichArg);
 
 	char ch;
 
@@ -218,7 +221,7 @@ char *AppendMacroArg(char whichArg, char *dest, size_t *destIndex)
 		 || ch == '#'
 		 || ch == '.') {
 			if (*destIndex >= MAXSYMLEN)
-				fatalerror("Symbol too long");
+				fatalerror(EX_SOFTWARE, "Symbol too long");
 
 			dest[*destIndex] = ch;
 			(*destIndex)++;
@@ -257,7 +260,7 @@ uint32_t ParseSymbol(char *src, uint32_t size)
 				break;
 		} else {
 			if (destIndex >= MAXSYMLEN)
-				fatalerror("Symbol too long");
+				fatalerror(EX_SOFTWARE, "Symbol too long");
 			dest[destIndex++] = ch;
 		}
 	}

--- a/src/asm/util.c
+++ b/src/asm/util.c
@@ -7,6 +7,7 @@
  */
 
 #include <stdint.h>
+#include <sysexits.h>
 
 #include "asm/main.h"
 #include "asm/util.h"
@@ -35,7 +36,7 @@ int32_t readUTF8Char(char *dest, char *src)
 
 	for (i = 0, state = 0;; i++) {
 		if (decode(&state, &codep, (uint8_t)src[i]) == 1)
-			fatalerror("invalid UTF-8 character");
+			fatalerror(EX_DATAERR, "Invalid UTF-8 character");
 
 		dest[i] = src[i];
 

--- a/src/asm/warning.c
+++ b/src/asm/warning.c
@@ -196,7 +196,7 @@ void yyerror(const char *fmt, ...)
 	va_end(args);
 }
 
-noreturn_ void fatalerror(const char *fmt, ...)
+noreturn_ void fatalerror(int retcode, const char *fmt, ...)
 {
 	va_list args;
 
@@ -204,7 +204,7 @@ noreturn_ void fatalerror(const char *fmt, ...)
 	verror(fmt, args, NULL);
 	va_end(args);
 
-	exit(5);
+	exit(retcode);
 }
 
 void warning(enum WarningID id, char const *fmt, ...)

--- a/src/fix/main.c
+++ b/src/fix/main.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sysexits.h>
 
 #include "extern/err.h"
 #include "extern/getopt.h"
@@ -55,7 +56,7 @@ static void print_usage(void)
 "usage: rgbfix [-CcjsVv] [-f fix_spec] [-i game_id] [-k licensee_str]\n"
 "              [-l licensee_id] [-m mbc_type] [-n rom_version] [-p pad_value]\n"
 "              [-r ram_size] [-t title_str] file\n");
-	exit(1);
+	exit(EX_USAGE);
 }
 
 int main(int argc, char *argv[])
@@ -119,7 +120,7 @@ int main(int argc, char *argv[])
 			setid = true;
 
 			if (strlen(optarg) != 4)
-				errx(1, "Game ID %s must be exactly 4 characters",
+				errx(EX_USAGE, "Game ID %s must be exactly 4 characters",
 				     optarg);
 
 			id = optarg;
@@ -131,7 +132,7 @@ int main(int argc, char *argv[])
 			setnewlicensee = true;
 
 			if (strlen(optarg) != 2)
-				errx(1, "New licensee code %s is not the correct length of 2 characters",
+				errx(EX_USAGE, "New licensee code %s is not the correct length of 2 characters",
 				     optarg);
 
 			newlicensee = optarg;
@@ -141,10 +142,10 @@ int main(int argc, char *argv[])
 
 			licensee = strtoul(optarg, &ep, 0);
 			if (optarg[0] == '\0' || *ep != '\0')
-				errx(1, "Invalid argument for option 'l'");
+				errx(EX_USAGE, "Invalid argument for option 'l'");
 
 			if (licensee < 0 || licensee > 0xFF)
-				errx(1, "Argument for option 'l' must be between 0 and 255");
+				errx(EX_USAGE, "Argument for option 'l' must be between 0 and 255");
 
 			break;
 		case 'm':
@@ -152,10 +153,10 @@ int main(int argc, char *argv[])
 
 			cartridge = strtoul(optarg, &ep, 0);
 			if (optarg[0] == '\0' || *ep != '\0')
-				errx(1, "Invalid argument for option 'm'");
+				errx(EX_USAGE, "Invalid argument for option 'm'");
 
 			if (cartridge < 0 || cartridge > 0xFF)
-				errx(1, "Argument for option 'm' must be between 0 and 255");
+				errx(EX_USAGE, "Argument for option 'm' must be between 0 and 255");
 
 			break;
 		case 'n':
@@ -164,10 +165,10 @@ int main(int argc, char *argv[])
 			version = strtoul(optarg, &ep, 0);
 
 			if (optarg[0] == '\0' || *ep != '\0')
-				errx(1, "Invalid argument for option 'n'");
+				errx(EX_USAGE, "Invalid argument for option 'n'");
 
 			if (version < 0 || version > 0xFF)
-				errx(1, "Argument for option 'n' must be between 0 and 255");
+				errx(EX_USAGE, "Argument for option 'n' must be between 0 and 255");
 
 			break;
 		case 'p':
@@ -176,10 +177,10 @@ int main(int argc, char *argv[])
 			padvalue = strtoul(optarg, &ep, 0);
 
 			if (optarg[0] == '\0' || *ep != '\0')
-				errx(1, "Invalid argument for option 'p'");
+				errx(EX_USAGE, "Invalid argument for option 'p'");
 
 			if (padvalue < 0 || padvalue > 0xFF)
-				errx(1, "Argument for option 'p' must be between 0 and 255");
+				errx(EX_USAGE, "Argument for option 'p' must be between 0 and 255");
 
 			break;
 		case 'r':
@@ -188,10 +189,10 @@ int main(int argc, char *argv[])
 			ramsize = strtoul(optarg, &ep, 0);
 
 			if (optarg[0] == '\0' || *ep != '\0')
-				errx(1, "Invalid argument for option 'r'");
+				errx(EX_USAGE, "Invalid argument for option 'r'");
 
 			if (ramsize < 0 || ramsize > 0xFF)
-				errx(1, "Argument for option 'r' must be between 0 and 255");
+				errx(EX_USAGE, "Argument for option 'r' must be between 0 and 255");
 
 			break;
 		case 's':
@@ -201,7 +202,7 @@ int main(int argc, char *argv[])
 			settitle = true;
 
 			if (strlen(optarg) > 16)
-				errx(1, "Title \"%s\" is greater than the maximum of 16 characters",
+				errx(EX_USAGE, "Title \"%s\" is greater than the maximum of 16 characters",
 				     optarg);
 
 			if (strlen(optarg) == 16)
@@ -237,7 +238,7 @@ int main(int argc, char *argv[])
 	rom = fopen(argv[argc - 1], "rb+");
 
 	if (rom == NULL)
-		err(1, "Error opening file %s", argv[argc - 1]);
+		err(EX_NOINPUT, "Error opening file %s", argv[argc - 1]);
 
 	/*
 	 * Read ROM header
@@ -248,10 +249,10 @@ int main(int argc, char *argv[])
 	uint8_t header[0x50];
 
 	if (fseek(rom, 0x100, SEEK_SET) != 0)
-		err(1, "Could not locate ROM header");
+		err(EX_NOINPUT, "Could not locate ROM header");
 	if (fread(header, sizeof(uint8_t), sizeof(header), rom)
 	    != sizeof(header))
-		err(1, "Could not read ROM header");
+		err(EX_NOINPUT, "Could not read ROM header");
 
 	if (fixlogo || trashlogo) {
 		/*
@@ -395,11 +396,11 @@ int main(int argc, char *argv[])
 		uint8_t *buf;
 
 		if (fseek(rom, 0, SEEK_END) != 0)
-			err(1, "Could not pad ROM file");
+			err(EX_IOERR, "Could not pad ROM file");
 
 		romsize = ftell(rom);
 		if (romsize == -1)
-			err(1, "Could not pad ROM file");
+			err(EX_IOERR, "Could not pad ROM file");
 
 		newsize = 0x8000;
 
@@ -414,11 +415,11 @@ int main(int argc, char *argv[])
 
 		buf = malloc(newsize - romsize);
 		if (buf == NULL)
-			errx(1, "Couldn't allocate memory for padded ROM.");
+			errx(EX_OSERR, "Couldn't allocate memory for padded ROM.");
 
 		memset(buf, padvalue, newsize - romsize);
 		if (fwrite(buf, 1, newsize - romsize, rom) != newsize - romsize)
-			err(1, "Could not pad ROM file");
+			err(EX_IOERR, "Could not pad ROM file");
 
 		header[0x48] = headbyte;
 
@@ -488,11 +489,11 @@ int main(int argc, char *argv[])
 	 */
 
 	if (fseek(rom, 0x100, SEEK_SET) != 0)
-		err(1, "Could not locate header for writing");
+		err(EX_IOERR, "Could not locate header for writing");
 
 	if (fwrite(header, sizeof(uint8_t), sizeof(header), rom)
 	    != sizeof(header))
-		err(1, "Could not write modified ROM header");
+		err(EX_IOERR, "Could not write modified ROM header");
 
 	if (fixglobalsum || trashglobalsum) {
 		/*
@@ -502,7 +503,7 @@ int main(int argc, char *argv[])
 		uint16_t globalcksum = 0;
 
 		if (fseek(rom, 0, SEEK_SET) != 0)
-			err(1, "Could not start calculating global checksum");
+			err(EX_IOERR, "Could not start calculating global checksum");
 
 		int i = 0;
 		int byte;
@@ -514,7 +515,7 @@ int main(int argc, char *argv[])
 		}
 
 		if (ferror(rom))
-			err(1, "Could not calculate global checksum");
+			err(EX_IOERR, "Could not calculate global checksum");
 
 		if (trashglobalsum)
 			globalcksum = ~globalcksum;
@@ -523,11 +524,11 @@ int main(int argc, char *argv[])
 		fputc(globalcksum >> 8, rom);
 		fputc(globalcksum & 0xFF, rom);
 		if (ferror(rom))
-			err(1, "Could not write global checksum");
+			err(EX_IOERR, "Could not write global checksum");
 	}
 
 	if (fclose(rom) != 0)
-		err(1, "Could not complete ROM write");
+		err(EX_IOERR, "Could not complete ROM write");
 
 	return 0;
 }

--- a/src/gfx/gb.c
+++ b/src/gfx/gb.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sysexits.h>
 
 #include "gfx/main.h"
 
@@ -62,7 +63,7 @@ void output_file(const struct Options *opts, const struct GBImage *gb)
 
 	f = fopen(opts->outfile, "wb");
 	if (!f)
-		err(1, "Opening output file '%s' failed", opts->outfile);
+		err(EX_IOERR, "Opening output file '%s' failed", opts->outfile);
 
 	fwrite(gb->data, 1, gb->size - gb->trim * 8 * depth, f);
 
@@ -261,7 +262,8 @@ void output_tilemap_file(const struct Options *opts,
 
 	f = fopen(opts->tilemapfile, "wb");
 	if (!f)
-		err(1, "Opening tilemap file '%s' failed", opts->tilemapfile);
+		err(EX_IOERR, "Opening tilemap file '%s' failed",
+		    opts->tilemapfile);
 
 	fwrite(tilemap->data, 1, tilemap->size, f);
 	fclose(f);
@@ -277,7 +279,8 @@ void output_attrmap_file(const struct Options *opts,
 
 	f = fopen(opts->attrmapfile, "wb");
 	if (!f)
-		err(1, "Opening attrmap file '%s' failed", opts->attrmapfile);
+		err(EX_IOERR, "Opening attrmap file '%s' failed",
+		    opts->attrmapfile);
 
 	fwrite(attrmap->data, 1, attrmap->size, f);
 	fclose(f);
@@ -319,7 +322,8 @@ void output_palette_file(const struct Options *opts,
 
 	f = fopen(opts->palfile, "wb");
 	if (!f)
-		err(1, "Opening palette file '%s' failed", opts->palfile);
+		err(EX_IOERR, "Opening palette file '%s' failed",
+		    opts->palfile);
 
 	for (i = 0; i < raw_image->num_colors; i++) {
 		int r = raw_image->palette[i].red;

--- a/src/gfx/main.c
+++ b/src/gfx/main.c
@@ -9,6 +9,7 @@
 #include <png.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sysexits.h>
 
 #include "gfx/main.h"
 
@@ -55,7 +56,7 @@ static void print_usage(void)
 	printf(
 "usage: rgbgfx [-ADFfhmPTuVv] [-o outfile] [-a attrmap] [-d #] [-p palfile]\n"
 "              [-t tilemap] [-x #] infile\n");
-	exit(1);
+	exit(EX_USAGE);
 }
 
 int main(int argc, char *argv[])
@@ -155,7 +156,7 @@ int main(int argc, char *argv[])
 	opts.infile = argv[argc - 1];
 
 	if (depth != 1 && depth != 2)
-		errx(1, "Depth option must be either 1 or 2.");
+		errx(EX_USAGE, "Depth option must be either 1 or 2.");
 
 	colors = 1 << depth;
 
@@ -188,17 +189,17 @@ int main(int argc, char *argv[])
 		opts.trim = png_options.trim;
 
 	if (raw_image->width % 8) {
-		errx(1, "Input PNG file %s not sized correctly. The image's width must be a multiple of 8.",
+		errx(EX_DATAERR, "Input PNG file %s not sized correctly. The image's width must be a multiple of 8.",
 		     opts.infile);
 	}
 	if (raw_image->width / 8 > 1 && raw_image->height % 8) {
-		errx(1, "Input PNG file %s not sized correctly. If the image is more than 1 tile wide, its height must be a multiple of 8.",
+		errx(EX_DATAERR, "Input PNG file %s not sized correctly. If the image is more than 1 tile wide, its height must be a multiple of 8.",
 		     opts.infile);
 	}
 
 	if (opts.trim &&
 	    opts.trim > (raw_image->width / 8) * (raw_image->height / 8) - 1) {
-		errx(1, "Trim (%i) for input raw_image file '%s' too large (max: %i)",
+		errx(EX_DATAERR, "Trim (%i) for input raw_image file '%s' too large (max: %i)",
 		     opts.trim, opts.infile,
 		     (raw_image->width / 8) * (raw_image->height / 8) - 1);
 	}

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -1,9 +1,10 @@
 
-#include <stdint.h>
+#include <assert.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
+#include <sysexits.h>
 
 #include "hashmap.h"
 #include "extern/err.h"
@@ -46,7 +47,7 @@ bool hash_AddElement(HashMap map, char const *key, void *element)
 	struct HashMapEntry *newEntry = malloc(sizeof(*newEntry));
 
 	if (!newEntry)
-		err(1, "%s: Failed to allocate new entry", __func__);
+		err(EX_OSERR, "%s: Failed to allocate new entry", __func__);
 
 	newEntry->hash = hashedKey >> HALF_HASH_NB_BITS;
 	newEntry->key = key;

--- a/src/link/main.c
+++ b/src/link/main.c
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <sysexits.h>
 
 #include "link/object.h"
 #include "link/symbol.h"
@@ -43,7 +44,7 @@ FILE *openFile(char const *fileName, char const *mode)
 	FILE *file = fopen(fileName, mode);
 
 	if (!file)
-		err(1, "Could not open file \"%s\"", fileName);
+		err(EX_IOERR, "Could not open file \"%s\"", fileName);
 
 	return file;
 }
@@ -127,9 +128,9 @@ int main(int argc, char *argv[])
 		case 'p':
 			value = strtoul(optarg, &endptr, 0);
 			if (optarg[0] == '\0' || *endptr != '\0')
-				errx(1, "Invalid argument for option 'p'");
+				errx(EX_USAGE, "Invalid argument for option 'p'");
 			if (value > 0xFF)
-				errx(1, "Argument for 'p' must be a byte (between 0 and 0xFF)");
+				errx(EX_USAGE, "Argument for 'p' must be a byte (between 0 and 0xFF)");
 			padValue = value;
 			break;
 		case 's':
@@ -151,7 +152,7 @@ int main(int argc, char *argv[])
 			break;
 		default:
 			printUsage();
-			exit(1);
+			exit(EX_USAGE);
 		}
 	}
 
@@ -161,7 +162,7 @@ int main(int argc, char *argv[])
 	if (curArgIndex == argc) {
 		fprintf(stderr, "No input files");
 		printUsage();
-		exit(1);
+		exit(EX_USAGE);
 	}
 
 	/* Patch the size array depending on command-line options */

--- a/src/link/symbol.c
+++ b/src/link/symbol.c
@@ -1,5 +1,6 @@
 
 #include <stdbool.h>
+#include <sysexits.h>
 
 #include "link/symbol.h"
 #include "link/main.h"
@@ -33,7 +34,7 @@ void sym_AddSymbol(struct Symbol *symbol)
 	struct Symbol *other = hash_GetElement(symbols, symbol->name);
 
 	if (other)
-		errx(1, "\"%s\" both in %s from %s(%d) and in %s from %s(%d)",
+		errx(EX_DATAERR, "\"%s\" both in %s from %s(%d) and in %s from %s(%d)",
 		     symbol->name,
 		     symbol->objFileName, symbol->fileName, symbol->lineNo,
 		      other->objFileName,  other->fileName,  other->lineNo);


### PR DESCRIPTION
RGBDS currently mostly exits with a single error code, which isn't very meaningful. This PR adds diversity into them, taken from a non-standard but conventional include file. It doesn't add much, but is probably nice to have.

The include file is non-standard, but in practice it's present in [glibc](https://sourceware.org/git/?p=glibc.git;a=blob;f=misc/sysexits.h;h=37246b6e752fad0122d842bd479b59d127975bb8;hb=HEAD), [FreeBSD](https://github.com/freebsd/freebsd/blob/master/include/sysexits.h), [OpenBSD](https://github.com/openbsd/src/blob/master/include/sysexits.h), [NetBSD](https://github.com/NetBSD/src/blob/trunk/include/sysexits.h) and [musl](https://git.musl-libc.org/cgit/musl/tree/include/sysexits.h), so I believe it's safe to consider de-facto standard.