### PR TITLE
Add DEVELOP option to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,33 +6,16 @@
 # SPDX-License-Identifier: MIT
 #
 
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.0)
+cmake_policy(VERSION 3.0)
 
-cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
+project(rgbds
+        LANGUAGES C)
 
-set(RGBDS_VER 0.4.1)
-set(RGBDS_DESC "Rednex Game Boy Development System")
-
-if(CMAKE_VERSION VERSION_LESS 3.0)
-  project(rgbds C)
-  set(PROJECT_VERSION "${RGBDS_VER}")
-else()
-  if(CMAKE_VERSION VERSION_LESS 3.9)
-    project(rgbds VERSION "${RGBDS_VER}"
-                  LANGUAGES C)
-  else()
-    project(rgbds VERSION "${RGBDS_VER}"
-                  DESCRIPTION "${RGBDS_DESC}"
-                  LANGUAGES C)
-  endif()
-endif()
-
-if(CMAKE_VERSION VERSION_LESS 3.9)
-  set(PROJECT_DESCRIPTION "${RGBDS_DESC}")
-endif()
+option(DEVELOP "build in development mode" OFF)
 
 set(DEFAULT_BUILD_TYPE "Release")
-if(NOT CMAKE_BUILD_TYPE)
+if(NOT CMAKE_BUILD_TYPE AND NOT DEVELOP)
   set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}")
 endif()
 
@@ -53,10 +36,32 @@ find_package(FLEX)
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
+if(DEVELOP)
+  add_definitions(-DDEVELOP)
+endif()
+
 if(MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W1 /MP -D_CRT_SECURE_NO_WARNINGS")
+  add_compile_options(/W1 /MP)
+  add_definitions(/D_CRT_SECURE_NO_WARNINGS)
 else()
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic")
+  if(DEVELOP)
+    add_compile_options(-Werror -Wall -Wextra -pedantic
+                        -Wno-sign-compare -Wformat -Wformat-security -Wformat-overflow=2
+                        -Wformat-truncation=1 -Wformat-y2k -Wswitch-enum -Wunused
+                        -Wuninitialized -Wunknown-pragmas -Wstrict-overflow=5
+                        -Wstringop-overflow=4 -Walloc-zero -Wduplicated-cond
+                        -Wfloat-equal -Wshadow -Wcast-qual -Wcast-align -Wlogical-op
+                        -Wnested-externs -Wno-aggressive-loop-optimizations -Winline
+                        -Wundef -Wstrict-prototypes -Wold-style-definition)
+
+     link_libraries(-fsanitize=shift -fsanitize=integer-divide-by-zero
+                    -fsanitize=unreachable -fsanitize=vla-bound
+                    -fsanitize=signed-integer-overflow -fsanitize=bounds
+                    -fsanitize=object-size -fsanitize=bool -fsanitize=enum
+                    -fsanitize=alignment -fsanitize=null)
+  else()
+    add_compile_options(-Wall -pedantic)
+  endif()
 endif()
 
 # Use versioning consistent with Makefile
@@ -67,11 +72,7 @@ execute_process(COMMAND git describe --tags --dirty --always
                 ERROR_QUIET)
 string(STRIP "${GIT_REV}" GIT_REV)
 
-if(CMAKE_VERSION VERSION_LESS 3.12)
-  add_definitions(-DBUILD_VERSION_STRING="${GIT_REV}")
-else()
-  add_compile_definitions(BUILD_VERSION_STRING="${GIT_REV}")
-endif()
+add_definitions(-DBUILD_VERSION_STRING="${GIT_REV}")
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED True)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,13 @@ project(rgbds
 option(DEVELOP "build in development mode" OFF)
 
 set(DEFAULT_BUILD_TYPE "Release")
-if(NOT CMAKE_BUILD_TYPE AND NOT DEVELOP)
-  set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}")
+set(DEVELOP_BUILD_TYPE "Debug")
+if(NOT CMAKE_BUILD_TYPE)
+  if(DEVELOP)
+    set(CMAKE_BUILD_TYPE "${DEVELOP_BUILD_TYPE}")
+  else()
+    set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}")
+  endif()
 endif()
 
 # get real path of source and binary directories

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,23 +17,12 @@ BISON_TARGET(ASMy "asm/asmy.y"
              DEFINES_FILE "${PROJECT_SOURCE_DIR}/src/asm/asmy.h"
              )
 
-# Lexer is not present yet
-if(False) # FLEX_FOUND
-  FLEX_TARGET(Lexer "asm/lexer.l"
-              "${PROJECT_SOURCE_DIR}/src/asm/lexer.c"
-              )
-  ADD_FLEX_BISON_DEPENDENCY(Lexer ASMy)
-  set(Lexer_SOURCE "${FLEX_Lexer_OUTPUTS}")
-else()
-  set(Lexer_SOURCE "asm/lexer.c")
-endif()
-
 set(rgbasm_src
     "${BISON_ASMy_OUTPUT_SOURCE}"
-    "${Lexer_SOURCE}"
     "asm/charmap.c"
     "asm/fstack.c"
     "asm/globlex.c"
+    "asm/lexer.c"
     "asm/macro.c"
     "asm/main.c"
     "asm/math.c"
@@ -79,22 +68,12 @@ foreach(PROG "asm" "fix" "gfx" "link")
   install(TARGETS rgb${PROG} RUNTIME DESTINATION bin)
 endforeach()
 
-if(CMAKE_VERSION VERSION_LESS 2.8.12)
-  add_definitions(${PNG_DEFINITIONS})
-  include_directories(${PNG_INCLUDE_DIRS})
-  target_link_libraries(rgbgfx ${PNG_LIBRARIES})
-else()
-  target_compile_definitions(rgbgfx PRIVATE ${PNG_DEFINITIONS})
-  target_include_directories(rgbgfx PRIVATE ${PNG_INCLUDE_DIRS})
-  target_link_libraries(rgbgfx PRIVATE ${PNG_LIBRARIES})
-endif()
+target_compile_definitions(rgbgfx PRIVATE ${PNG_DEFINITIONS})
+target_include_directories(rgbgfx PRIVATE ${PNG_INCLUDE_DIRS})
+target_link_libraries(rgbgfx PRIVATE ${PNG_LIBRARIES})
 
 include(CheckLibraryExists)
 check_library_exists("m" "sin" "" HAS_LIBM)
 if(HAS_LIBM)
-  if(CMAKE_VERSION VERSION_LESS 2.8.12)
-    target_link_libraries(rgbasm LINK_PRIVATE "m")
-  else()
-    target_link_libraries(rgbasm PRIVATE "m")
-  endif()
+  target_link_libraries(rgbasm PRIVATE "m")
 endif()


### PR DESCRIPTION
This requires CMake 3.0 so -Werror won't conflict with link tests.
Remove all version checks to improve simplicity.