### PR TITLE
Fix error in documentation about unary not

### DIFF
--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -165,7 +165,7 @@ still evaluates both operands of
 and
 .Sq || .
 .Pp
-! returns 1 if the operand was 0, and 1 otherwise.
+! returns 1 if the operand was 0, and 0 otherwise.
 .Ss Fixed‐point Expressions
 .Pp
 Fixed-point numbers are basically normal (32-bit) integers, which count 65536th's instead of entire units, offering better precision than integers but limiting the range of values.


### PR DESCRIPTION
rgbasm.5 stated that ! (unary not operator) always returns 1.
This change reflects the actual behavior of the operator.