### PR TITLE
Fix DJGPP build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ WARNFLAGS	:= -Wall
 # Overridable CFLAGS
 CFLAGS		:= -O3
 # Non-overridable CFLAGS
-REALCFLAGS	:= ${CFLAGS} ${WARNFLAGS} -std=c11 -D_POSIX_C_SOURCE=200809L \
-		   -D_DEFAULT_SOURCE -Iinclude
+REALCFLAGS	:= ${CFLAGS} ${WARNFLAGS} -std=gnu11 -D_POSIX_C_SOURCE=200809L \
+		   -Iinclude
 # Overridable LDFLAGS
 LDFLAGS		:=
 # Non-overridable LDFLAGS

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1108,10 +1108,10 @@ popc		: T_POP_POPC	{ charmap_Pop(); }
 printt		: T_POP_PRINTT string	{ printf("%s", $2); }
 ;
 
-printv		: T_POP_PRINTV const	{ printf("$%X", $2); }
+printv		: T_POP_PRINTV const	{ printf("$%" PRIX32, $2); }
 ;
 
-printi		: T_POP_PRINTI const	{ printf("%d", $2); }
+printi		: T_POP_PRINTI const	{ printf("%" PRId32, $2); }
 ;
 
 printf		: T_POP_PRINTF const	{ math_Print($2); }


### PR DESCRIPTION
GCC with the `-std=c11` option defines `__STRICT_ANSI__`. DJGPP checks if
`__STRICT_ANSI__` is defined and if so doesn't define some things
mandated by POSIX such as `struct stat`, `PATH_MAX`, and others.
The `-std=gnu11` option does not define this macro, so use it instead.

`_DEFAULT_SOURCE` isn't needed as no GNU nor BSD-specific functions
are used. Remove it.

Fix the last two occurrences of incorrect format specifiers for standard
fixed-width integer types.