### PR TITLE
Give a warning when longer stings are used in expressions.

### DIFF
--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -101,7 +101,11 @@ static uint32_t str2int2(char *s, int32_t length)
 	int32_t i;
 	uint32_t r = 0;
 
-	i = length < 4 ? 0 : length - 4;
+	i = 0;
+	if (length > 4) {
+		warning(WARNING_LONG_STR, "String is too long in expression '%s' only last 4 characters will be used.", s)
+		i = length - 4;
+	}
 	while (i < length) {
 		r <<= 8;
 		r |= (uint8_t)s[i];

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -103,7 +103,7 @@ static uint32_t str2int2(char *s, int32_t length)
 
 	i = 0;
 	if (length > 4) {
-		warning(WARNING_LONG_STR, "String is too long in expression '%s' only last 4 characters will be used.", s)
+		warning(WARNING_LONG_STR, "String '%s' is too long, conversion will use only last 4 characters", s)
 		i = length - 4;
 	}
 	while (i < length) {


### PR DESCRIPTION
Give a warning when you use strings longer then 4 characters in expressions, as only the last 4 characters will be used in this case:
```
assert "yyyyy" == "xyyyyyy"
assert "yyyyy" != "yyyyyyx"
```
Giving the potential for all kinds of annoying bugs.