### PR TITLE
Fix indexing of banks array

### DIFF
--- a/src/link/output.c
+++ b/src/link/output.c
@@ -88,8 +88,9 @@ void out_AddSection(struct Section const *section)
 
 struct Section const *out_OverlappingSection(struct Section const *section)
 {
+	struct SortedSections *banks = sections[section->type].banks;
 	struct SortedSection *ptr =
-		sections[section->type].banks[section->bank].sections;
+		banks[section->bank - bankranges[section->type][0]].sections;
 
 	while (ptr) {
 		if (ptr->section->org < section->org + section->size


### PR DESCRIPTION
When ROMX bank 1 is given, the banks array is indexed with an index
of 1 rather than an index of zero.