### PR TITLE
Fix modulo by zero

### DIFF
--- a/src/link/patch.c
+++ b/src/link/patch.c
@@ -185,7 +185,13 @@ static int32_t computeRPNExpr(struct Patch const *patch,
 			break;
 		case RPN_MOD:
 			value = popRPN();
-			value = popRPN() % value;
+			if (value == 0) {
+				error("%s: Modulo by 0", patch->fileName);
+				popRPN();
+				value = 0;
+			} else {
+				value = popRPN() % value;
+			}
 			break;
 		case RPN_UNSUB:
 			value = -popRPN();


### PR DESCRIPTION
Yet another case caught by scan-build:

```
src/link/patch.c:188:21: warning: Division by zero
                        value = popRPN() % value;
                                ~~~~~~~~~^~~~~~~
```

Just copy over the code from the division case, with a few modifications.

I'm not sure if this `INT_MIN` value is what should be expected, but it seems like the most logical answer. I'm also not sure if the word "Modulo" or simply "Division" should be used. Insight?

Signed-off-by: JL2210 <larrowe.semaj11@gmail.com>