### PR TITLE
Add option to disable padding in rgblink

### DIFF
--- a/include/link/main.h
+++ b/include/link/main.h
@@ -27,6 +27,7 @@ extern uint8_t padValue;
 extern bool is32kMode;
 extern bool beVerbose;
 extern bool isWRA0Mode;
+extern bool disablePadding;
 
 /* Helper macro for printing verbose-mode messages */
 #define verbosePrint(...)   do { \

--- a/src/link/main.c
+++ b/src/link/main.c
@@ -119,7 +119,7 @@ static struct option const longopts[] = {
 static void printUsage(void)
 {
 	fputs(
-"Usage: rgblink [-dtVvw] [-l script] [-m map_file] [-n sym_file]\n"
+"Usage: rgblink [-dtVvwx] [-l script] [-m map_file] [-n sym_file]\n"
 "               [-O overlay_file] [-o out_file] [-p pad_value] [-s symbol]\n"
 "               <file> ...\n"
 "Useful options:\n"

--- a/src/link/main.c
+++ b/src/link/main.c
@@ -34,6 +34,7 @@ uint8_t padValue;             /* -p */
 bool is32kMode;               /* -t */
 bool beVerbose;               /* -v */
 bool isWRA0Mode;              /* -w */
+bool disablePadding;          /* -x */
 
 static uint32_t nbErrors = 0;
 
@@ -83,7 +84,7 @@ FILE *openFile(char const *fileName, char const *mode)
 }
 
 /* Short options */
-static char const *optstring = "dl:m:n:O:o:p:s:tVvw";
+static char const *optstring = "dl:m:n:O:o:p:s:tVvwx";
 
 /*
  * Equivalent long options
@@ -108,6 +109,7 @@ static struct option const longopts[] = {
 	{ "version",      no_argument,       NULL, 'V' },
 	{ "verbose",      no_argument,       NULL, 'v' },
 	{ "wramx",        no_argument,       NULL, 'w' },
+	{ "nopad",        no_argument,       NULL, 'x' },
 	{ NULL,           no_argument,       NULL, 0   }
 };
 
@@ -126,6 +128,7 @@ static void printUsage(void)
 "    -n, --sym <path>           set the output symbol list file\n"
 "    -o, --output <path>        set the output file\n"
 "    -p, --pad <value>          set the value to pad between sections with\n"
+"    -x, --nopad                disable padding of output binary\n"
 "    -V, --version              print RGBLINK version and exits\n"
 "\n"
 "For help, use `man rgblink' or go to https://rednex.github.io/rgbds/\n",
@@ -198,6 +201,11 @@ int main(int argc, char *argv[])
 			break;
 		case 'w':
 			isWRA0Mode = true;
+			break;
+		case 'x':
+			disablePadding = true;
+			/* implies tiny mode */
+			is32kMode = true;
 			break;
 		default:
 			printUsage();

--- a/src/link/output.c
+++ b/src/link/output.c
@@ -175,9 +175,13 @@ static void writeBank(struct SortedSection *bankSections, uint16_t baseOffset,
 		bankSections = bankSections->next;
 	}
 
-	while (offset < size) {
-		putc(overlayFile ? getc(overlayFile) : padValue, outputFile);
-		offset++;
+	if (!disablePadding) {
+		while (offset < size) {
+			putc(overlayFile ? getc(overlayFile)
+					 : padValue,
+			     outputFile);
+			offset++;
+		}
 	}
 }
 

--- a/src/link/rgblink.1
+++ b/src/link/rgblink.1
@@ -13,7 +13,7 @@
 .Nd Game Boy linker
 .Sh SYNOPSIS
 .Nm
-.Op Fl dtVvw
+.Op Fl dtVvwx
 .Op Fl l Ar linker_script
 .Op Fl m Ar map_file
 .Op Fl n Ar sym_file
@@ -102,6 +102,14 @@ Print the version of the program and exit.
 Verbose: enable printing more information to standard error.
 .It Fl w , Fl Fl wramx
 Expand the WRAM0 section size from 4 KiB to the full 8 KiB assigned to WRAM and prohibit the use of WRAMX sections.
+.It Fl x , Fl Fl nopad
+Disables padding the end of the final file.
+This option automatically enables
+.Fl t .
+You can use this when not not making a ROM.
+When making a ROM, be careful that not using this is not a replacement for
+.Xr rgbfix 1 Ap s Fl p
+option!
 .El
 .Sh EXAMPLES
 All you need for a basic ROM is an object file, which can be made into a ROM image like so:


### PR DESCRIPTION
Fixes #307

RGBFIX can handle padding, so there's no reason why
we can't add an option to disable padding in rgblink.

I don't think this is worth a short argument, though,
especially considering that all the good letters are used up.
Take up a letter for a short argument but don't put it in the `optstring`,
and leave a comment to this effect.

Signed-off-by: JL2210 <larrowe.semaj11@gmail.com>