### PR TITLE
Use inttypes for stdint types

### DIFF
--- a/include/linkdefs.h
+++ b/include/linkdefs.h
@@ -13,8 +13,8 @@
 #include <stdint.h>
 
 #define RGBDS_OBJECT_VERSION_STRING "RGB%1hhu"
-#define RGBDS_OBJECT_VERSION_NUMBER (uint8_t)9
-#define RGBDS_OBJECT_REV 4
+#define RGBDS_OBJECT_VERSION_NUMBER 9
+#define RGBDS_OBJECT_REV 4U
 
 enum AssertionType {
 	ASSERT_WARN,

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -9,6 +9,7 @@
 %{
 #include <ctype.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -79,7 +80,7 @@ size_t symvaluetostring(char *dest, size_t maxLength, char *symName,
 			strncpy(dest, write_ptr, maxLength + 1);
 		} else {
 			fullLength = snprintf(dest, maxLength + 1,
-							  mode ? mode : "$%X",
+							  mode ? mode : "$%" PRIX32,
 						      value);
 		}
 

--- a/src/asm/fstack.c
+++ b/src/asm/fstack.c
@@ -10,14 +10,15 @@
  * FileStack routines
  */
 
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "asm/fstack.h"
@@ -69,7 +70,7 @@ static void pushcontext(void)
 	struct sContext **ppFileStack;
 
 	if (++nFileStackDepth > nMaxRecursionDepth)
-		fatalerror("Recursion limit (%d) exceeded", nMaxRecursionDepth);
+		fatalerror("Recursion limit (%u) exceeded", nMaxRecursionDepth);
 
 	ppFileStack = &pFileStack;
 	while (*ppFileStack)
@@ -271,12 +272,12 @@ void fstk_Dump(void)
 	pLastFile = pFileStack;
 
 	while (pLastFile) {
-		fprintf(stderr, "%s(%d) -> ", pLastFile->tzFileName,
+		fprintf(stderr, "%s(%" PRId32 ") -> ", pLastFile->tzFileName,
 			pLastFile->nLine);
 		pLastFile = pLastFile->pNext;
 	}
 
-	fprintf(stderr, "%s(%d)", tzCurrentFileName, nLineNo);
+	fprintf(stderr, "%s(%" PRId32 ")", tzCurrentFileName, nLineNo);
 }
 
 void fstk_DumpToStr(char *buf, size_t buflen)
@@ -286,7 +287,7 @@ void fstk_DumpToStr(char *buf, size_t buflen)
 	size_t len = buflen;
 
 	while (pLastFile) {
-		retcode = snprintf(&buf[buflen - len], len, "%s(%d) -> ",
+		retcode = snprintf(&buf[buflen - len], len, "%s(%" PRId32 ") -> ",
 				   pLastFile->tzFileName, pLastFile->nLine);
 		if (retcode < 0)
 			fatalerror("Failed to dump file stack to string: %s",
@@ -298,8 +299,8 @@ void fstk_DumpToStr(char *buf, size_t buflen)
 		pLastFile = pLastFile->pNext;
 	}
 
-	retcode = snprintf(&buf[buflen - len], len, "%s(%d)", tzCurrentFileName,
-			   nLineNo);
+	retcode = snprintf(&buf[buflen - len], len, "%s(%" PRId32 ")",
+			   tzCurrentFileName, nLineNo);
 	if (retcode < 0)
 		fatalerror("Failed to dump file stack to string: %s",
 			   strerror(errno));

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -7,12 +7,13 @@
  */
 
 #include <assert.h>
+#include <ctype.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <ctype.h>
 
 #include "asm/asm.h"
 #include "asm/fstack.h"
@@ -120,7 +121,7 @@ void yyunputstr(const char *s)
 void lex_BeginStringExpansion(const char *tzName)
 {
 	if (++nNbStringExpansions > nMaxRecursionDepth)
-		fatalerror("Recursion limit (%d) exceeded", nMaxRecursionDepth);
+		fatalerror("Recursion limit (%u) exceeded", nMaxRecursionDepth);
 
 	struct sStringExpansionPos *pNewStringExpansion =
 		malloc(sizeof(*pNewStringExpansion));
@@ -371,7 +372,7 @@ uint32_t lex_FloatAlloc(const struct sLexFloat *token)
 bool lex_CheckCharacterRange(uint16_t start, uint16_t end)
 {
 	if (start > end || start < 1 || end > 127) {
-		yyerror("Invalid character range (start: %u, end: %u)",
+		yyerror("Invalid character range (start: %" PRIu16 ", end: %" PRIu16 ")",
 			start, end);
 		return false;
 	}
@@ -672,7 +673,7 @@ size_t yylex_ReadBracketedSymbol(char *dest, size_t index)
 			 * so it's handled differently
 			 */
 			static const char * const formatSpecifiers[] = {
-				"", "%x", "%X", "%d"
+				"", "%" PRIx32, "%" PRIX32, "%" PRId32
 			};
 			/* Prevent reading out of bounds! */
 			const char *designatedMode;

--- a/src/asm/macro.c
+++ b/src/asm/macro.c
@@ -1,5 +1,6 @@
 
 #include <assert.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -82,7 +83,7 @@ void macro_SetUniqueID(uint32_t id)
 		uniqueIDPtr = NULL;
 	} else {
 		/* The buffer is guaranteed to be the correct size */
-		sprintf(uniqueIDBuf, "_%u", id);
+		sprintf(uniqueIDBuf, "_%" PRIu32, id);
 		uniqueIDPtr = uniqueIDBuf;
 	}
 }

--- a/src/asm/main.c
+++ b/src/asm/main.c
@@ -167,7 +167,7 @@ void opt_Parse(char *s)
 		/* fallthrough */
 	case 'p':
 		if (strlen(&s[1]) <= 2) {
-			int32_t result;
+			int result;
 			unsigned int fillchar;
 
 			result = sscanf(&s[1], "%x", &fillchar);
@@ -551,10 +551,11 @@ int main(int argc, char *argv[])
 		fclose(dependfile);
 
 	if (nIFDepth != 0)
-		errx(1, "Unterminated IF construct (%u levels)!", nIFDepth);
+		errx(1, "Unterminated IF construct (%" PRIu32 " levels)!",
+		     nIFDepth);
 
 	if (nUnionDepth != 0) {
-		errx(1, "Unterminated UNION construct (%u levels)!",
+		errx(1, "Unterminated UNION construct (%" PRIu32 " levels)!",
 		     nUnionDepth);
 	}
 
@@ -564,8 +565,9 @@ int main(int argc, char *argv[])
 	timespent = ((double)(nEndClock - nStartClock))
 		     / (double)CLOCKS_PER_SEC;
 	if (verbose) {
-		printf("Success! %u lines in %d.%02d seconds ", nTotalLines,
-		       (int)timespent, ((int)(timespent * 100.0)) % 100);
+		printf("Success! %" PRIu32 " lines in %d.%02d seconds ",
+		       nTotalLines, (int)timespent,
+		       ((int)(timespent * 100.0)) % 100);
 		if (timespent < FLT_MIN_EXP)
 			printf("(INFINITY lines/minute)\n");
 		else

--- a/src/asm/math.c
+++ b/src/asm/math.c
@@ -10,6 +10,7 @@
  * Fixedpoint math routines
  */
 
+#include <inttypes.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -37,12 +38,16 @@ void math_DefinePI(void)
  */
 void math_Print(int32_t i)
 {
-	if (i >= 0)
-		printf("%d.%05d", i >> 16,
-		       ((int32_t)(fx2double(i) * 100000 + 0.5)) % 100000);
-	else
-		printf("-%d.%05d", (-i) >> 16,
-		       ((int32_t)(fx2double(-i) * 100000 + 0.5)) % 100000);
+	uint32_t u = i;
+	const char *sign = "";
+
+	if (i < 0) {
+		u = -u;
+		sign = "-";
+	}
+
+	printf("%s%" PRIu32 ".%05" PRIu32, sign, u >> 16,
+	       ((uint32_t)(fx2double(u) * 100000 + 0.5)) % 100000);
 }
 
 /*

--- a/src/asm/symbol.c
+++ b/src/asm/symbol.c
@@ -12,6 +12,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -286,7 +287,7 @@ static struct Symbol *createNonrelocSymbol(char const *symbolName)
 	if (!symbol)
 		symbol = createsymbol(symbolName);
 	else if (sym_IsDefined(symbol))
-		yyerror("'%s' already defined at %s(%u)", symbolName,
+		yyerror("'%s' already defined at %s(%" PRIu32 ")", symbolName,
 			symbol->fileName, symbol->fileLine);
 
 	return symbol;
@@ -346,8 +347,8 @@ struct Symbol *sym_AddSet(char const *symName, int32_t value)
 	if (sym == NULL)
 		sym = createsymbol(symName);
 	else if (sym_IsDefined(sym) && sym->type != SYM_SET)
-		yyerror("'%s' already defined as %s at %s(%u)", symName,
-			sym->type == SYM_LABEL ? "label" : "constant",
+		yyerror("'%s' already defined as %s at %s(%" PRIu32 ")",
+			symName, sym->type == SYM_LABEL ? "label" : "constant",
 			sym->fileName, sym->fileLine);
 	else
 		/* TODO: can the scope be incorrect when talking over refs? */
@@ -407,7 +408,7 @@ struct Symbol *sym_AddReloc(char const *symName)
 	if (!sym)
 		sym = createsymbol(symName);
 	else if (sym_IsDefined(sym))
-		yyerror("'%s' already defined in %s(%d)", symName,
+		yyerror("'%s' already defined in %s(%" PRIu32 ")", symName,
 			sym->fileName, sym->fileLine);
 	/* If the symbol already exists as a ref, just "take over" it */
 

--- a/src/gfx/main.c
+++ b/src/gfx/main.c
@@ -210,7 +210,7 @@ int main(int argc, char *argv[])
 
 	if (opts.trim &&
 	    opts.trim > (raw_image->width / 8) * (raw_image->height / 8) - 1) {
-		errx(1, "Trim (%i) for input raw_image file '%s' too large (max: %i)",
+		errx(1, "Trim (%d) for input raw_image file '%s' too large (max: %u)",
 		     opts.trim, opts.infile,
 		     (raw_image->width / 8) * (raw_image->height / 8) - 1);
 	}

--- a/src/gfx/makepng.c
+++ b/src/gfx/makepng.c
@@ -38,7 +38,7 @@ struct RawIndexedImage *input_png_file(const struct Options *opts,
 
 	if (img.depth != depth) {
 		if (opts->verbose) {
-			warnx("Image bit depth is not %i (is %i).",
+			warnx("Image bit depth is not %d (is %d).",
 			      depth, img.depth);
 		}
 	}

--- a/src/link/main.c
+++ b/src/link/main.c
@@ -6,12 +6,13 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <stdio.h>
+#include <inttypes.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #include "link/object.h"
 #include "link/symbol.h"
@@ -65,7 +66,7 @@ noreturn_ void fatal(char const *fmt, ...)
 	if (nbErrors != UINT32_MAX)
 		nbErrors++;
 
-	fprintf(stderr, "Linking aborted after %u error%s\n", nbErrors,
+	fprintf(stderr, "Linking aborted after %" PRIu32 " error%s\n", nbErrors,
 		nbErrors != 1 ? "s" : "");
 	exit(1);
 }
@@ -245,8 +246,8 @@ int main(int argc, char *argv[])
 	/* and finally output the result. */
 	patch_ApplyPatches();
 	if (nbErrors) {
-		fprintf(stderr, "Linking failed with %u error%s\n", nbErrors,
-			nbErrors != 1 ? "s" : "");
+		fprintf(stderr, "Linking failed with %" PRIu32 " error%s\n",
+			nbErrors, nbErrors != 1 ? "s" : "");
 		exit(1);
 	}
 	out_WriteFiles();

--- a/src/link/output.c
+++ b/src/link/output.c
@@ -6,8 +6,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <stdlib.h>
+#include <inttypes.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include "link/output.h"
 #include "link/main.h"
@@ -51,7 +52,7 @@ void out_AddSection(struct Section const *section)
 	uint32_t minNbBanks = targetBank + 1;
 
 	if (minNbBanks > maxNbBanks[section->type])
-		errx(1, "Section \"%s\" has invalid bank range (%u > %u)",
+		errx(1, "Section \"%s\" has an invalid bank range (%" PRIu32 " > %" PRIu32 ")",
 		     section->name, section->bank,
 		     maxNbBanks[section->type] - 1);
 
@@ -283,7 +284,7 @@ static void writeSymBank(struct SortedSections const *bankSections)
 
 			minSectList = &zlSectList;
 		}
-		fprintf(symFile, "%02x:%04x %s\n",
+		fprintf(symFile, "%02" PRIx32 ":%04" PRIx16 " %s\n",
 			minSectList->sect->bank, minSectList->addr,
 			minSectList->sym->name);
 		minSectList->i++;
@@ -304,7 +305,7 @@ static void writeMapBank(struct SortedSections const *sectList,
 	struct SortedSection const *section        = sectList->sections;
 	struct SortedSection const *zeroLenSection = sectList->zeroLenSections;
 
-	fprintf(mapFile, "%s bank #%u:\n", typeNames[type],
+	fprintf(mapFile, "%s bank #%" PRIu32 ":\n", typeNames[type],
 		bank + bankranges[type][0]);
 
 	uint16_t slack = maxsize[type];
@@ -317,16 +318,16 @@ static void writeMapBank(struct SortedSections const *sectList,
 		slack -= sect->size;
 
 		if (sect->size != 0)
-			fprintf(mapFile, "  SECTION: $%04x-$%04x ($%04x byte%s) [\"%s\"]\n",
+			fprintf(mapFile, "  SECTION: $%04" PRIx16 "-$%04" PRIx16 " ($%04" PRIx16 " byte%s) [\"%s\"]\n",
 				sect->org, sect->org + sect->size - 1,
 				sect->size, sect->size == 1 ? "" : "s",
 				sect->name);
 		else
-			fprintf(mapFile, "  SECTION: $%04x (0 bytes) [\"%s\"]\n",
+			fprintf(mapFile, "  SECTION: $%04" PRIx16 " (0 bytes) [\"%s\"]\n",
 				sect->org, sect->name);
 
 		for (size_t i = 0; i < sect->nbSymbols; i++)
-			fprintf(mapFile, "           $%04x = %s\n",
+			fprintf(mapFile, "           $%04" PRIx32 " = %s\n",
 				sect->symbols[i]->offset + sect->org,
 				sect->symbols[i]->name);
 
@@ -336,7 +337,7 @@ static void writeMapBank(struct SortedSections const *sectList,
 	if (slack == maxsize[type])
 		fputs("  EMPTY\n\n", mapFile);
 	else
-		fprintf(mapFile, "    SLACK: $%04x byte%s\n\n", slack,
+		fprintf(mapFile, "    SLACK: $%04" PRIx16 " byte%s\n\n", slack,
 			slack == 1 ? "" : "s");
 }
 

--- a/src/link/patch.c
+++ b/src/link/patch.c
@@ -6,8 +6,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <stdlib.h>
+#include <inttypes.h>
 #include <limits.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "link/patch.h"
@@ -316,7 +317,7 @@ static int32_t computeRPNExpr(struct Patch const *patch,
 			if (value < 0
 			 || (value > 0xFF && value < 0xFF00)
 			 || value > 0xFFFF)
-				error("%s: Value %d is not in HRAM range",
+				error("%s: Value %" PRId32 " is not in HRAM range",
 				      patch->fileName, value);
 			value &= 0xFF;
 			break;
@@ -327,7 +328,7 @@ static int32_t computeRPNExpr(struct Patch const *patch,
 			 * They can be easily checked with a bitmask
 			 */
 			if (value & ~0x38)
-				error("%s: Value %d is not a RST vector",
+				error("%s: Value %" PRId32 " is not a RST vector",
 				      patch->fileName, value);
 			value |= 0xC7;
 			break;
@@ -370,7 +371,7 @@ static int32_t computeRPNExpr(struct Patch const *patch,
 	}
 
 	if (stack.size > 1)
-		error("%s: RPN stack has %lu entries on exit, not 1",
+		error("%s: RPN stack has %zu entries on exit, not 1",
 		      patch->fileName, stack.size);
 
 	return popRPN();
@@ -440,7 +441,7 @@ static void applyFilePatches(struct Section *section)
 			int16_t offset = value - address;
 
 			if (offset < -128 || offset > 127)
-				error("%s: jr target out of reach (expected -129 < %d < 128)",
+				error("%s: jr target out of reach (expected -129 < %" PRId16 " < 128)",
 				      patch->fileName, offset);
 			section->data[patch->offset] = offset & 0xFF;
 		} else {
@@ -457,10 +458,10 @@ static void applyFilePatches(struct Section *section)
 
 			if (value < types[patch->type].min
 			 || value > types[patch->type].max)
-				error("%s: Value %#x%s is not %u-bit",
+				error("%s: Value %#" PRIx32 "%s is not %u-bit",
 				      patch->fileName, value,
 				      value < 0 ? " (maybe negative?)" : "",
-				      types[patch->type].size * 8);
+				      types[patch->type].size * 8U);
 			for (uint8_t i = 0; i < types[patch->type].size; i++) {
 				section->data[patch->offset + i] = value & 0xFF;
 				value >>= 8;

--- a/src/link/symbol.c
+++ b/src/link/symbol.c
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include <inttypes.h>
 #include <stdbool.h>
 
 #include "link/symbol.h"
@@ -40,7 +41,7 @@ void sym_AddSymbol(struct Symbol *symbol)
 	struct Symbol *other = hash_GetElement(symbols, symbol->name);
 
 	if (other)
-		errx(1, "\"%s\" both in %s from %s(%d) and in %s from %s(%d)",
+		errx(1, "\"%s\" both in %s from %s(%" PRId32 ") and in %s from %s(%" PRId32 ")",
 		     symbol->name,
 		     symbol->objFileName, symbol->fileName, symbol->lineNo,
 		      other->objFileName,  other->fileName,  other->lineNo);

--- a/test/asm/pc-bank.err
+++ b/test/asm/pc-bank.err
@@ -1,5 +1,5 @@
 ERROR: pc-bank.asm(2):
-    Source address $2a00 not in $FF00 to $FFFF
+    Source address $2a00 not between $FF00 to $FFFF
 ERROR: pc-bank.asm(11):
     Expected constant expression: Current section's bank is not known
 error: Assembly aborted (2 errors)!

--- a/test/link/section-union/no-room.out
+++ b/test/link/section-union/no-room.out
@@ -1,2 +1,2 @@
-error: Unable to place "test" (WRAMX section) in bank $02 with align mask ffffffc0
+error: Unable to place "test" (WRAMX section) in bank $02 with align mask ffc0
 ---


### PR DESCRIPTION
This should help make RGBDS portable to systems with 16-bit integers,
like DOS.

For kicks, use the macros for 16-bit and 8-bit integers as well.

Fix other miscellaneous things, like `#include` ordering and other
`printf`-format related things.

Reduce repetition in `math.c` while I'm there.

Apologies for checkpatch but it can't handle macro expansions in strings.