### PR TITLE
Make INCBIN's length argument optional

### DIFF
--- a/docs/rgbasm.5.html
+++ b/docs/rgbasm.5.html
@@ -1346,6 +1346,9 @@ INCBIN &quot;sprites/hero.bin&quot;
 INCBIN &quot;data.bin&quot;,78,256
 </pre>
 </div>
+<p class="Pp">The length arugment is optional. If only the start position is
+    specified, the bytes from the start position until the end of the file will
+    be included.</p>
 </section>
 <section class="Ss">
 <h2 class="Ss" id="Unions"><a class="permalink" href="#Unions">Unions</a></h2>

--- a/include/asm/section.h
+++ b/include/asm/section.h
@@ -57,7 +57,7 @@ void out_RelBytes(struct Expression *expr, uint32_t n);
 void out_RelWord(struct Expression *expr);
 void out_RelLong(struct Expression *expr);
 void out_PCRelByte(struct Expression *expr);
-void out_BinaryFile(char const *s);
+void out_BinaryFile(char const *s, int32_t startPos);
 void out_BinaryFileSlice(char const *s, int32_t start_pos, int32_t length);
 
 void out_PushSection(void);

--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -1073,7 +1073,12 @@ include		: T_POP_INCLUDE string {
 ;
 
 incbin		: T_POP_INCBIN string {
-			out_BinaryFile($2);
+			out_BinaryFile($2, 0);
+			if (oFailedOnMissingInclude)
+				YYACCEPT;
+		}
+		| T_POP_INCBIN string ',' const {
+			out_BinaryFile($2, $4);
 			if (oFailedOnMissingInclude)
 				YYACCEPT;
 		}

--- a/src/asm/rgbasm.5
+++ b/src/asm/rgbasm.5
@@ -1080,6 +1080,8 @@ The example below includes 256 bytes from data.bin, starting from byte 78.
 .Bd -literal -offset indent
 INCBIN "data.bin",78,256
 .Ed
+.Pp
+The length arugment is optional. If only the start position is specified, the bytes from the start position until the end of the file will be included.
 .Ss Unions
 .Pp
 Unions allow multiple memory allocations to overlap, like unions in C.


### PR DESCRIPTION
I have some files that can get relatively large, so I split them across multiple banks by specifying an offset and length after the INCBIN. If the files change even just slightly in size then I need to adjust the length argument in my `INCBIN` for the last chunk of the file.

To avoid doing that, this patch allows writing `INCBIN "data.bin", 78` without a specifying a length, so it will include everything starting from offset 78 to the end of the file.