### PR TITLE
Fix possible null pointer dereference

### DIFF
--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -254,7 +254,7 @@ YY_BUFFER_STATE yy_create_buffer(FILE *f)
 	else if (capacity == 0)
 		capacity = 1;
 
-	while (!feof(f)) {
+	do {
 		if (buf == NULL || size >= capacity) {
 			if (buf)
 				capacity *= 2;
@@ -273,7 +273,7 @@ YY_BUFFER_STATE yy_create_buffer(FILE *f)
 			fatalerror("%s: fread error", __func__);
 
 		size += read_count;
-	}
+	} while (!feof(f));
 
 	pBuffer->pBufferRealStart = buf;
 	pBuffer->pBufferStart = buf + SAFETYMARGIN;


### PR DESCRIPTION
It's possible that if the `FILE *` passed to `yy_create_buffer` is at the
end-of file, there may be a null pointer dereference.

This should fix that, and I don't see any possible repercussions.

Found with `clang-tools`' `scan-build`:

```
src/asm/lexer.c:281:25: warning: Array access (via field 'pBuffer') results in a null pointer dereference
        pBuffer->pBuffer[size] = 0;
                 ~~~~~~~       ^
1 warning generated.
```

Signed-off-by: JL2210 <larrowe.semaj11@gmail.com>