### PR TITLE
Resolve #554: STRSUB("<N-char string>", N, 0) will not warn "Position N is past the end of the string"

### DIFF
--- a/src/asm/asmy.y
+++ b/src/asm/asmy.y
@@ -461,7 +461,7 @@ static void strsubUTF8(char *dest, const char *src, uint32_t pos, uint32_t len)
 		srcIndex++;
 	}
 
-	if (!src[srcIndex])
+	if (!src[srcIndex] && len)
 		warning(WARNING_BUILTIN_ARG, "STRSUB: Position %lu is past the end of the string",
 			(unsigned long)pos);
 


### PR DESCRIPTION
With this change, all of these `PRINTT`s will build without warnings:

```
	PRINTT STRCAT(STRCAT("<", STRSUB("hello", 1, 5)), ">\n") ; <hello>
	PRINTT STRCAT(STRCAT("<", STRSUB("hello", 2, 4)), ">\n") ; <ello>
	PRINTT STRCAT(STRCAT("<", STRSUB("hello", 3, 3)), ">\n") ; <llo>
	PRINTT STRCAT(STRCAT("<", STRSUB("hello", 4, 2)), ">\n") ; <lo>
	PRINTT STRCAT(STRCAT("<", STRSUB("hello", 5, 1)), ">\n") ; <o>
	PRINTT STRCAT(STRCAT("<", STRSUB("hello", 6, 0)), ">\n") ; <>
```

Before, `STRSUB("hello", 6, 0)` would warn `Position 6 is past the end of the string` with `-Wbuiltin-args`, and `STRSUB("", 1, 0)` would likewise warn (meaning it's impossible to `STRSUB` an empty string without the warning, whereas I'd expect the 0-length substring starting at the beginning to be a valid substring of the empty string).