### PR TITLE
Fix uninitialized strcat

### DIFF
--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -477,6 +477,7 @@ int main(int argc, char *argv[])
 							nTargetFileNameLen + 1);
 					if (tzTargetFileName == NULL)
 						err(1, "Cannot append new file to target file list");
+					*tzTargetFileName = 0;
 					strcat(tzTargetFileName, ep);
 					if (depType == 'Q')
 						free(ep);


### PR DESCRIPTION
When it's allocated the first time, `tzTargetFileName` is uninitialized,
and so the `strcat` just reads junk until it finds a "string terminator".

Signed-off-by: James Larrowe <larrowe.semaj11@gmail.com>