### PR TITLE
Fix Clang warning in linkdefs

### DIFF
--- a/include/linkdefs.h
+++ b/include/linkdefs.h
@@ -12,8 +12,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define RGBDS_OBJECT_VERSION_STRING "RGB%1hhu"
-#define RGBDS_OBJECT_VERSION_NUMBER 9
+#define RGBDS_OBJECT_VERSION_STRING "RGB%1u"
+#define RGBDS_OBJECT_VERSION_NUMBER 9U
 #define RGBDS_OBJECT_REV 4U
 
 enum AssertionType {

--- a/src/link/object.c
+++ b/src/link/object.c
@@ -400,18 +400,18 @@ void obj_ReadFile(char const *fileName)
 		err(1, "Could not open file %s", fileName);
 
 	/* Begin by reading the magic bytes and version number */
-	uint8_t versionNumber;
+	unsigned versionNumber;
 	int matchedElems = fscanf(file, RGBDS_OBJECT_VERSION_STRING,
 				  &versionNumber);
 
 	if (matchedElems != 1)
 		errx(1, "\"%s\" is not a RGBDS object file", fileName);
 
-	verbosePrint("Reading object file %s, version %hhu\n",
+	verbosePrint("Reading object file %s, version %u\n",
 		     fileName, versionNumber);
 
 	if (versionNumber != RGBDS_OBJECT_VERSION_NUMBER)
-		errx(1, "\"%s\" is an incompatible version %hhu object file",
+		errx(1, "\"%s\" is an incompatible version %u object file",
 		     fileName, versionNumber);
 
 	uint32_t revNum;


### PR DESCRIPTION
This one's really stupid; printing an int with %hhu gives a warning
even though a regular unsigned char is promoted to an int before
printing anyway. Fix the issue so the build with Clang works.

This is a regression that was introduced in https://github.com/rednex/rgbds/commit/5c24de3dc4e62c74fcd4f2a6a5055df73ee41a0a