### PR TITLE
Make the local variables of getopt static.

### DIFF
--- a/src/extern/getopt.c
+++ b/src/extern/getopt.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include "extern/getopt.h"
 
-int __optpos, __optreset;
+static int __optpos, __optreset;
 
 void musl__getopt_msg(const char *a, const char *b, const char *c, size_t l)
 {


### PR DESCRIPTION
While compiling for empscripten there is a duplicate symbol conflict with these two variables. And as they are only used locally, and do not need a symbol exported they can just be static.