### PR TITLE
Fix use of zero-allocated memory

### DIFF
--- a/src/link/patch.c
+++ b/src/link/patch.c
@@ -82,10 +82,18 @@ static inline void clearRPNStack(void)
 static void pushRPN(int32_t value)
 {
 	if (stack.size >= stack.capacity) {
-		stack.capacity *= 2;
+		static const size_t increase_factor = 2;
+
+		if (stack.capacity > SIZE_MAX / increase_factor)
+			err(1, "Overflow in RPN stack resize");
+
+		stack.capacity *= increase_factor;
 		stack.buf =
 			realloc(stack.buf, sizeof(*stack.buf) * stack.capacity);
-		if (!stack.buf)
+		// || !stack.capacity to fix bogus
+		// zero-size allocation warning from
+		// scan-build, already caught above
+		if (!stack.buf || !stack.capacity)
 			err(1, "Failed to resize RPN stack");
 	}
 

--- a/src/link/patch.c
+++ b/src/link/patch.c
@@ -85,14 +85,16 @@ static void pushRPN(int32_t value)
 		static const size_t increase_factor = 2;
 
 		if (stack.capacity > SIZE_MAX / increase_factor)
-			err(1, "Overflow in RPN stack resize");
+			errx(1, "Overflow in RPN stack resize");
 
 		stack.capacity *= increase_factor;
 		stack.buf =
 			realloc(stack.buf, sizeof(*stack.buf) * stack.capacity);
-		// || !stack.capacity to fix bogus
-		// zero-size allocation warning from
-		// scan-build, already caught above
+		/*
+		 * Static analysis tools complain that the capacity might become
+		 * zero due to overflow, but fail to realize that it's caught by
+		 * the overflow check above. Hence the stringent check below.
+		 */
 		if (!stack.buf || !stack.capacity)
 			err(1, "Failed to resize RPN stack");
 	}


### PR DESCRIPTION
It's possible that `stack.capacity` may overflow to zero,
and then we might use zero-allocated memory (memory from `malloc` with size zero).

This is incredibly unlikely, and I would even go so far as to say
that this is a false positive. Fix it anyway, to silence this warning:

```
src/link/patch.c:92:24: warning: Use of zero-allocated memory
        stack.buf[stack.size] = value;
        ~~~~~~~~~~~~~~~~~~~~~ ^
```

Signed-off-by: JL2210 <larrowe.semaj11@gmail.com>