### PR TITLE
Use more conventional permissions and man-page directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@
 Q		:= @
 PREFIX		:= /usr/local
 bindir		:= ${PREFIX}/bin
-mandir		:= ${PREFIX}/man
+mandir		:= ${PREFIX}/share/man
 STRIP		:= -s
-BINMODE		:= 555
-MANMODE		:= 444
+BINMODE		:= 755
+MANMODE		:= 644
 CHECKPATCH	:= ../linux/scripts/checkpatch.pl
 
 # Other variables

--- a/README.rst
+++ b/README.rst
@@ -147,7 +147,7 @@ This is the complete list of user-defined variables:
   ``${PREFIX}/bin``.
 
 - ``mandir``: Location where the manpages will be installed. Defaults to
-  ``${PREFIX}/man``.
+  ``${PREFIX}/share/man``.
 
 - ``DESTDIR``: This is prepended to all paths during the installation. It is
   mainly used for packaging.
@@ -158,9 +158,9 @@ This is the complete list of user-defined variables:
 - ``STRIP``: Whether to strip the installed binaries of debug symbols or not.
   Defaults to ``-s``.
 
-- ``BINMODE``: Permissions of the installed binaries. Defaults to ``555``.
+- ``BINMODE``: Permissions of the installed binaries. Defaults to ``755``.
 
-- ``MANMODE``: Permissions of the installed manpages. Defaults to ``444``.
+- ``MANMODE``: Permissions of the installed manpages. Defaults to ``644``.
 
 - ``CHECKPATCH``: Path of the script ``checkpatch.pl`` of the Linux kernel.
   Defaults to ``../linux/scripts/checkpatch.pl``.


### PR DESCRIPTION
As 444 and 555 seem to be used for no apparent reason, use the more conventional 644 and 755.

`/man` is typically unused or a symlink to `/share/man` now, so just use `/share/man`.

Signed-off-by: JL2210 <larrowe.semaj11@gmail.com>

I changed the README while I was at it and this doesn't cause any issues with the install.