### PR TITLE
Add platform-specific fixes file (only for MSVC, currently)

### DIFF
--- a/include/extern/getopt.h
+++ b/include/extern/getopt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2005-2019 Rich Felker, et al.
+ * Copyright © 2005-2020 Rich Felker, et al.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -23,8 +23,8 @@
 
 /* This implementation was taken from musl and modified for RGBDS */
 
-#ifndef _GETOPT_H
-#define _GETOPT_H
+#ifndef RGBDS_EXTERN_GETOPT_H
+#define RGBDS_EXTERN_GETOPT_H
 
 extern char *optarg;
 extern int optind, opterr, optopt, optreset;

--- a/include/hashmap.h
+++ b/include/hashmap.h
@@ -15,7 +15,7 @@
 
 #define HASH_NB_BITS 32
 #define HALF_HASH_NB_BITS 16
-_Static_assert(HALF_HASH_NB_BITS * 2 == HASH_NB_BITS, "");
+static_assert(HALF_HASH_NB_BITS * 2 == HASH_NB_BITS, "");
 #define HASHMAP_NB_BUCKETS (1 << HALF_HASH_NB_BITS)
 
 /* HashMapEntry is internal, please do not attempt to use it */

--- a/include/platform.h
+++ b/include/platform.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of RGBDS.
+ *
+ * Copyright (c) 2020 RGBDS contributors.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* platform-specific hacks */
+
+#ifndef RGBDS_PLATFORM_H
+#define RGBDS_PLATFORM_H
+
+/* MSVC doesn't have strncasecmp, use a suitable replacement */
+#ifdef _MSC_VER
+# include <string.h>
+# define strncasecmp _strnicmp
+#else
+# include <strings.h>
+#endif
+
+/* MSVC has deprecated strdup in favor of _strdup */
+#ifdef _MSC_VER
+# define strdup _strdup
+#endif
+
+/* MSVC prefixes the names of S_* macros with underscores,
+   and doesn't define any S_IS* macros. Define them ourselves */
+#ifdef _MSC_VER
+# define S_IFMT _S_IFMT
+# define S_IFDIR _S_IFDIR
+# define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#endif
+
+#endif /* RGBDS_PLATFORM_H */

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -15,7 +15,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include "asm/asm.h"
 #include "asm/charmap.h"
@@ -34,6 +33,7 @@
 #include "extern/utf8decoder.h"
 
 #include "linkdefs.h"
+#include "platform.h" // strncasecmp, strdup
 
 uint32_t nListCountEmpty;
 char *tzNewMacro;

--- a/src/asm/fstack.c
+++ b/src/asm/fstack.c
@@ -19,7 +19,6 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 #include "asm/fstack.h"
 #include "asm/lexer.h"
@@ -30,6 +29,7 @@
 
 #include "extern/err.h"
 
+#include "platform.h" // S_ISDIR (stat macro)
 #include "types.h"
 
 static struct sContext *pFileStack;

--- a/src/asm/lexer.c
+++ b/src/asm/lexer.c
@@ -13,7 +13,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include "asm/asm.h"
 #include "asm/fstack.h"
@@ -27,6 +26,7 @@
 #include "extern/err.h"
 
 #include "asmy.h"
+#include "platform.h" // strncasecmp, strdup
 
 struct sLexString {
 	char *tzName;

--- a/src/asm/output.c
+++ b/src/asm/output.c
@@ -30,6 +30,7 @@
 #include "extern/err.h"
 
 #include "linkdefs.h"
+#include "platform.h" // strdup
 
 struct Patch {
 	char tzFilename[_MAX_PATH + 1];

--- a/src/asm/section.c
+++ b/src/asm/section.c
@@ -14,6 +14,7 @@
 #include "asm/warning.h"
 
 #include "extern/err.h"
+#include "platform.h" // strdup
 
 struct SectionStackEntry {
 	struct Section *pSection;

--- a/src/fix/main.c
+++ b/src/fix/main.c
@@ -98,9 +98,9 @@ int main(int argc, char *argv[])
 	bool resize = false;
 	bool setversion = false;
 
-	char *title; /* game title in ASCII */
-	char *id; /* game ID in ASCII */
-	char *newlicensee; /* new licensee ID, two ASCII characters */
+	char *title = NULL; /* game title in ASCII */
+	char *id = NULL; /* game ID in ASCII */
+	char *newlicensee = NULL; /* new licensee ID, two ASCII characters */
 
 	int licensee = 0;  /* old licensee ID */
 	int cartridge = 0; /* cartridge hardware ID */

--- a/src/link/object.c
+++ b/src/link/object.c
@@ -454,9 +454,8 @@ void obj_ReadFile(char const *fileName)
 	symbolList->next = symbolLists;
 	symbolLists = symbolList;
 
-	uint32_t nbSymPerSect[nbSections ? nbSections : 1];
-
-	memset(nbSymPerSect, 0, sizeof(nbSymPerSect));
+	uint32_t *nbSymPerSect = calloc(nbSections ? nbSections : 1,
+					sizeof(*nbSymPerSect));
 
 	verbosePrint("Reading %" PRIu32 " symbols...\n", nbSymbols);
 	for (uint32_t i = 0; i < nbSymbols; i++) {
@@ -475,7 +474,8 @@ void obj_ReadFile(char const *fileName)
 	}
 
 	/* This file's sections, stored in a table to link symbols to them */
-	struct Section *fileSections[nbSections ? nbSections : 1];
+	struct Section **fileSections = malloc(sizeof(*fileSections)
+					    * (nbSections ? nbSections : 1));
 
 	verbosePrint("Reading %" PRIu32 " sections...\n", nbSections);
 	for (uint32_t i = 0; i < nbSections; i++) {
@@ -500,6 +500,8 @@ void obj_ReadFile(char const *fileName)
 
 		sect_AddSection(fileSections[i]);
 	}
+
+	free(nbSymPerSect);
 
 	/* Give symbols pointers to their sections */
 	for (uint32_t i = 0; i < nbSymbols; i++) {
@@ -539,6 +541,7 @@ void obj_ReadFile(char const *fileName)
 		assertions = assertion;
 	}
 
+	free(fileSections);
 	fclose(file);
 }
 


### PR DESCRIPTION
Create a new file, platform.h, for platform-specific hacks

for MSVC, this includes defining strncasecmp to _stricmp and
strdup to _strdup, among other things like defining missing
stat macros

Change some things not supported in MSVC, like _Static_assert,
to their counterparts (in this case, static_assert)

Replace usage of VLAs with malloc and free

Update getopt_long and use the getopt implementation from musl
on Windows.

Use comments to show which functions from platform.h are being used