### PR TITLE
Overhaul the symbol system

### DIFF
--- a/include/asm/output.h
+++ b/include/asm/output.h
@@ -40,7 +40,6 @@ void out_AbsByteGroup(char *s, int32_t length);
 void out_RelByte(struct Expression *expr);
 void out_RelWord(struct Expression *expr);
 void out_PCRelByte(struct Expression *expr);
-void out_CheckErrors(void);
 void out_WriteObject(void);
 void out_Skip(int32_t skip);
 void out_BinaryFile(char *s);

--- a/include/asm/symbol.h
+++ b/include/asm/symbol.h
@@ -9,20 +9,33 @@
 #ifndef RGBDS_SYMBOL_H
 #define RGBDS_SYMBOL_H
 
+#include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "types.h"
 
 #define HASHSIZE	(1 << 16)
 #define MAXSYMLEN	256
 
+enum SymbolType {
+	SYM_LABEL,
+	SYM_EQU,
+	SYM_SET,
+	SYM_MACRO,
+	SYM_EQUS,
+	SYM_REF // Forward reference to a label
+};
+
 struct sSymbol {
 	char tzName[MAXSYMLEN + 1];
-	int32_t nValue;
-	uint32_t nType;
+	enum SymbolType type;
+	bool isConstant; /* Whether the symbol's value is currently known */
+	bool isExported; /* Whether the symbol is to be exported */
 	struct sSymbol *pScope;
 	struct sSymbol *pNext;
 	struct Section *pSection;
+	int32_t nValue;
 	uint32_t ulMacroSize;
 	char *pMacro;
 	int32_t (*Callback)(struct sSymbol *self);
@@ -30,26 +43,49 @@ struct sSymbol {
 	uint32_t nFileLine; /* Line where the symbol was defined. */
 };
 
-/* Symbol will be relocated during linking, it's absolute value is unknown */
+static inline bool sym_IsDefined(struct sSymbol const *sym)
+{
+	return sym->type != SYM_REF;
+}
+static inline bool sym_IsConstant(struct sSymbol const *sym)
+{
+	return sym->isConstant;
+}
+static inline bool sym_IsNumeric(struct sSymbol const *sym)
+{
+	return sym->type == SYM_LABEL || sym->type == SYM_EQU
+	    || sym->type == SYM_SET;
+}
+static inline bool sym_IsLocal(struct sSymbol const *sym)
+{
+	return (sym->type == SYM_LABEL || sym->type == SYM_REF)
+		&& strchr(sym->tzName, '.');
+}
+static inline bool sym_IsExported(struct sSymbol const *sym)
+{
+	return sym->isExported;
+}
+/* Symbol will be relocated during linking, it's absolute value is unknown
 #define SYMF_RELOC	0x001
-/* Symbol is defined using EQU, will not be changed during linking */
+Symbol is defined using EQU, will not be changed during linking
 #define SYMF_EQU	0x002
-/* Symbol is (re)defined using SET, will not be changed during linking */
+Symbol is (re)defined using SET, will not be changed during linking
 #define SYMF_SET	0x004
-/* Symbol should be exported */
+Symbol should be exported
 #define SYMF_EXPORT	0x008
-/* Symbol referenced in RPN expression */
+Symbol referenced in RPN expression
 #define SYMF_REF	0x010
-/* Symbol is a local symbol */
+Symbol is a local symbol
 #define SYMF_LOCAL	0x020
-/* Symbol has been defined, not only referenced */
+Symbol has been defined, not only referenced
 #define SYMF_DEFINED	0x040
-/* Symbol is a macro */
+Symbol is a macro
 #define SYMF_MACRO	0x080
-/* Symbol is a stringsymbol */
+Symbol is a stringsymbol
 #define SYMF_STRING	0x100
-/* Symbol has a constant value, will not be changed during linking */
+Symbol has a constant value, will not be changed during linking
 #define SYMF_CONST	0x200
+*/
 
 uint32_t sym_CalcHash(const char *s);
 void sym_SetExportAll(uint8_t set);
@@ -67,22 +103,18 @@ void sym_AddEqu(char *tzSym, int32_t value);
 void sym_AddSet(char *tzSym, int32_t value);
 void sym_Init(void);
 uint32_t sym_GetConstantValue(char *s);
-uint32_t sym_isConstant(char *s);
 struct sSymbol *sym_FindSymbol(char *tzName);
 char *sym_FindMacroArg(int32_t i);
-char *sym_GetStringValue(char *tzSym);
+char *sym_GetStringValue(struct sSymbol const *sym);
 void sym_UseCurrentMacroArgs(void);
 void sym_SetMacroArgID(uint32_t nMacroCount);
-uint32_t sym_isString(char *tzSym);
 void sym_AddMacro(char *tzSym, int32_t nDefLineNo);
 void sym_Ref(char *tzSym);
 void sym_ShiftCurrentMacroArgs(void);
 void sym_AddString(char *tzSym, char *tzValue);
 uint32_t sym_GetDefinedValue(char *s);
-uint32_t sym_isDefined(char *tzName);
 void sym_Purge(char *tzName);
-uint32_t sym_isConstDefined(char *tzName);
-int32_t sym_IsRelocDiffDefined(char *tzSym1, char *tzSym2);
+bool sym_IsRelocDiffDefined(char *tzSym1, char *tzSym2);
 
 /* Functions to save and restore the current symbol scope. */
 struct sSymbol *sym_GetCurrentSymbolScope(void);

--- a/include/link/symbol.h
+++ b/include/link/symbol.h
@@ -19,7 +19,7 @@
 struct Symbol {
 	/* Info contained in the object files */
 	char *name;
-	enum SymbolType type;
+	enum ExportLevel type;
 	char const *objFileName;
 	char *fileName;
 	int32_t lineNo;

--- a/include/linkdefs.h
+++ b/include/linkdefs.h
@@ -59,7 +59,7 @@ enum SectionType {
 	SECTTYPE_INVALID
 };
 
-enum SymbolType {
+enum ExportLevel {
 	SYMTYPE_LOCAL,
 	SYMTYPE_IMPORT,
 	SYMTYPE_EXPORT

--- a/src/asm/globlex.c
+++ b/src/asm/globlex.c
@@ -277,20 +277,24 @@ uint32_t ParseSymbol(char *src, uint32_t size)
 		yyunputstr(rest);
 
 	/* If the symbol is an EQUS, expand it */
-	if (!oDontExpandStrings && sym_isString(dest)) {
-		char *s;
+	if (!oDontExpandStrings) {
+		struct sSymbol const *sym = sym_FindSymbol(dest);
 
-		lex_BeginStringExpansion(dest);
+		if (sym && sym->type == SYM_EQUS) {
+			char *s;
 
-		/* Feed the symbol's contents into the buffer */
-		yyunputstr(s = sym_GetStringValue(dest));
+			lex_BeginStringExpansion(dest);
 
-		/* Lines inserted this way shall not increase nLineNo */
-		while (*s) {
-			if (*s++ == '\n')
-				nLineNo--;
+			/* Feed the symbol's contents into the buffer */
+			yyunputstr(s = sym_GetStringValue(sym));
+
+			/* Lines inserted this way shall not increase nLineNo */
+			while (*s) {
+				if (*s++ == '\n')
+					nLineNo--;
+			}
+			return 0;
 		}
-		return 0;
 	}
 
 	strcpy(yylval.tzSym, dest);

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -471,7 +471,6 @@ int main(int argc, char *argv[])
 			       (int)(60 / timespent * nTotalLines));
 	}
 
-	out_CheckErrors();
 	/* If no path specified, don't write file */
 	if (tzObjectname != NULL)
 		out_WriteObject();

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -527,34 +527,6 @@ static void checksectionoverflow(uint32_t delta_size)
 }
 
 /*
- * Check for errors that could happen while writing an object file
- * This is important as out_WriteObject is skipped entirely when `-o` is omitted
- * Therefore, errors such as memory allocations still should be handled in
- * out_WriteObject and not here
- */
-void out_CheckErrors(void)
-{
-	/* Local symbols cannot be imported from elsewhere */
-	struct PatchSymbol *pSym = pPatchSymbols;
-
-	while (pSym) {
-		struct sSymbol const *pSymbol = pSym->pSymbol;
-
-		if (!(pSymbol->nType & SYMF_DEFINED)
-		   && pSymbol->nType & SYMF_LOCAL) {
-			char const *name = pSymbol->tzName;
-			char const *localPtr = strchr(name, '.');
-
-			if (localPtr)
-				name = localPtr;
-			errx(1, "%s(%u) : '%s' not defined",
-			     pSymbol->tzFileName, pSymbol->nFileLine, name);
-		}
-		pSym = pSym->pNext;
-	}
-}
-
-/*
  * Write an objectfile
  */
 void out_WriteObject(void)

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -45,7 +45,7 @@ struct Patch {
 
 struct PatchSymbol {
 	uint32_t ID;
-	struct sSymbol *pSymbol;
+	struct sSymbol const *pSymbol;
 	struct PatchSymbol *pNext;
 	struct PatchSymbol *pBucketNext; /* next symbol in hash table bucket */
 };
@@ -186,7 +186,7 @@ static void fputlong(uint32_t i, FILE *f)
 /*
  * Write a NULL-terminated string to a file
  */
-static void fputstring(char *s, FILE *f)
+static void fputstring(char const *s, FILE *f)
 {
 	while (*s)
 		fputc(*s++, f);
@@ -259,7 +259,7 @@ static void writesection(struct Section *pSect, FILE *f)
 /*
  * Write a symbol to a file
  */
-static void writesymbol(struct sSymbol *pSym, FILE *f)
+static void writesymbol(struct sSymbol const *pSym, FILE *f)
 {
 	uint32_t type;
 	uint32_t offset;
@@ -538,12 +538,12 @@ void out_CheckErrors(void)
 	struct PatchSymbol *pSym = pPatchSymbols;
 
 	while (pSym) {
-		struct sSymbol *pSymbol = pSym->pSymbol;
+		struct sSymbol const *pSymbol = pSym->pSymbol;
 
 		if (!(pSymbol->nType & SYMF_DEFINED)
 		   && pSymbol->nType & SYMF_LOCAL) {
-			char *name = pSymbol->tzName;
-			char *localPtr = strchr(name, '.');
+			char const *name = pSymbol->tzName;
+			char const *localPtr = strchr(name, '.');
 
 			if (localPtr)
 				name = localPtr;

--- a/src/asm/rpn.c
+++ b/src/asm/rpn.c
@@ -143,7 +143,9 @@ void rpn_Number(struct Expression *expr, uint32_t i)
 
 void rpn_Symbol(struct Expression *expr, char *tzSym)
 {
-	if (!sym_isConstant(tzSym)) {
+	struct sSymbol *sym = sym_FindSymbol(tzSym);
+
+	if (!sym || !sym_IsConstant(sym)) {
 		rpn_Init(expr);
 		sym_Ref(tzSym);
 		expr->isReloc = 1;
@@ -176,13 +178,15 @@ void rpn_BankSelf(struct Expression *expr)
 
 void rpn_BankSymbol(struct Expression *expr, char *tzSym)
 {
+	struct sSymbol const *sym = sym_FindSymbol(tzSym);
+
 	/* The @ symbol is treated differently. */
-	if (sym_FindSymbol(tzSym) == pPCSymbol) {
+	if (sym == pPCSymbol) {
 		rpn_BankSelf(expr);
 		return;
 	}
 
-	if (sym_isConstant(tzSym)) {
+	if (sym && sym_IsConstant(sym)) {
 		yyerror("BANK argument must be a relocatable identifier");
 	} else {
 		rpn_Init(expr);

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -493,12 +493,10 @@ void sym_AddEqu(char *tzSym, int32_t value)
 {
 	struct sSymbol *nsym = createNonrelocSymbol(tzSym);
 
-	if (nsym) {
-		nsym->nValue = value;
-		nsym->nType |= SYMF_EQU | SYMF_DEFINED | SYMF_CONST;
-		nsym->pScope = NULL;
-		updateSymbolFilename(nsym);
-	}
+	nsym->nValue = value;
+	nsym->nType |= SYMF_EQU | SYMF_DEFINED | SYMF_CONST;
+	nsym->pScope = NULL;
+	updateSymbolFilename(nsym);
 }
 
 /*
@@ -517,18 +515,16 @@ void sym_AddString(char *tzSym, char *tzValue)
 {
 	struct sSymbol *nsym = createNonrelocSymbol(tzSym);
 
-	if (nsym) {
-		nsym->pMacro = malloc(strlen(tzValue) + 1);
+	nsym->pMacro = malloc(strlen(tzValue) + 1);
 
-		if (nsym->pMacro != NULL)
-			strcpy(nsym->pMacro, tzValue);
-		else
-			fatalerror("No memory for string equate");
+	if (nsym->pMacro != NULL)
+		strcpy(nsym->pMacro, tzValue);
+	else
+		fatalerror("No memory for string equate");
 
-		nsym->nType |= SYMF_STRING | SYMF_DEFINED;
-		nsym->ulMacroSize = strlen(tzValue);
-		nsym->pScope = NULL;
-	}
+	nsym->nType |= SYMF_STRING | SYMF_DEFINED;
+	nsym->ulMacroSize = strlen(tzValue);
+	nsym->pScope = NULL;
 }
 
 /*
@@ -570,12 +566,10 @@ void sym_AddSet(char *tzSym, int32_t value)
 		nsym = createsymbol(tzSym);
 	}
 
-	if (nsym) {
-		nsym->nValue = value;
-		nsym->nType |= SYMF_SET | SYMF_DEFINED | SYMF_CONST;
-		nsym->pScope = NULL;
-		updateSymbolFilename(nsym);
-	}
+	nsym->nValue = value;
+	nsym->nType |= SYMF_SET | SYMF_DEFINED | SYMF_CONST;
+	nsym->pScope = NULL;
+	updateSymbolFilename(nsym);
 }
 
 /*
@@ -634,24 +628,22 @@ void sym_AddReloc(char *tzSym)
 		nsym = createsymbol(tzSym);
 	}
 
-	if (nsym) {
-		nsym->nValue = nPC;
-		nsym->nType |= SYMF_RELOC | SYMF_DEFINED;
-		if (localPtr)
-			nsym->nType |= SYMF_LOCAL;
+	nsym->nValue = nPC;
+	nsym->nType |= SYMF_RELOC | SYMF_DEFINED;
+	if (localPtr)
+		nsym->nType |= SYMF_LOCAL;
 
-		if (exportall)
-			nsym->nType |= SYMF_EXPORT;
+	if (exportall)
+		nsym->nType |= SYMF_EXPORT;
 
-		nsym->pScope = scope;
-		nsym->pSection = pCurrentSection;
-		/* Labels need to be assigned a section, except PC */
-		if (!pCurrentSection && strcmp(tzSym, "@"))
-			yyerror("Label \"%s\" created outside of a SECTION",
-				tzSym);
+	nsym->pScope = scope;
+	nsym->pSection = pCurrentSection;
+	/* Labels need to be assigned a section, except PC */
+	if (!pCurrentSection && strcmp(tzSym, "@"))
+		yyerror("Label \"%s\" created outside of a SECTION",
+			tzSym);
 
-		updateSymbolFilename(nsym);
-	}
+	updateSymbolFilename(nsym);
 
 	pScope = findsymbol(tzSym, scope);
 }
@@ -713,8 +705,7 @@ void sym_Export(char *tzSym)
 	if (nsym == NULL)
 		nsym = createsymbol(tzSym);
 
-	if (nsym)
-		nsym->nType |= SYMF_EXPORT;
+	nsym->nType |= SYMF_EXPORT;
 }
 
 /*
@@ -724,18 +715,16 @@ void sym_AddMacro(char *tzSym, int32_t nDefLineNo)
 {
 	struct sSymbol *nsym = createNonrelocSymbol(tzSym);
 
-	if (nsym) {
-		nsym->nType |= SYMF_MACRO | SYMF_DEFINED;
-		nsym->pScope = NULL;
-		nsym->ulMacroSize = ulNewMacroSize;
-		nsym->pMacro = tzNewMacro;
-		updateSymbolFilename(nsym);
-		/*
-		 * The symbol is created at the line after the `endm`,
-		 * override this with the actual definition line
-		 */
-		nsym->nFileLine = nDefLineNo;
-	}
+	nsym->nType |= SYMF_MACRO | SYMF_DEFINED;
+	nsym->pScope = NULL;
+	nsym->ulMacroSize = ulNewMacroSize;
+	nsym->pMacro = tzNewMacro;
+	updateSymbolFilename(nsym);
+	/*
+	 * The symbol is created at the line after the `endm`,
+	 * override this with the actual definition line
+	 */
+	nsym->nFileLine = nDefLineNo;
 }
 
 /*
@@ -762,12 +751,11 @@ void sym_Ref(char *tzSym)
 
 		nsym = createsymbol(tzSym);
 
-		if (nsym && isLocal)
+		if (isLocal)
 			nsym->nType |= SYMF_LOCAL;
 	}
 
-	if (nsym)
-		nsym->nType |= SYMF_REF;
+	nsym->nType |= SYMF_REF;
 }
 
 /*

--- a/test/asm/label-diff.asm
+++ b/test/asm/label-diff.asm
@@ -27,7 +27,7 @@ POPS ; Ensure we are in neither section
 
 ; TODO: uncomment all that can be, there is seriously room for improvement here
 	; Diffing two constants should work
-; But it doesn't yet	print_diff Constant, Constant2
+	print_diff Constant, Constant2
 	; Diffing two labels in the same SECTION as well
 	print_diff Known2, Known
 	; Diffing a constant and a "floating" label cannot work
@@ -40,7 +40,7 @@ POPS ; Ensure we are in neither section
 	; Now let's fiddle with PC
 SECTION "fixed PC", ROM0[420]
 	; Diffing a constant and PC should work
-; But it doesn't yet	print_diff Constant, @
+	print_diff Constant, @
 	; Diffing a floating label and PC cannot work
 ; ...And that causes a fatal error	print_diff Known, @
 	; Diffinf a ref and PC cannot work
@@ -49,7 +49,7 @@ SECTION "fixed PC", ROM0[420]
 	print_diff @, @
 	; Diffing PC and a label from here should work
 LocalFixed:
-; But it doesn't yet	print_diff LocalFixed, @
+	print_diff LocalFixed, @
 
 SECTION "Floating PC", ROM0
 	; Diffing a constant and PC cannot work

--- a/test/asm/label-diff.out
+++ b/test/asm/label-diff.out
@@ -1,5 +1,11 @@
+$FFFFFFE5
+$1B
 $4
 $FFFFFFFC
+$FFFFFE86
+$17A
+$0
+$0
 $0
 $0
 $0

--- a/test/asm/pc-bank.err
+++ b/test/asm/pc-bank.err
@@ -1,5 +1,5 @@
 ERROR: pc-bank.asm(2):
     Source address $2a00 not in $FF00 to $FFFF
 ERROR: pc-bank.asm(11):
-    @'s bank is not known yet
+    Current bank is not known yet
 error: Assembly aborted (2 errors)!

--- a/test/asm/pc-def.err
+++ b/test/asm/pc-def.err
@@ -1,2 +1,3 @@
 ERROR: pc-def.asm(1):
-    '@' is not allowed as argument to the DEF function
+    Label "@" is not a valid argument to DEF
+error: Assembly aborted (1 errors)!

--- a/test/asm/pc-def.out
+++ b/test/asm/pc-def.out
@@ -1,0 +1,1 @@
+defined

--- a/test/asm/undefined-dot.err
+++ b/test/asm/undefined-dot.err
@@ -1,1 +1,0 @@
-error: undefined-dot.asm(3) : '.' not defined


### PR DESCRIPTION
Stop using that bitfield for everything, including what can be determined otherwise
It also makes it easier to have a sane state, since some bits were (supposedly) mutually exclusive