### PR TITLE
Fixed error in POP AF instruction reference

### DIFF
--- a/src/gbz80.7
+++ b/src/gbz80.7
@@ -1142,10 +1142,10 @@ This is roughly equivalent to the following
 .Em imaginary
 instructions:
 .Bd -literal -offset indent
+ld f, [sp] ; See below for individual flags
 inc sp
 ld a, [sp]
 inc sp
-ld f, [sp] ; See below for individual flags
 .Ed
 .Pp
 Cycles: 3


### PR DESCRIPTION
The "imaginary" equivalent instructions put the instructions in the wrong order.
Before:
```
inc sp
ld a, [sp]
inc sp
ld f, [sp]
```
Edited:
```
ld f, [sp]
inc sp
ld a, [sp]
inc sp
```