### PR TITLE
strncasecmp alternative for MSVC

### DIFF
--- a/include/platform.h
+++ b/include/platform.h
@@ -1,0 +1,22 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 2020 RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* platform-specific hacks */
+
+#ifndef RGBDS_PLATFORM_H
+#define RGBDS_PLATFORM_H
+
+/* MSVC doesn't have strncasecmp, use a suitable replacement */
+#ifdef _MSC_VER
+# include <string.h>
+# define strncasecmp _strnicmp
+#else
+# include <strings.h>
+#endif
+
+#endif /* RGBDS_PLATFORM_H */

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -15,7 +15,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include "asm/asm.h"
 #include "asm/charmap.h"
@@ -34,6 +33,7 @@
 #include "extern/utf8decoder.h"
 
 #include "linkdefs.h"
+#include "platform.h" // strncasecmp
 
 uint32_t nListCountEmpty;
 char *tzNewMacro;

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -13,7 +13,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include "asm/asm.h"
 #include "asm/fstack.h"
@@ -27,6 +26,7 @@
 #include "extern/err.h"
 
 #include "asmy.h"
+#include "platform.h" // strncasecmp
 
 struct sLexString {
 	char *tzName;


### PR DESCRIPTION
This defines strncasecmp to _strnicmp if _MSC_VER is defined.
As of yet, this is useless, but as this is unrelated to the build
system, I thought that it would do better in a separate comment.