### PR TITLE
Add CMake build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ rgbshim.sh
 *.o
 *.exe
 .checkpatch-camelcase.*
+CMakeCache.txt
+CMakeFiles
+cmake_install.cmake
 
 test/pokecrystal
 test/pokered

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,71 @@
+#
+# This file is part of RGBDS.
+#
+# Copyright (c) 2020 RGBDS contributors.
+#
+# SPDX-License-Identifier: MIT
+#
+
+cmake_minimum_required(VERSION 2.8.8)
+
+cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
+
+set(RGBDS_VER 0.4.0)
+set(RGBDS_DESC "Rednex Game Boy Development System")
+
+if(CMAKE_VERSION VERSION_LESS 3.0)
+  project(rgbds C)
+  set(PROJECT_VERSION "${RGBDS_VER}")
+else()
+  if(CMAKE_VERSION VERSION_LESS 3.9)
+    project(rgbds VERSION "${RGBDS_VER}"
+                  LANGUAGES C)
+  else()
+    project(rgbds VERSION "${RGBDS_VER}"
+                  DESCRIPTION "${RGBDS_DESC}"
+                  LANGUAGES C)
+  endif()
+endif()
+
+if(CMAKE_VERSION VERSION_LESS 3.9)
+  set(PROJECT_DESCRIPTION "${RGBDS_DESC}")
+endif()
+
+set(DEFAULT_BUILD_TYPE "Release")
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}")
+endif()
+
+# get real path of source and binary directories
+get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
+get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+
+# reject in-source builds, may conflict with Makefile
+if(srcdir STREQUAL bindir)
+  message("RGBDS should not be built in the source directory.")
+  message("Instead, create a separate build directory and specify to CMake the path to the source directory.")
+  message(FATAL_ERROR "Terminating configuration")
+endif()
+
+find_package(PNG 1.6 REQUIRED)
+find_package(BISON REQUIRED)
+find_package(FLEX)
+
+include_directories("${PROJECT_SOURCE_DIR}/include")
+
+if(MSVC)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W1 /MP -D_CRT_SECURE_NO_WARNINGS")
+else()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic")
+endif()
+
+if(CMAKE_VERSION VERSION_LESS 3.12)
+  add_definitions(-DBUILD_VERSION_STRING="${PROJECT_VERSION}")
+else()
+  add_compile_definitions(BUILD_VERSION_STRING="${PROJECT_VERSION}")
+endif()
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED True)
+
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,99 @@
+#
+# This file is part of RGBDS.
+#
+# Copyright (c) 2020 RGBDS contributors.
+#
+# SPDX-License-Identifier: MIT
+#
+
+set(common_src
+    "extern/err.c"
+    "extern/getopt.c"
+    "version.c"
+    )
+
+BISON_TARGET(ASMy "asm/asmy.y"
+             "${PROJECT_SOURCE_DIR}/src/asm/asmy.c"
+             DEFINES_FILE "${PROJECT_SOURCE_DIR}/src/asm/asmy.h"
+             )
+
+# Lexer is not present yet
+if(False) # FLEX_FOUND
+  FLEX_TARGET(Lexer "asm/lexer.l"
+              "${PROJECT_SOURCE_DIR}/src/asm/lexer.c"
+              )
+  ADD_FLEX_BISON_DEPENDENCY(Lexer ASMy)
+  set(Lexer_SOURCE "${FLEX_Lexer_OUTPUTS}")
+else()
+  set(Lexer_SOURCE "asm/lexer.c")
+endif()
+
+set(rgbasm_src
+    "${BISON_ASMy_OUTPUT_SOURCE}"
+    "${Lexer_SOURCE}"
+    "asm/charmap.c"
+    "asm/fstack.c"
+    "asm/globlex.c"
+    "asm/macro.c"
+    "asm/main.c"
+    "asm/math.c"
+    "asm/output.c"
+    "asm/rpn.c"
+    "asm/section.c"
+    "asm/symbol.c"
+    "asm/util.c"
+    "asm/warning.c"
+    "extern/utf8decoder.c"
+    "hashmap.c"
+    "linkdefs.c"
+    )
+
+set(rgbfix_src
+    "fix/main.c"
+    )
+
+set(rgbgfx_src
+    "gfx/gb.c"
+    "gfx/main.c"
+    "gfx/makepng.c"
+    )
+
+set(rgblink_src
+    "link/assign.c"
+    "link/main.c"
+    "link/object.c"
+    "link/output.c"
+    "link/patch.c"
+    "link/script.c"
+    "link/section.c"
+    "link/symbol.c"
+    "hashmap.c"
+    "linkdefs.c"
+    )
+
+foreach(PROG "asm" "fix" "gfx" "link")
+  add_executable(rgb${PROG}
+                 ${rgb${PROG}_src}
+                 ${common_src}
+                 )
+endforeach()
+
+if(CMAKE_VERSION VERSION_LESS 2.8.12)
+  add_definitions(${PNG_DEFINITIONS})
+  include_directories(${PNG_INCLUDE_DIRS})
+  target_link_libraries(rgbgfx ${PNG_LIBRARIES})
+else()
+  target_compile_definitions(rgbgfx PRIVATE ${PNG_DEFINITIONS})
+  target_include_directories(rgbgfx PRIVATE ${PNG_INCLUDE_DIRS})
+  target_link_libraries(rgbgfx PRIVATE ${PNG_LIBRARIES})
+endif()
+
+include(CheckLibraryExists)
+check_library_exists("m" "sin" "" HAS_LIBM)
+if(HAS_LIBM)
+  if(CMAKE_VERSION VERSION_LESS 2.8.12)
+    target_link_libraries(rgbasm LINK_PRIVATE "m")
+  else()
+    target_link_libraries(rgbasm PRIVATE "m")
+  endif()
+endif()


### PR DESCRIPTION
This should hopefully work torwards compatibility with more systems.
I've tried to make this as general as possible but some small assumptions
about the compiler are made. I've also tried to recreate the build process
as closely as possible, but I had to change some things slightly to work
with CMake (version strings, mainly).

For now, it doesn't allow in-source builds, as that could overwrite the
Makefile.

This adds:

- Support for more build systems
- Automatic dependency generation
- Performance gains (especially when using i.e. Ninja)